### PR TITLE
fix(Carousel): Hide Pagination Bar if not required

### DIFF
--- a/packages/main/__karma_snapshots__/Carousel.md
+++ b/packages/main/__karma_snapshots__/Carousel.md
@@ -6,90 +6,84 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
-        <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" activePage={0}>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
             </div>
-            <WithStyles(CarouselPagination) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationArrowContent--- CarouselPagination-paginationBottom---">
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <span className="CarouselPagination-paginationIconActive--- CarouselPagination-paginationIcon---" aria-label="Item 1 of 7 displayed">
-                      1
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 2 of 7 displayed">
-                      2
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 3 of 7 displayed">
-                      3
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 4 of 7 displayed">
-                      4
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 5 of 7 displayed">
-                      5
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 6 of 7 displayed">
-                      6
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 7 of 7 displayed">
-                      7
-                    </span>
-                  </div>
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+          <CarouselPagination arrowsPlacement="Content" showPageIndicator={true} pageIndicatorPlacement="Bottom" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationArrowContent--- -paginationBottom---">
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>
@@ -101,89 +95,83 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
-        <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" activePage={0}>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 8
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 9
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 10
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={0} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
             </div>
-            <WithStyles(CarouselPagination) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationArrowContent--- CarouselPagination-paginationBottom---">
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <Label for="">
-                      <ui5-label for="" class="">
-                        Showing 1 of 10
-                      </ui5-label>
-                    </Label>
-                  </div>
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={1} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={2} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={3} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={4} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={5} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={6} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={7} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 8
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={8} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 9
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={9} aria-setsize={10} style={{...}}>
+              <p>
+                Carousel 10
+              </p>
+            </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+          <CarouselPagination arrowsPlacement="Content" showPageIndicator={true} pageIndicatorPlacement="Bottom" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationArrowContent--- -paginationBottom---">
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <Label for="">
+                  <ui5-label for="" class="">
+                    Showing 1 of 10
+                  </ui5-label>
+                </Label>
+              </div>
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>
@@ -195,90 +183,84 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) arrowsPlacement="Content" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
-        <Carousel arrowsPlacement="Content" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" activePage={0}>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel arrowsPlacement="Content" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
             </div>
-            <WithStyles(CarouselPagination) arrowsPlacement="Content" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination arrowsPlacement="Content" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationArrowContent--- CarouselPagination-paginationBottom---">
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <span className="CarouselPagination-paginationIconActive--- CarouselPagination-paginationIcon---" aria-label="Item 1 of 7 displayed">
-                      1
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 2 of 7 displayed">
-                      2
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 3 of 7 displayed">
-                      3
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 4 of 7 displayed">
-                      4
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 5 of 7 displayed">
-                      5
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 6 of 7 displayed">
-                      6
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 7 of 7 displayed">
-                      7
-                    </span>
-                  </div>
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+          <CarouselPagination arrowsPlacement="Content" showPageIndicator={true} pageIndicatorPlacement="Bottom" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationArrowContent--- -paginationBottom---">
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>
@@ -290,90 +272,84 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) arrowsPlacement="PageIndicator" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
-        <Carousel arrowsPlacement="PageIndicator" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem---" activePage={0}>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel arrowsPlacement="PageIndicator" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
             </div>
-            <WithStyles(CarouselPagination) arrowsPlacement="PageIndicator" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination arrowsPlacement="PageIndicator" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationBottom---">
-                  <div data-value={{...}} className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <span className="CarouselPagination-paginationIconActive--- CarouselPagination-paginationIcon---" aria-label="Item 1 of 7 displayed">
-                      1
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 2 of 7 displayed">
-                      2
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 3 of 7 displayed">
-                      3
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 4 of 7 displayed">
-                      4
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 5 of 7 displayed">
-                      5
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 6 of 7 displayed">
-                      6
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 7 of 7 displayed">
-                      7
-                    </span>
-                  </div>
-                  <div data-value={{...}} className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+          <CarouselPagination arrowsPlacement="PageIndicator" showPageIndicator={true} pageIndicatorPlacement="Bottom" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationBottom---">
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>
@@ -385,90 +361,171 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false}>
-        <Carousel arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <WithStyles(CarouselPagination) arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationTop---">
-                  <div data-value={{...}} className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <span className="CarouselPagination-paginationIconActive--- CarouselPagination-paginationIcon---" aria-label="Item 1 of 7 displayed">
-                      1
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 2 of 7 displayed">
-                      2
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 3 of 7 displayed">
-                      3
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 4 of 7 displayed">
-                      4
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 5 of 7 displayed">
-                      5
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 6 of 7 displayed">
-                      6
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 7 of 7 displayed">
-                      7
-                    </span>
-                  </div>
-                  <div data-value={{...}} className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem---" activePage={0}>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={0} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false}>
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <CarouselPagination arrowsPlacement="PageIndicator" showPageIndicator={true} pageIndicatorPlacement="Top" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationTop---">
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
             </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+        </div>
+      </Carousel>
+    </ThemeProvider>
+  </JssProvider>
+</ThemeProvider>
+```
+
+```
+<ThemeProvider withToastContainer={false}>
+  <JssProvider generateId={[Function]}>
+    <ThemeProvider theme={{...}}>
+      <Carousel arrowsPlacement="PageIndicator" pageIndicatorPlacement="Top" activePage={1} onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false}>
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <CarouselPagination arrowsPlacement="PageIndicator" showPageIndicator={true} pageIndicatorPlacement="Top" activePage={1} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationTop---">
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="null -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value={{...}} className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
+          </div>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>
@@ -480,90 +537,84 @@
 <ThemeProvider withToastContainer={false}>
   <JssProvider generateId={[Function]}>
     <ThemeProvider theme={{...}}>
-      <WithStyles(Carousel) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
-        <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}}>
-          <div className="Carousel-carousel---" style={{...}} title={[undefined]} slot={[undefined]}>
-            <div className="Carousel-carouselInner---">
-              <CarouselInner className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" activePage={0}>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 1
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 2
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 3
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 4
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 5
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 6
-                  </p>
-                </div>
-                <div className="Carousel-carouselItem--- Carousel-carouselItemContentIndicator---" style={{...}}>
-                  <p>
-                    Carousel 7
-                  </p>
-                </div>
-              </CarouselInner>
+      <Carousel activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom">
+        <div className="Carousel--carousel---" style={{...}} title={[undefined]} slot={[undefined]} role="list">
+          <div className="Carousel--carouselInner---" style={{...}}>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={0} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 1
+              </p>
             </div>
-            <WithStyles(CarouselPagination) activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-              <CarouselPagination activePage={0} arrowsPlacement="Content" onPageChanged={[Function: onPageChanged]} height="100%" width="100%" showPageIndicator={true} loop={false} pageIndicatorPlacement="Bottom" innerRef={{...}} classes={{...}} theme={{...}} goToPreviousPage={[Function]} goToNextPage={[Function]}>
-                <div className="CarouselPagination-pagination--- CarouselPagination-paginationArrowContent--- CarouselPagination-paginationBottom---">
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-left">
-                      <ui5-icon src="slim-arrow-left" class="" />
-                    </Icon>
-                  </div>
-                  <div className="CarouselPagination-paginationIndicator---">
-                    <span className="CarouselPagination-paginationIconActive--- CarouselPagination-paginationIcon---" aria-label="Item 1 of 7 displayed">
-                      1
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 2 of 7 displayed">
-                      2
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 3 of 7 displayed">
-                      3
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 4 of 7 displayed">
-                      4
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 5 of 7 displayed">
-                      5
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 6 of 7 displayed">
-                      6
-                    </span>
-                    <span className="null CarouselPagination-paginationIcon---" aria-label="Item 7 of 7 displayed">
-                      7
-                    </span>
-                  </div>
-                  <div data-value="paginationArrow" className="CarouselPagination-paginationArrow---" onClick={[Function]}>
-                    <Icon src="slim-arrow-right">
-                      <ui5-icon src="slim-arrow-right" class="" />
-                    </Icon>
-                  </div>
-                </div>
-              </CarouselPagination>
-            </WithStyles(CarouselPagination)>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={1} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 2
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={2} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 3
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={3} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 4
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={4} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 5
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={5} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 6
+              </p>
+            </div>
+            <div className="Carousel--carouselItem--- Carousel--carouselItemContentIndicator---" role="listitem" aria-posinset={6} aria-setsize={7} style={{...}}>
+              <p>
+                Carousel 7
+              </p>
+            </div>
           </div>
-        </Carousel>
-      </WithStyles(Carousel)>
+          <CarouselPagination arrowsPlacement="Content" showPageIndicator={true} pageIndicatorPlacement="Bottom" activePage={0} goToPreviousPage={[Function]} goToNextPage={[Function]}>
+            <div className="-pagination--- -paginationArrowContent--- -paginationBottom---">
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-left">
+                  <ui5-icon src="sap-icon://slim-arrow-left" class="" />
+                </Icon>
+              </div>
+              <div className="-paginationIndicator---">
+                <span className="-paginationIconActive--- -paginationIcon---" aria-label="Item 1 of 7 displayed">
+                  1
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 2 of 7 displayed">
+                  2
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 3 of 7 displayed">
+                  3
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 4 of 7 displayed">
+                  4
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 5 of 7 displayed">
+                  5
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 6 of 7 displayed">
+                  6
+                </span>
+                <span className="null -paginationIcon---" aria-label="Item 7 of 7 displayed">
+                  7
+                </span>
+              </div>
+              <div data-value="paginationArrow" className="-paginationArrow---" onClick={[Function]}>
+                <Icon src="sap-icon://slim-arrow-right">
+                  <ui5-icon src="sap-icon://slim-arrow-right" class="" />
+                </Icon>
+              </div>
+            </div>
+          </CarouselPagination>
+        </div>
+      </Carousel>
     </ThemeProvider>
   </JssProvider>
 </ThemeProvider>

--- a/packages/main/src/components/Carousel/Carousel.jss.ts
+++ b/packages/main/src/components/Carousel/Carousel.jss.ts
@@ -1,7 +1,7 @@
 import { fonts } from '@ui5/webcomponents-react-base';
 import { JSSTheme } from '../../interfaces/JSSTheme';
 
-const styles = ({ theme, contentDensity, parameters }: JSSTheme) => ({
+const styles = ({ parameters }: JSSTheme) => ({
   carousel: {
     position: 'relative',
     overflow: 'hidden',

--- a/packages/main/src/components/Carousel/Carousel.jss.ts
+++ b/packages/main/src/components/Carousel/Carousel.jss.ts
@@ -1,4 +1,3 @@
-import { fonts } from '@ui5/webcomponents-react-base';
 import { JSSTheme } from '../../interfaces/JSSTheme';
 
 const styles = ({ parameters }: JSSTheme) => ({
@@ -9,7 +8,8 @@ const styles = ({ parameters }: JSSTheme) => ({
     border: '1px solid transparent',
     touchAction: 'pan-y',
     minWidth: '15.5rem',
-    fontFamily: fonts.sapUiFontFamily,
+    fontFamily: parameters.sapUiFontFamily,
+    backgroundColor: parameters.sapUiBaseBG,
     '&:hover': {
       '& [data-value="paginationArrow"]': {
         opacity: 1
@@ -22,22 +22,17 @@ const styles = ({ parameters }: JSSTheme) => ({
     whiteSpace: 'nowrap',
     textAlign: 'start',
     fontSize: '0',
-    backgroundColor: parameters.sapUiBaseBG,
-    '& > *': {
-      transitionProperty: 'transform',
-      transitionTimingFunction: 'cubic-bezier(0.46, 0, 0.44, 1)',
-      transitionDuration: '0.5s',
-      display: 'inline-block',
-      verticalAlign: 'top',
-      whiteSpace: 'normal',
-      fontSize: '1rem',
-      backgroundColor: parameters.sapUiBaseBG
-    }
+    transition: 'transform 0.5s cubic-bezier(0.46, 0, 0.44, 1)'
   },
   carouselItem: {
     width: '100%',
     height: '100%',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    display: 'inline-block',
+    verticalAlign: 'top',
+    whiteSpace: 'normal',
+    fontSize: '1rem',
+    visibility: 'hidden'
   },
   carouselItemContentIndicator: {
     padding: '0 4rem',

--- a/packages/main/src/components/Carousel/Carousel.karma.tsx
+++ b/packages/main/src/components/Carousel/Carousel.karma.tsx
@@ -70,10 +70,7 @@ describe('Carousel', () => {
       children: cloneElement(wrapper.props().children, { activePage: 1 })
     });
     wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(1);
+    expect(wrapper.debug()).to.matchSnapshot();
   });
 
   it('Update activePage via prop', () => {
@@ -92,77 +89,57 @@ describe('Carousel', () => {
       .find(Icon)
       .last()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(1);
     expect(getEventFromCallback(callback).getParameter('selectedIndex')).to.equal(1);
   });
 
   it('Navigation to previous page', () => {
-    const wrapper = mountThemedComponent(renderCarousel({ activePage: 1 }));
+    const callback = sinon.spy();
+    const wrapper = mountThemedComponent(renderCarousel({ activePage: 1, onPageChanged: callback }));
     wrapper
       .find(Icon)
       .first()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(0);
+    expect(getEventFromCallback(callback).getParameter('selectedIndex')).to.equal(0);
   });
 
   it('Navigation to previous page - w/o Loop', () => {
-    const wrapper = mountThemedComponent(renderCarousel({ activePage: 0 }));
+    const callback = sinon.spy();
+    const wrapper = mountThemedComponent(renderCarousel({ activePage: 0, onPageChanged: callback }));
     wrapper
       .find(Icon)
       .first()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(0);
+    expect(callback.called).to.equal(false);
   });
 
   it('Navigation to previous page - w/ Loop', () => {
-    const wrapper = mountThemedComponent(renderCarousel({ activePage: 0, loop: true }));
+    const callback = sinon.spy();
+    const wrapper = mountThemedComponent(renderCarousel({ activePage: 0, loop: true, onPageChanged: callback }));
     wrapper
       .find(Icon)
       .first()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(6);
+    expect(getEventFromCallback(callback).getParameter('selectedIndex')).to.equal(6);
   });
 
   it('Navigation to next page - w/o Loop', () => {
-    const wrapper = mountThemedComponent(renderCarousel({ activePage: 6 }));
+    const callback = sinon.spy();
+    const wrapper = mountThemedComponent(renderCarousel({ activePage: 6, onPageChanged: callback }));
     wrapper
       .find(Icon)
       .last()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(6);
+    expect(callback.called).to.equal(false);
   });
 
   it('Navigation to next page - w/ Loop', () => {
-    const wrapper = mountThemedComponent(renderCarousel({ activePage: 6, loop: true }));
+    const callback = sinon.spy();
+    const wrapper = mountThemedComponent(renderCarousel({ activePage: 6, loop: true, onPageChanged: callback }));
     wrapper
       .find(Icon)
       .last()
       .simulate('click');
-    wrapper.update();
-    // @ts-ignore
-    const instance = wrapper.find(Carousel.InnerComponent).instance();
-    // @ts-ignore
-    expect(instance.state.activePage).to.equal(0);
+    expect(getEventFromCallback(callback).getParameter('selectedIndex')).to.equal(0);
   });
 
   it('Carousel with 1 child', () => {

--- a/packages/main/src/components/Carousel/CarouselPagination.jss.ts
+++ b/packages/main/src/components/Carousel/CarouselPagination.jss.ts
@@ -12,12 +12,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     backgroundColor: parameters.sapUiPageFooterBackground
   },
   paginationTop: {
-    borderBottom: `1px solid ${parameters.sapUiPageFooterBorderColor}`,
-    '&$paginationArrowContent': {
-      '& $paginationArrow': {
-        top: 'calc(50% + 2rem) !important'
-      }
-    }
+    borderBottom: `1px solid ${parameters.sapUiPageFooterBorderColor}`
   },
   paginationBottom: {
     borderTop: `1px solid ${parameters.sapUiPageFooterBorderColor}`
@@ -76,14 +71,33 @@ const styles = ({ parameters }: JSSTheme) => ({
       boxShadow: parameters.sapUiShadowLevel1,
       '&:first-child': {
         position: 'absolute',
-        top: 'calc(50% - 2rem)',
+        top: 'calc(50% - 2.75rem)',
         left: '0.5rem',
         opacity: 0,
         zIndex: ZIndex.InputModal
       },
       '&:last-child': {
         position: 'absolute',
-        top: 'calc(50% - 2rem)',
+        top: 'calc(50% - 2.75rem)',
+        right: '0.5rem',
+        opacity: 0,
+        zIndex: ZIndex.InputModal
+      }
+    }
+  },
+  paginationArrowContentNoBar: {
+    '& $paginationArrow': {
+      boxShadow: parameters.sapUiShadowLevel1,
+      '&:first-child': {
+        position: 'absolute',
+        top: 'calc(50% - 1rem)',
+        left: '0.5rem',
+        opacity: 0,
+        zIndex: ZIndex.InputModal
+      },
+      '&:last-child': {
+        position: 'absolute',
+        top: 'calc(50% - 1rem)',
         right: '0.5rem',
         opacity: 0,
         zIndex: ZIndex.InputModal

--- a/packages/main/src/components/Carousel/demo.stories.tsx
+++ b/packages/main/src/components/Carousel/demo.stories.tsx
@@ -1,4 +1,5 @@
 import { boolean, number, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Carousel } from '../../lib/Carousel';
@@ -10,6 +11,7 @@ function renderCarousel() {
   return (
     <Carousel
       activePage={number('active', 0)}
+      onPageChanged={action('onPageChanged')}
       arrowsPlacement={select(
         'arrowsPlacement',
         Object.values(CarouselArrowsPlacement),

--- a/packages/main/src/components/Carousel/index.tsx
+++ b/packages/main/src/components/Carousel/index.tsx
@@ -7,15 +7,13 @@ import { PlacementType } from '../../lib/PlacementType';
 import styles from './Carousel.jss';
 import { CarouselPagination, CarouselPaginationPropTypes } from './CarouselPagination';
 
-export interface CarouselPropTypes extends CarouselPaginationPropTypes, CommonProps {
+export interface CarouselPropTypes
+  extends Omit<CarouselPaginationPropTypes, 'goToPreviousPage' | 'goToNextPage'>,
+    CommonProps {
   /**
    * The content which the carousel displays.
    */
   children: ReactNode | ReactNodeArray;
-  /**
-   * Index of the active page to be displayed
-   */
-  activePage?: number;
   /**
    * This event is fired after a carousel swipe has been completed
    */
@@ -44,27 +42,6 @@ interface CarouselState {
     activePage: number;
   };
 }
-
-const CarouselInner = (props) => {
-  const { children, className, activePage } = props;
-
-  return (
-    <Fragment>
-      {Children.map(children, (item, index) => (
-        <div
-          key={index}
-          className={className}
-          style={{
-            transform: `translateX(-${activePage * 100}%)`,
-            visibility: [activePage - 1, activePage, activePage + 1].includes(index) ? 'visible' : 'hidden'
-          }}
-        >
-          {item}
-        </div>
-      ))}
-    </Fragment>
-  );
-};
 
 @withStyles(styles)
 export class Carousel extends Component<CarouselPropTypes, CarouselState> {
@@ -133,7 +110,8 @@ export class Carousel extends Component<CarouselPropTypes, CarouselState> {
       className,
       style,
       arrowsPlacement,
-      tooltip
+      tooltip,
+      showPageIndicator
     } = this.props as CarouselPropsInternal;
 
     const { activePage } = this.state;
@@ -158,21 +136,35 @@ export class Carousel extends Component<CarouselPropTypes, CarouselState> {
       <div className={classNameString.toString()} style={outerStyle} title={tooltip} slot={this.props['slot']}>
         {Children.count(children) > 1 && pageIndicatorPlacement === PlacementType.Top && (
           <CarouselPagination
-            {...this.props}
+            arrowsPlacement={arrowsPlacement}
+            showPageIndicator={showPageIndicator}
+            pageIndicatorPlacement={pageIndicatorPlacement}
             activePage={activePage}
+            children={children}
             goToPreviousPage={this.goToPreviousPage}
             goToNextPage={this.goToNextPage}
           />
         )}
         <div className={classes.carouselInner}>
-          <CarouselInner className={carouselItemClasses.toString()} activePage={activePage}>
-            {children}
-          </CarouselInner>
+          {Children.map(children, (item, index) => (
+            <div
+              key={index}
+              className={carouselItemClasses.toString()}
+              style={{
+                transform: `translateX(-${activePage * 100}%)`
+              }}
+            >
+              {item}
+            </div>
+          ))}
         </div>
         {Children.count(children) > 1 && pageIndicatorPlacement === PlacementType.Bottom && (
           <CarouselPagination
-            {...this.props}
+            arrowsPlacement={arrowsPlacement}
+            showPageIndicator={showPageIndicator}
+            pageIndicatorPlacement={pageIndicatorPlacement}
             activePage={activePage}
+            children={children}
             goToPreviousPage={this.goToPreviousPage}
             goToNextPage={this.goToNextPage}
           />


### PR DESCRIPTION
Fixes #95 

The Pagination Bar is now hidden in case the arrowPlacement is in the content and showPagination is set to false.
In addition, the component is now refactored from a HOC implementation to a forwarfRef implementation.