### PR TITLE
feat(WebComponents): Updated Wrappers to v1.0.0-rc.1

### DIFF
--- a/packages/main/__karma_snapshots__/AnalyticalTable.md
+++ b/packages/main/__karma_snapshots__/AnalyticalTable.md
@@ -46,7 +46,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -85,7 +85,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -124,7 +124,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -165,7 +165,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -552,21 +552,21 @@
                           </Label>
                         </div>
                         <LinkHOC mode={1} enabled={false} onClick={[Function]} selectedPage={0} page={-1}>
-                          <Link style={{...}} onPress={[Function]} design="Default">
+                          <Link style={{...}} onClick={[Function]} design="Default">
                             <ui5-link style={{...}} design="Default" class="">
                               &lt;
                             </ui5-link>
                           </Link>
                         </LinkHOC>
                         <LinkHOC onClick={[Function]} page={0} selectedPage={0} enabled={true}>
-                          <Link style={{...}} onPress={[Function]} design="Emphasized">
+                          <Link style={{...}} onClick={[Function]} design="Emphasized">
                             <ui5-link style={{...}} design="Emphasized" class="">
                               1
                             </ui5-link>
                           </Link>
                         </LinkHOC>
                         <LinkHOC mode={0} enabled={false} onClick={[Function]} selectedPage={0} page={-1}>
-                          <Link style={{...}} onPress={[Function]} design="Default">
+                          <Link style={{...}} onClick={[Function]} design="Default">
                             <ui5-link style={{...}} design="Default" class="">
                               &gt;
                             </ui5-link>
@@ -639,7 +639,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -678,7 +678,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -717,7 +717,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -758,7 +758,7 @@
                                       </div>
                                       <WithWebComponent(Popover) noHeader={true} noArrow={true} horizontalAlign="Left" placementType="Bottom" initialFocus={{...}} headerText="" verticalAlign="Center">
                                         <ui5-popover no-header={true} no-arrow={true} horizontal-align="Left" placement-type="Bottom" initial-focus={{...}} header-text="" vertical-align="Center" class="">
-                                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                                               <StandardListItem type="Active" icon="sap-icon://sort-ascending" data-sort="asc" infoState="None">
                                                 <ui5-li type="Active" icon="sap-icon://sort-ascending" data-sort="asc" info-state="None" class="">
@@ -1153,28 +1153,28 @@
                           </Label>
                         </div>
                         <LinkHOC mode={1} enabled={false} onClick={[Function]} selectedPage={0} page={-1}>
-                          <Link style={{...}} onPress={[Function]} design="Default">
+                          <Link style={{...}} onClick={[Function]} design="Default">
                             <ui5-link style={{...}} design="Default" class="">
                               &lt;
                             </ui5-link>
                           </Link>
                         </LinkHOC>
                         <LinkHOC onClick={[Function]} page={0} selectedPage={0} enabled={true}>
-                          <Link style={{...}} onPress={[Function]} design="Emphasized">
+                          <Link style={{...}} onClick={[Function]} design="Emphasized">
                             <ui5-link style={{...}} design="Emphasized" class="">
                               1
                             </ui5-link>
                           </Link>
                         </LinkHOC>
                         <LinkHOC onClick={[Function]} page={1} selectedPage={0} enabled={true}>
-                          <Link style={{...}} onPress={[Function]} design="Default">
+                          <Link style={{...}} onClick={[Function]} design="Default">
                             <ui5-link style={{...}} design="Default" class="">
                               2
                             </ui5-link>
                           </Link>
                         </LinkHOC>
                         <LinkHOC mode={0} enabled={true} onClick={[Function]} selectedPage={0} page={-1}>
-                          <Link style={{...}} onPress={[Function]} design="Default">
+                          <Link style={{...}} onClick={[Function]} design="Default">
                             <ui5-link style={{...}} design="Default" class="">
                               &gt;
                             </ui5-link>

--- a/packages/main/__karma_snapshots__/Card.md
+++ b/packages/main/__karma_snapshots__/Card.md
@@ -6,8 +6,8 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]} id={{...}}>
     <ThemeProvider theme={{...}}>
-      <Card heading="" subtitle="" status="" avatar={{...}}>
-        <ui5-card heading="" subtitle="" status="" avatar={{...}} class="" />
+      <Card>
+        <ui5-card class="" />
       </Card>
     </ThemeProvider>
   </JssProvider>

--- a/packages/main/__karma_snapshots__/FilterBar.md
+++ b/packages/main/__karma_snapshots__/FilterBar.md
@@ -29,12 +29,12 @@
                     </div>
                     <WithWebComponent(Popover) onAfterOpen={[Function]} headerText="Variants" placementType="Bottom" footer={{...}} className={[undefined]} innerStyles={[undefined]} tooltip={[undefined]} initialFocus={{...}} horizontalAlign="Center" verticalAlign="Center">
                       <ui5-popover header-text="Variants" placement-type="Bottom" tooltip={[undefined]} initial-focus={{...}} horizontal-align="Center" vertical-align="Center" class="">
-                        <Button className="VariantManagement-footer---" onPress={[Function]} design="Emphasized" data-ui5-slot="footer">
+                        <Button className="VariantManagement-footer---" onClick={[Function]} design="Emphasized" data-ui5-slot="footer">
                           <ui5-button design="Emphasized" data-ui5-slot="footer" class="VariantManagement-footer---">
                             Cancel
                           </ui5-button>
                         </Button>
-                        <WithWebComponent(List) onItemPress={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
+                        <WithWebComponent(List) onItemClick={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
                           <ui5-list mode="SingleSelect" header-text="" footer-text="" no-data-text="" separators="All" class="">
                             <StandardListItem style={{...}} data-key="1" type="Active" selected={true} infoState="None">
                               <ui5-li selected={true} style={{...}} data-key="1" type="Active" info-state="None" class="">
@@ -61,7 +61,7 @@
                  
               </div>
               <div className="FilterBar-headerRowRight---">
-                <Button onPress={[Function]} design="Transparent">
+                <Button onClick={[Function]} design="Transparent">
                   <ui5-button design="Transparent" class="">
                     Hide Filter Bar
                   </ui5-button>
@@ -148,12 +148,12 @@
                     </div>
                     <WithWebComponent(Popover) onAfterOpen={[Function]} headerText="Variants" placementType="Bottom" footer={{...}} className={[undefined]} innerStyles={[undefined]} tooltip={[undefined]} initialFocus={{...}} horizontalAlign="Center" verticalAlign="Center">
                       <ui5-popover header-text="Variants" placement-type="Bottom" tooltip={[undefined]} initial-focus={{...}} horizontal-align="Center" vertical-align="Center" class="">
-                        <Button className="VariantManagement-footer---" onPress={[Function]} design="Emphasized" data-ui5-slot="footer">
+                        <Button className="VariantManagement-footer---" onClick={[Function]} design="Emphasized" data-ui5-slot="footer">
                           <ui5-button design="Emphasized" data-ui5-slot="footer" class="VariantManagement-footer---">
                             Cancel
                           </ui5-button>
                         </Button>
-                        <WithWebComponent(List) onItemPress={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
+                        <WithWebComponent(List) onItemClick={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
                           <ui5-list mode="SingleSelect" header-text="" footer-text="" no-data-text="" separators="All" class="">
                             <StandardListItem style={{...}} data-key="1" type="Active" selected={true} infoState="None">
                               <ui5-li selected={true} style={{...}} data-key="1" type="Active" info-state="None" class="">
@@ -173,7 +173,7 @@
                 </VariantManagement>
               </WithStyles(VariantManagement)>
               <div className="FilterBar-headerRowRight---">
-                <Button onPress={[Function]} design="Transparent">
+                <Button onClick={[Function]} design="Transparent">
                   <ui5-button design="Transparent" class="">
                     Hide Filter Bar
                   </ui5-button>
@@ -274,12 +274,12 @@
                     </div>
                     <WithWebComponent(Popover) onAfterOpen={[Function]} headerText="Variants" placementType="Bottom" footer={{...}} className={[undefined]} innerStyles={[undefined]} tooltip={[undefined]} initialFocus={{...}} horizontalAlign="Center" verticalAlign="Center">
                       <ui5-popover header-text="Variants" placement-type="Bottom" tooltip={[undefined]} initial-focus={{...}} horizontal-align="Center" vertical-align="Center" class="">
-                        <Button className="VariantManagement-footer---" onPress={[Function]} design="Emphasized" data-ui5-slot="footer">
+                        <Button className="VariantManagement-footer---" onClick={[Function]} design="Emphasized" data-ui5-slot="footer">
                           <ui5-button design="Emphasized" data-ui5-slot="footer" class="VariantManagement-footer---">
                             Cancel
                           </ui5-button>
                         </Button>
-                        <WithWebComponent(List) onItemPress={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
+                        <WithWebComponent(List) onItemClick={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
                           <ui5-list mode="SingleSelect" header-text="" footer-text="" no-data-text="" separators="All" class="">
                             <StandardListItem style={{...}} data-key="1" type="Active" selected={true} infoState="None">
                               <ui5-li selected={true} style={{...}} data-key="1" type="Active" info-state="None" class="">
@@ -299,7 +299,7 @@
                 </VariantManagement>
               </WithStyles(VariantManagement)>
               <div className="FilterBar-headerRowRight---">
-                <Button onPress={[Function]} design="Transparent">
+                <Button onClick={[Function]} design="Transparent">
                   <ui5-button design="Transparent" class="">
                     Hide Filter Bar
                   </ui5-button>

--- a/packages/main/__karma_snapshots__/MessageBox.md
+++ b/packages/main/__karma_snapshots__/MessageBox.md
@@ -33,14 +33,14 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
                   </Button>
                 </MessageBoxButton>
                 <MessageBoxButton emphasize={false} onClick={[Function]} action="Cancel">
-                  <Button style={{...}} onPress={[Function]} design="Transparent">
+                  <Button style={{...}} onClick={[Function]} design="Transparent">
                     <ui5-button style={{...}} design="Transparent" class="">
                       Cancel
                     </ui5-button>
@@ -89,14 +89,14 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
                   </Button>
                 </MessageBoxButton>
                 <MessageBoxButton emphasize={false} onClick={[Function]} action="Cancel">
-                  <Button style={{...}} onPress={[Function]} design="Transparent">
+                  <Button style={{...}} onClick={[Function]} design="Transparent">
                     <ui5-button style={{...}} design="Transparent" class="">
                       Cancel
                     </ui5-button>
@@ -145,7 +145,7 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
@@ -194,7 +194,7 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
@@ -243,7 +243,7 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="Close">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       Close
                     </ui5-button>
@@ -292,7 +292,7 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
@@ -341,14 +341,14 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="Yes">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       Yes
                     </ui5-button>
                   </Button>
                 </MessageBoxButton>
                 <MessageBoxButton emphasize={false} onClick={[Function]} action="No">
-                  <Button style={{...}} onPress={[Function]} design="Transparent">
+                  <Button style={{...}} onClick={[Function]} design="Transparent">
                     <ui5-button style={{...}} design="Transparent" class="">
                       No
                     </ui5-button>
@@ -397,7 +397,7 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
@@ -460,14 +460,14 @@
               </section>
               <footer className="MessageBox-footer---">
                 <MessageBoxButton emphasize={true} onClick={[Function]} action="OK">
-                  <Button style={{...}} onPress={[Function]} design="Emphasized">
+                  <Button style={{...}} onClick={[Function]} design="Emphasized">
                     <ui5-button style={{...}} design="Emphasized" class="">
                       OK
                     </ui5-button>
                   </Button>
                 </MessageBoxButton>
                 <MessageBoxButton emphasize={false} onClick={[Function]} action="Cancel">
-                  <Button style={{...}} onPress={[Function]} design="Transparent">
+                  <Button style={{...}} onClick={[Function]} design="Transparent">
                     <ui5-button style={{...}} design="Transparent" class="">
                       Cancel
                     </ui5-button>

--- a/packages/main/__karma_snapshots__/ObjectPage.md
+++ b/packages/main/__karma_snapshots__/ObjectPage.md
@@ -61,7 +61,7 @@
                   </span>
                 </div>
                 <div className="ObjectPage-hideHeaderContent---">
-                  <Button style={{...}} icon="sap-icon://navigation-up-arrow" onPress={[Function]} design="Default">
+                  <Button style={{...}} icon="sap-icon://navigation-up-arrow" onClick={[Function]} design="Default">
                     <ui5-button style={{...}} icon="sap-icon://navigation-up-arrow" design="Default" class="" />
                   </Button>
                 </div>
@@ -117,7 +117,7 @@
                       </div>
                       <WithWebComponent(Popover) placementType="Bottom" onAfterClose={[Function]} noArrow={true} noHeader={true} initialFocus={{...}} headerText="" horizontalAlign="Center" verticalAlign="Center">
                         <ui5-popover no-header={true} no-arrow={true} placement-type="Bottom" initial-focus={{...}} header-text="" horizontal-align="Center" vertical-align="Center" class="">
-                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                               <StandardListItem data-key="4.1" type="Active" infoState="None">
                                 <ui5-li data-key="4.1" type="Active" info-state="None" class="">
@@ -153,7 +153,7 @@
                       </div>
                       <WithWebComponent(Popover) placementType="Bottom" onAfterClose={[Function]} noArrow={true} noHeader={true} initialFocus={{...}} headerText="" horizontalAlign="Center" verticalAlign="Center">
                         <ui5-popover no-header={true} no-arrow={true} placement-type="Bottom" initial-focus={{...}} header-text="" horizontal-align="Center" vertical-align="Center" class="">
-                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                               <StandardListItem data-key="5.1" type="Active" infoState="None">
                                 <ui5-li data-key="5.1" type="Active" info-state="None" class="">
@@ -562,7 +562,7 @@
                   </span>
                 </div>
                 <div className="ObjectPage-hideHeaderContent---">
-                  <Button style={{...}} icon="sap-icon://navigation-up-arrow" onPress={[Function]} design="Default">
+                  <Button style={{...}} icon="sap-icon://navigation-up-arrow" onClick={[Function]} design="Default">
                     <ui5-button style={{...}} icon="sap-icon://navigation-up-arrow" design="Default" class="" />
                   </Button>
                 </div>
@@ -618,7 +618,7 @@
                       </div>
                       <WithWebComponent(Popover) placementType="Bottom" onAfterClose={[Function]} noArrow={true} noHeader={true} initialFocus={{...}} headerText="" horizontalAlign="Center" verticalAlign="Center">
                         <ui5-popover no-header={true} no-arrow={true} placement-type="Bottom" initial-focus={{...}} header-text="" horizontal-align="Center" vertical-align="Center" class="">
-                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                               <StandardListItem data-key="4.1" type="Active" infoState="None">
                                 <ui5-li data-key="4.1" type="Active" info-state="None" class="">
@@ -654,7 +654,7 @@
                       </div>
                       <WithWebComponent(Popover) placementType="Bottom" onAfterClose={[Function]} noArrow={true} noHeader={true} initialFocus={{...}} headerText="" horizontalAlign="Center" verticalAlign="Center">
                         <ui5-popover no-header={true} no-arrow={true} placement-type="Bottom" initial-focus={{...}} header-text="" horizontal-align="Center" vertical-align="Center" class="">
-                          <WithWebComponent(List) onItemPress={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
+                          <WithWebComponent(List) onItemClick={[Function]} headerText="" footerText="" mode="None" noDataText="" separators="All">
                             <ui5-list header-text="" footer-text="" mode="None" no-data-text="" separators="All" class="">
                               <StandardListItem data-key="5.1" type="Active" infoState="None">
                                 <ui5-li data-key="5.1" type="Active" info-state="None" class="">

--- a/packages/main/__karma_snapshots__/ShellBar.md
+++ b/packages/main/__karma_snapshots__/ShellBar.md
@@ -6,8 +6,8 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]} id={{...}}>
     <ThemeProvider theme={{...}}>
-      <ShellBar logo={{...}} profile="">
-        <ui5-shellbar logo={{...}} profile="" class="" />
+      <ShellBar>
+        <ui5-shellbar class="" />
       </ShellBar>
     </ThemeProvider>
   </JssProvider>

--- a/packages/main/__karma_snapshots__/VariantManagement.md
+++ b/packages/main/__karma_snapshots__/VariantManagement.md
@@ -25,12 +25,12 @@
             </div>
             <WithWebComponent(Popover) onAfterOpen={[Function]} headerText="Variants" placementType="Bottom" footer={{...}} className={[undefined]} innerStyles={[undefined]} tooltip={[undefined]} initialFocus={{...}} horizontalAlign="Center" verticalAlign="Center">
               <ui5-popover header-text="Variants" placement-type="Bottom" tooltip={[undefined]} initial-focus={{...}} horizontal-align="Center" vertical-align="Center" class="">
-                <Button className="VariantManagement-footer---" onPress={[Function]} design="Emphasized" data-ui5-slot="footer">
+                <Button className="VariantManagement-footer---" onClick={[Function]} design="Emphasized" data-ui5-slot="footer">
                   <ui5-button design="Emphasized" data-ui5-slot="footer" class="VariantManagement-footer---">
                     Cancel
                   </ui5-button>
                 </Button>
-                <WithWebComponent(List) onItemPress={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
+                <WithWebComponent(List) onItemClick={[Function]} mode="SingleSelect" headerText="" footerText="" noDataText="" separators="All">
                   <ui5-list mode="SingleSelect" header-text="" footer-text="" no-data-text="" separators="All" class="">
                     <StandardListItem style={{...}} data-key="1" type="Active" selected={true} infoState="None">
                       <ui5-li selected={true} style={{...}} data-key="1" type="Active" info-state="None" class="">

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -14,13 +14,13 @@
   "license": "Apache-2.0",
   "private": false,
   "scripts": {
-    "generateWebComponents": "ts-node -O '{\"module\": \"commonjs\"}' -r esm ./scripts/wrapperGeneration/generateWebComponentWrappers --onlyStopForMerge && prettier --write --config ../../prettier.config.js \"src/webComponents/**/*.tsx\"",
+    "generateWebComponents": "ts-node -O '{\"module\": \"commonjs\"}' -r esm ./scripts/wrapperGeneration/generateWebComponentWrappers --onlyStopForMerge",
     "build": "webpack --config ./scripts/wrapperGeneration/webpack.config.js",
     "test:karma": "karma start ../../config/karma.conf.js",
     "test:karma:update": "cross-env UPDATE=1 yarn run test:karma"
   },
   "dependencies": {
-    "@ui5/webcomponents": "0.13.1",
+    "@ui5/webcomponents": "1.0.0-rc.1",
     "@ui5/webcomponents-react-base": "0.3.2-rc.8",
     "react-scroll": "^1.7.11",
     "react-table": "6.8.6",

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -17,12 +17,8 @@ export interface ActionSheetPropTypes extends Fiori3CommonProps {
 
 export interface ActionSheetPropsInternal extends ActionSheetPropTypes, ClassProps {}
 
-interface ActionSheetState {
-  open: boolean;
-}
-
 @withStyles(styles)
-export class ActionSheet extends Component<ActionSheetPropTypes, ActionSheetState> {
+export class ActionSheet extends Component<ActionSheetPropTypes> {
   static defaultProps = {
     placement: PlacementType.Bottom
   };
@@ -30,8 +26,8 @@ export class ActionSheet extends Component<ActionSheetPropTypes, ActionSheetStat
   private popoverRef: RefObject<Ui5PopoverDomRef> = React.createRef();
 
   private onActionButtonClicked = (handler) => () => {
-    this.setState({ open: false });
-    handler();
+    this.popoverRef.current.close();
+    typeof handler === 'function' && handler();
   };
 
   private renderActionSheetButton = (element) => {
@@ -45,7 +41,7 @@ export class ActionSheet extends Component<ActionSheetPropTypes, ActionSheetStat
             },
             design: ButtonDesign.Transparent,
             className: classes.actionButton,
-            onPress: this.onActionButtonClicked(element.props.onPress)
+            onClick: this.onActionButtonClicked(element.props.onClick)
           })}
         </div>
       );

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.karma.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.karma.tsx
@@ -80,7 +80,7 @@ describe('AnalyticalTable', () => {
       .at(3)
       .instance();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
 
     // test the right page number link of the pagination
     component = wrapper
@@ -88,7 +88,7 @@ describe('AnalyticalTable', () => {
       .at(2)
       .instance();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
 
     // test the left page number link of the pagination
     component = wrapper
@@ -96,7 +96,7 @@ describe('AnalyticalTable', () => {
       .at(1)
       .instance();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
 
     // test the left arrow of the pagination
     component = wrapper
@@ -104,7 +104,7 @@ describe('AnalyticalTable', () => {
       .at(0)
       .instance();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
 
     expect(wrapper.debug()).to.matchSnapshot();
   });

--- a/packages/main/src/components/AnalyticalTable/columnHeader/ColumnHeaderModal.tsx
+++ b/packages/main/src/components/AnalyticalTable/columnHeader/ColumnHeaderModal.tsx
@@ -84,7 +84,7 @@ export class ColumnHeaderModal extends Component<ColumnHeaderModalProperties> {
         placementType={PlacementType.Bottom}
         ref={this.popoverRef}
       >
-        <List onItemPress={this.handleSort}>
+        <List onItemClick={this.handleSort}>
           {showSort && (
             <StandardListItem type={ListItemTypes.Active} icon={'sap-icon://sort-ascending'} data-sort={'asc'}>
               Sort Ascending

--- a/packages/main/src/components/AnalyticalTable/pagination/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/pagination/index.tsx
@@ -41,7 +41,7 @@ export const LinkHOC: FC<LinkHOCProps> = (props) => {
   return (
     <Link
       style={{ paddingRight: '0.2rem' }}
-      onPress={onClickHandler(props)}
+      onClick={onClickHandler(props)}
       design={page === selectedPage ? LinkDesign.Emphasized : LinkDesign.Default}
     >
       {children.toString()}

--- a/packages/main/src/components/FilterBar/FilterBar.karma.tsx
+++ b/packages/main/src/components/FilterBar/FilterBar.karma.tsx
@@ -73,11 +73,11 @@ describe('FilterBar', () => {
         </FilterItem>
       </FilterBar>
     );
-    (wrapper
-      .find('Button')
-      .at(2)
-      .prop('onPress') as any)({ target: {} });
-
+    const component = wrapper
+      .find('ui5-button')
+      .first()
+      .instance() as any;
+    component.fireEvent('click');
     expect(wrapper.debug()).to.matchSnapshot();
   });
 

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -38,7 +38,7 @@ export class FilterBar extends PureComponent<FilterBarPropTypes> {
           {renderVariants && renderVariants()}
           {renderSearch && <div className={classes.vLine}> {renderSearch()} </div>}
           <div className={classes.headerRowRight}>
-            <Button onPress={this.handelHideFilterBar} design={ButtonDesign.Transparent}>
+            <Button onClick={this.handelHideFilterBar} design={ButtonDesign.Transparent}>
               {this.state.showFilters ? 'Hide Filter Bar' : 'Show Filter Bar'}
             </Button>
           </div>

--- a/packages/main/src/components/MessageBox/MessageBox.karma.tsx
+++ b/packages/main/src/components/MessageBox/MessageBox.karma.tsx
@@ -10,17 +10,6 @@ import { MessageBoxTypes } from '../../lib/MessageBoxTypes';
 use(matchSnapshot);
 
 describe('MessageBox', () => {
-  // let appRoot: HTMLElement;
-  //
-  // before(() => {
-  //   appRoot = document.createElement("div");
-  //   document.body.appendChild(appRoot);
-  // });
-  //
-  // after(() => {
-  //   document.body.removeChild(appRoot);
-  // });
-
   it('Confirm - OK', () => {
     const callback = spy();
     const wrapper = mountThemedComponent(
@@ -31,10 +20,12 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.OK);
   });
 
@@ -47,10 +38,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .last()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.CANCEL);
   });
 
@@ -63,10 +55,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.OK);
   });
 
@@ -79,10 +72,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.OK);
   });
 
@@ -95,10 +89,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.CLOSE);
   });
 
@@ -111,10 +106,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.OK);
   });
 
@@ -127,16 +123,18 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    let component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.YES);
 
-    (wrapper
-      .find('Button')
+    component = wrapper
+      .find('ui5-button')
       .last()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback, 1).getParameter('action')).to.equal(MessageBoxActions.NO);
   });
 
@@ -149,10 +147,11 @@ describe('MessageBox', () => {
     );
     expect(wrapper.debug()).to.matchSnapshot();
 
-    (wrapper
-      .find('Button')
+    const component = wrapper
+      .find('ui5-button')
       .first()
-      .prop('onPress') as any)({ target: {} });
+      .instance() as any;
+    component.fireEvent('click');
     expect(getEventFromCallback(callback).getParameter('action')).to.equal(MessageBoxActions.OK);
   });
 

--- a/packages/main/src/components/MessageBox/MessageBoxButton.tsx
+++ b/packages/main/src/components/MessageBox/MessageBoxButton.tsx
@@ -18,7 +18,7 @@ export class MessageBoxButton extends PureComponent<{
         style={{
           minWidth: '4rem'
         }}
-        onPress={this.handleClick}
+        onClick={this.handleClick}
         design={emphasize ? ButtonDesign.Emphasized : ButtonDesign.Transparent}
       >
         {this.props.action}

--- a/packages/main/src/components/MessageToast/demo.stories.tsx
+++ b/packages/main/src/components/MessageToast/demo.stories.tsx
@@ -9,7 +9,7 @@ storiesOf('Components | MessageToast', module).add(
   () => (
     <div>
       <Button
-        onPress={() => {
+        onClick={() => {
           MessageToast.show('Hello World');
         }}
       >
@@ -17,7 +17,7 @@ storiesOf('Components | MessageToast', module).add(
       </Button>
 
       <Button
-        onPress={() => {
+        onClick={() => {
           MessageToast.error('Hello World');
         }}
       >
@@ -25,7 +25,7 @@ storiesOf('Components | MessageToast', module).add(
       </Button>
 
       <Button
-        onPress={() => {
+        onClick={() => {
           MessageToast.success('Hello World');
         }}
       >
@@ -33,7 +33,7 @@ storiesOf('Components | MessageToast', module).add(
       </Button>
 
       <Button
-        onPress={() => {
+        onClick={() => {
           MessageToast.warning('Hello World this is a very long message. Just testing. Hello Hello Hello.');
         }}
       >

--- a/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
+++ b/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
@@ -121,6 +121,7 @@ const styles = ({ parameters }: JSSTheme) => ({
       position: 'relative',
       display: 'inline-flex',
       alignItems: 'center',
+      cursor: 'pointer',
       '&:not(:first-child)': {
         marginLeft: '2rem'
       }
@@ -137,7 +138,6 @@ const styles = ({ parameters }: JSSTheme) => ({
   headerImage: {},
   headerCustomContent: {},
   anchorButtonContainer: {},
-  anchorButton: {},
   active: {},
   hiddenHeader: {}
 });

--- a/packages/main/src/components/ObjectPage/ObjectPageAnchor.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPageAnchor.tsx
@@ -114,7 +114,7 @@ export class ObjectPageAnchor extends Component<ObjectPageAnchorPropTypes, Objec
             noArrow
             noHeader
           >
-            <List onItemPress={this.onSubSectionClick}>
+            <List onItemClick={this.onSubSectionClick}>
               {this.props.section.props.children
                 .filter((item) => item.props && item.props.isSubSection)
                 .map(this.renderSubSectionListItem)}

--- a/packages/main/src/components/ObjectPage/demo.stories.tsx
+++ b/packages/main/src/components/ObjectPage/demo.stories.tsx
@@ -29,10 +29,10 @@ const renderDemo = () => {
       title={text('title', 'Object Page Title')}
       subTitle={text('subTitle', 'Object Page Sub Title')}
       headerActions={[
-        <Button key="1" design={ButtonDesign.Emphasized} onPress={action('onHeaderAction1Pressed')}>
+        <Button key="1" design={ButtonDesign.Emphasized} onClick={action('onHeaderAction1Pressed')}>
           Primary Action
         </Button>,
-        <Button key="2" onPress={action('onHeaderAction2Pressed')}>
+        <Button key="2" onClick={action('onHeaderAction2Pressed')}>
           Action
         </Button>
       ]}

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -280,7 +280,7 @@ export class ObjectPage extends PureComponent<ObjectPagePropTypes, ObjectPageSta
                 <Button
                   style={{ position: 'absolute', '--_ui5_button_compact_height': '1rem', lineHeight: '1.25rem' } as any}
                   icon={this.state.showHeader ? 'sap-icon://navigation-up-arrow' : 'sap-icon://navigation-down-arrow'}
-                  onPress={this.changeHeader}
+                  onClick={this.changeHeader}
                 />
               )}
             </div>

--- a/packages/main/src/components/Page/index.tsx
+++ b/packages/main/src/components/Page/index.tsx
@@ -43,7 +43,7 @@ export class Page extends Component<PagePropTypes> {
 
   private renderBackButton = () => {
     return (
-      <Button icon="navigation-left-arrow" design={ButtonDesign.Transparent} onPress={this.handleNavBackButtonPress} />
+      <Button icon="navigation-left-arrow" design={ButtonDesign.Transparent} onClick={this.handleNavBackButtonPress} />
     );
   };
 

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -123,7 +123,7 @@ export class VariantManagement extends Component<VariantManagementPropTypes, Var
       <Button
         className={classes.footer}
         key="btn-cancel"
-        onPress={this.handleCancelButtonClick}
+        onClick={this.handleCancelButtonClick}
         design={ButtonDesign.Emphasized}
       >
         Cancel
@@ -151,7 +151,7 @@ export class VariantManagement extends Component<VariantManagementPropTypes, Var
         innerStyles={style}
         tooltip={tooltip}
       >
-        <List onItemPress={this.handleVariantItemSelect} mode={ListMode.SingleSelect}>
+        <List onItemClick={this.handleVariantItemSelect} mode={ListMode.SingleSelect}>
           {variantItems.map((item) => (
             <StandardListItem
               style={{ width: '300px' }}

--- a/packages/main/src/internal/WithWebComponent.karma.tsx
+++ b/packages/main/src/internal/WithWebComponent.karma.tsx
@@ -9,20 +9,20 @@ describe('withWebComponent', () => {
   it('Unmount Event Handlers correctly after prop update', () => {
     let Button: FC<any> = withWebComponent(UI5Button);
     const callback = spy();
-    const wrapper = mountThemedComponent(<Button onPress={(...args) => callback(...args)} />);
+    const wrapper = mountThemedComponent(<Button onClick={(...args) => callback(...args)} />);
     const component = wrapper
       .find('ui5-button')
       .first()
       .instance();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
     expect(callback.callCount).to.equal(1, 'onPress handler has not been called');
     wrapper.setProps({
-      children: cloneElement(wrapper.prop('children'), { onPress: (...args) => callback(...args) })
+      children: cloneElement(wrapper.prop('children'), { onClick: (...args) => callback(...args) })
     });
     wrapper.update();
     // @ts-ignore
-    component.onclick({});
+    component.fireEvent('click');
     expect(callback.callCount).to.equal(2, 'onPress handler has not been called after update');
   });
 });

--- a/packages/main/src/webComponents/BusyIndicator/index.tsx
+++ b/packages/main/src/webComponents/BusyIndicator/index.tsx
@@ -1,6 +1,6 @@
-import UI5BusyIndicator from '@ui5/webcomponents/dist/BusyIndicator';
 import React, { FC } from 'react';
-import { BusyIndicatorType } from '../../enums/BusyIndicatorType';
+import { BusyIndicatorType } from '../../lib/BusyIndicatorType';
+import UI5BusyIndicator from '@ui5/webcomponents/dist/BusyIndicator';
 import { withWebComponent, WithWebComponentPropTypes } from '../../internal/withWebComponent';
 
 export interface BusyIndicatorPropTypes extends WithWebComponentPropTypes {

--- a/packages/main/src/webComponents/Button/demo.stories.tsx
+++ b/packages/main/src/webComponents/Button/demo.stories.tsx
@@ -30,15 +30,15 @@ class DemoButton extends React.Component {
     return (
       <div>
         <div>
-          <Button onPress={() => this.setState({ showCS1: !showCS1 })}>Toggle Custom Style 1</Button>
-          <Button onPress={() => this.setState({ showCS2: !showCS2 })}>Toggle Custom Style 2</Button>
+          <Button onClick={() => this.setState({ showCS1: !showCS1 })}>Toggle Custom Style 1</Button>
+          <Button onClick={() => this.setState({ showCS2: !showCS2 })}>Toggle Custom Style 2</Button>
         </div>
         <Button
           design={select('design', ButtonDesign, ButtonDesign.Default)}
           disabled={boolean('disabled', false)}
           icon={'sap-icon://add'}
           iconEnd={boolean('iconEnd', false)}
-          onPress={action('Button clicked')}
+          onClick={action('Button clicked')}
           innerStyles={innerStyles}
         >
           Some Content
@@ -55,7 +55,7 @@ storiesOf('UI5 Web Components | Button', module)
       disabled={boolean('disabled', false)}
       icon={'sap-icon://add'}
       iconEnd={boolean('iconEnd', false)}
-      onPress={action('Button clicked')}
+      onClick={action('onClick')}
     >
       Some Content
     </Button>

--- a/packages/main/src/webComponents/Button/index.tsx
+++ b/packages/main/src/webComponents/Button/index.tsx
@@ -10,8 +10,8 @@ export interface ButtonPropTypes extends WithWebComponentPropTypes {
   icon?: string; // @generated
   iconEnd?: boolean; // @generated
   submits?: boolean; // @generated
-  onPress?: (event: Event) => void; // @generated
-  children?: string; // @generated
+  onClick?: (event: Event) => void; // @generated
+  default?: string; // @generated
 }
 
 const Button: FC<ButtonPropTypes> = withWebComponent<ButtonPropTypes>(UI5Button);

--- a/packages/main/src/webComponents/Card/demo.stories.tsx
+++ b/packages/main/src/webComponents/Card/demo.stories.tsx
@@ -17,7 +17,7 @@ storiesOf('UI5 Web Components | Card', module).add(
       status={text('status', '5 of 22')}
       avatar={text('avatar', 'sap-icon://order-status')}
       headerInteractive={boolean('headerInteractive', false)}
-      onHeaderPress={action('onHeaderPress')}
+      onHeaderClick={action('onHeaderClick')}
     >
       <List>
         <StandardListItem info="100€">Keyboard</StandardListItem>

--- a/packages/main/src/webComponents/Card/index.tsx
+++ b/packages/main/src/webComponents/Card/index.tsx
@@ -1,5 +1,6 @@
-import UI5Card from '@ui5/webcomponents/dist/Card';
 import React, { FC, ReactNode } from 'react';
+import { Event } from '@ui5/webcomponents-react-base';
+import UI5Card from '@ui5/webcomponents/dist/Card';
 import { withWebComponent, WithWebComponentPropTypes } from '../../internal/withWebComponent';
 
 export interface CardPropTypes extends WithWebComponentPropTypes {
@@ -8,19 +9,12 @@ export interface CardPropTypes extends WithWebComponentPropTypes {
   status?: string; // @generated
   headerInteractive?: boolean; // @generated
   avatar?: string; // @generated
-  onHeaderPress?: (event: Event) => void; // @generated
-  children?: ReactNode | ReactNode[];
+  onHeaderClick?: (event: Event) => void; // @generated
+  children?: ReactNode | ReactNode[]; // @generated
 }
 
 const Card: FC<CardPropTypes> = withWebComponent<CardPropTypes>(UI5Card);
 
 Card.displayName = 'Card';
-
-Card.defaultProps = {
-  heading: '', // @generated
-  subtitle: '', // @generated
-  status: '', // @generated
-  avatar: null // @generated
-};
 
 export { Card };

--- a/packages/main/src/webComponents/Link/demo.stories.tsx
+++ b/packages/main/src/webComponents/Link/demo.stories.tsx
@@ -1,4 +1,5 @@
 import { boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Link } from '../../lib/Link';
@@ -11,7 +12,7 @@ storiesOf('UI5 Web Components | Link', module).add('Generated default story', ()
     target={'generatedString'}
     design={select('design', LinkDesign, null)}
     wrap={boolean('wrap', false)}
-    onPress={null}
+    onClick={action('onClick')}
   >
     Some Content
   </Link>

--- a/packages/main/src/webComponents/Link/index.tsx
+++ b/packages/main/src/webComponents/Link/index.tsx
@@ -10,7 +10,7 @@ export interface LinkPropTypes extends WithWebComponentPropTypes {
   target?: string; // @generated
   design?: LinkDesign; // @generated
   wrap?: boolean; // @generated
-  onPress?: (event: Event) => void; // @generated
+  onClick?: (event: Event) => void; // @generated
   children?: string; // @generated
 }
 

--- a/packages/main/src/webComponents/List/demo.stories.tsx
+++ b/packages/main/src/webComponents/List/demo.stories.tsx
@@ -1,4 +1,5 @@
 import { boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { List } from '../../lib/List';
@@ -15,9 +16,9 @@ storiesOf('UI5 Web Components | List', module).add('Generated default story', ()
     mode={select('mode', ListMode, null)}
     noDataText={'generatedString'}
     separators={select('separators', ListSeparators, null)}
-    onItemPress={null}
-    onItemDelete={null}
-    onSelectionChange={null}
+    onItemClick={action('onItemClick')}
+    onItemDelete={action('onItemDelete')}
+    onSelectionChange={action('onSelectionChange')}
     header={null}
   >
     <StandardListItem info="3" infoState={ValueState.Warning}>

--- a/packages/main/src/webComponents/List/index.tsx
+++ b/packages/main/src/webComponents/List/index.tsx
@@ -12,7 +12,7 @@ export interface ListPropTypes extends WithWebComponentPropTypes {
   mode?: ListMode;
   noDataText?: string;
   separators?: ListSeparators;
-  onItemPress?: (event: Event) => void;
+  onItemClick?: (event: Event) => void;
   onItemDelete?: (event: Event) => void;
   onSelectionChange?: (event: Event) => void;
   header?: ReactNode;

--- a/packages/main/src/webComponents/Option/demo.stories.tsx
+++ b/packages/main/src/webComponents/Option/demo.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { boolean } from '@storybook/addon-knobs';
+import { Option } from './index';
+
+storiesOf('UI5 Web Components | Option', module).add('Generated default story', () => (
+  <Option selected={boolean('selected', false)} icon={'sap-icon://add'} value={'generatedString'} />
+));

--- a/packages/main/src/webComponents/ShellBar/demo.stories.tsx
+++ b/packages/main/src/webComponents/ShellBar/demo.stories.tsx
@@ -15,12 +15,12 @@ storiesOf('UI5 Web Components | ShellBar', module).add('Generated default story'
     showNotifications={boolean('showNotifications', true)}
     showProductSwitch={boolean('showProductSwitch', true)}
     showCoPilot={boolean('showCoPilot', true)}
-    onMenuItemPress={action('onMenuItemPress')}
-    onCoPilotPress={action('onCoPilotPress')}
-    onLogoPress={action('onLogoPress')}
-    onNotificationsPress={action('onNotificationsPress')}
-    onProfilePress={action('onProfilePress')}
-    onProductSwitchPress={action('onProductSwitchPress')}
+    onMenuItemClick={action('onMenuItemClick')}
+    onCoPilotClick={action('onCoPilotClick')}
+    onLogoClick={action('onLogoClick')}
+    onNotificationsClick={action('onNotificationsClick')}
+    onProfileClick={action('onProfileClick')}
+    onProductSwitchClick={action('onProductSwitchClick')}
     searchField={null}
     icon={null}
   >

--- a/packages/main/src/webComponents/ShellBar/index.tsx
+++ b/packages/main/src/webComponents/ShellBar/index.tsx
@@ -1,6 +1,6 @@
+import React, { FC, ReactNode } from 'react';
 import { Event } from '@ui5/webcomponents-react-base';
 import UI5ShellBar from '@ui5/webcomponents/dist/ShellBar';
-import React, { FC, ReactNode, ReactNodeArray } from 'react';
 import { withWebComponent, WithWebComponentPropTypes } from '../../internal/withWebComponent';
 
 export interface ShellBarPropTypes extends WithWebComponentPropTypes {
@@ -12,14 +12,14 @@ export interface ShellBarPropTypes extends WithWebComponentPropTypes {
   showNotifications?: boolean; // @generated
   showProductSwitch?: boolean; // @generated
   showCoPilot?: boolean; // @generated
-  onNotificationsPress?: (event: Event) => void; // @generated
-  onProfilePress?: (event: Event) => void; // @generated
-  onProductSwitchPress?: (event: Event) => void; // @generated
-  onLogoPress?: (event: Event) => void; // @generated
-  onCoPilotPress?: (event: Event) => void; // @generated
-  onMenuItemPress?: (event: Event) => void; // @generated
-  children?: ReactNode | ReactNodeArray; // @generated
-  menuItems?: ReactNode | ReactNodeArray; // @generated
+  onNotificationsClick?: (event: Event) => void; // @generated
+  onProfileClick?: (event: Event) => void; // @generated
+  onProductSwitchClick?: (event: Event) => void; // @generated
+  onLogoClick?: (event: Event) => void; // @generated
+  onCoPilotClick?: (event: Event) => void; // @generated
+  onMenuItemClick?: (event: Event) => void; // @generated
+  children?: ReactNode; // @generated
+  menuItems?: ReactNode; // @generated
   searchField?: ReactNode; // @generated
   icon?: ReactNode; // @generated
 }
@@ -27,10 +27,5 @@ export interface ShellBarPropTypes extends WithWebComponentPropTypes {
 const ShellBar: FC<ShellBarPropTypes> = withWebComponent<ShellBarPropTypes>(UI5ShellBar);
 
 ShellBar.displayName = 'ShellBar';
-
-ShellBar.defaultProps = {
-  logo: null, // @generated
-  profile: '' // @generated
-};
 
 export { ShellBar };

--- a/packages/main/src/webComponents/TimelineItem/index.tsx
+++ b/packages/main/src/webComponents/TimelineItem/index.tsx
@@ -9,7 +9,7 @@ export interface TimelineItemPropTypes extends WithWebComponentPropTypes {
   itemNameClickable?: boolean; // @generated
   titleText?: string; // @generated
   subtitleText?: string; // @generated
-  onItemNamePress?: (event: Event) => void; // @generated
+  onItemNameClick?: (event: Event) => void; // @generated
   children?: ReactNode; // @generated
 }
 

--- a/packages/main/src/webComponents/ToggleButton/demo.stories.tsx
+++ b/packages/main/src/webComponents/ToggleButton/demo.stories.tsx
@@ -1,4 +1,5 @@
 import { boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { ButtonDesign } from '../../lib/ButtonDesign';
@@ -11,7 +12,7 @@ storiesOf('UI5 Web Components | ToggleButton', module).add('Generated default st
     icon="sap-icon://add"
     iconEnd={boolean('iconEnd', false)}
     pressed={boolean('pressed', false)}
-    onPress={null}
+    onClick={action('onClick')}
   >
     Some Content
   </ToggleButton>

--- a/packages/main/src/webComponents/ToggleButton/index.tsx
+++ b/packages/main/src/webComponents/ToggleButton/index.tsx
@@ -11,7 +11,7 @@ export interface ToggleButtonPropTypes extends WithWebComponentPropTypes {
   iconEnd?: boolean; // @generated
   submits?: boolean; // @generated
   pressed?: boolean; // @generated
-  onPress?: (event: Event) => void; // @generated
+  onClick?: (event: Event) => void; // @generated
   children?: string; // @generated
 }
 

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -32,57 +32,57 @@
       "filename": "base.development.js",
       "bundleType": "NODE_ES_DEV",
       "packageName": "base",
-      "size": 209580,
-      "gzip": 45730
+      "size": 206904,
+      "gzip": 44045
     },
     {
       "filename": "base.production.min.js",
       "bundleType": "NODE_ES_PROD",
       "packageName": "base",
-      "size": 209400,
-      "gzip": 45611
+      "size": 206724,
+      "gzip": 43947
     },
     {
       "filename": "base.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "base",
-      "size": 210207,
-      "gzip": 45814
+      "size": 207531,
+      "gzip": 44127
     },
     {
       "filename": "base.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "base",
-      "size": 85535,
-      "gzip": 25658
+      "size": 92664,
+      "gzip": 24806
     },
     {
       "filename": "main.development.js",
       "bundleType": "NODE_ES_DEV",
       "packageName": "main",
-      "size": 182744,
-      "gzip": 32318
+      "size": 182033,
+      "gzip": 32207
     },
     {
       "filename": "main.production.min.js",
       "bundleType": "NODE_ES_PROD",
       "packageName": "main",
-      "size": 182744,
-      "gzip": 32318
+      "size": 182033,
+      "gzip": 32207
     },
     {
       "filename": "main.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "main",
-      "size": 188375,
-      "gzip": 32399
+      "size": 187506,
+      "gzip": 32311
     },
     {
       "filename": "main.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "main",
-      "size": 96671,
-      "gzip": 24719
+      "size": 96047,
+      "gzip": 24646
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,28 +2785,28 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
-"@ui5/webcomponents-base@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-base/-/webcomponents-base-0.13.1.tgz#0f374876172bccb31c8eb177c7112d51c7ff9388"
-  integrity sha512-Vv+wvD+gRL7l6UI66QEs8wpFZhlquLrEp/lVOzMcvJ6ziTQSHL60AjN2E0X5OU7er2NbPzMFNOmX8J128bBHBQ==
+"@ui5/webcomponents-base@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-base/-/webcomponents-base-0.14.0.tgz#05a42308959a31b2e0585eec638a3c0066577e2b"
+  integrity sha512-nYx1BMIDhCT+nQZE25M8PSGWrU0JjEpdIhGexWqnmKXKycMYJEsyxmTYJggiBlnur7gY/oMtaJTujVsS2IIw3Q==
   dependencies:
-    "@ui5/webcomponents-core" "0.13.1"
+    "@ui5/webcomponents-core" "0.14.0"
     lit-html "^1.0.0"
     regenerator-runtime "0.12.1"
     url-search-params-polyfill "^5.0.0"
 
-"@ui5/webcomponents-core@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-core/-/webcomponents-core-0.13.1.tgz#024275d47384a01126b9c049db45310e18f8ab7a"
-  integrity sha512-OJHE89oxdmnpsVhihM76JO7XUHmTEtv/X4I6LnxmX5vNgHNcezMYB6wIIqyLMEcuE3yB2BnYp6EwyFXUc6nQBQ==
+"@ui5/webcomponents-core@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-core/-/webcomponents-core-0.14.0.tgz#c7827b0093470bbbb868e76cf60cf630628f1c53"
+  integrity sha512-sQYL5JJ0W0e+GFmUTPX5YYrwXJJhrUVDCCu9PSXL5+gxWwzqvr4Egfgd5pYPMNI362uRBLsTzmVTktclwW6mWw==
 
-"@ui5/webcomponents@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents/-/webcomponents-0.13.1.tgz#c8795cfe203543864e0e90716ff3e0cd1a20c4f2"
-  integrity sha512-OWEhX1QPPCGhOs71yC0YeHSDgWMEicpvPxBPglePhT14YBg8I42Eb7xQ0aodIFT3tz8z7sxaCebOHaruDBlJ5Q==
+"@ui5/webcomponents@1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@ui5/webcomponents/-/webcomponents-1.0.0-rc.1.tgz#7781a1d2fd7fd92375e002d462d2c661102a8fc3"
+  integrity sha512-abhs/oNMWR5ZmtzZ9e5NSnaMr9bwXr58vuCJv2igrkfihS41Iur3/OiehopcYsLVWlJ6zeu1HVDqu0K+JaF0+g==
   dependencies:
-    "@ui5/webcomponents-base" "0.13.1"
-    "@ui5/webcomponents-core" "0.13.1"
+    "@ui5/webcomponents-base" "0.14.0"
+    "@ui5/webcomponents-core" "0.14.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"


### PR DESCRIPTION
BREAKING CHANGE **Button**: `onPress` renamed to `onClick`
BREAKING CHANGE **Card**: `onHeaderPress` renamed to `onHeaderClick`
BREAKING CHANGE **Link**: `onPress` renamed to `onClick`
BREAKING CHANGE **List**: `onItemPress` renamed to `onItemClick`
BREAKING CHANGE **ShellBar**: `onNotificationsPress` renamed to `onNotificationsClick`
BREAKING CHANGE **ShellBar**: `onProfilePress` renamed to `onProfileClick`
BREAKING CHANGE **ShellBar**: `onProductSwitchPress` renamed to `onProductSwitchClick`
BREAKING CHANGE **ShellBar**: `onLogoPress` renamed to `onLogoClick`
BREAKING CHANGE **ShellBar**: `onCoPilotPress` renamed to `onCoPilotClick`
BREAKING CHANGE **TimelineItem**: `onItemNamePress` renamed to `onItemNameClick`
BREAKING CHANGE **ToggleButton**: `onPress` renamed to `onClick`

Closes #43
