### PR TITLE
fix(AnalyticalTable): Fix Grouping

### DIFF
--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -356,53 +356,19 @@ exports[`AnalyticalTable Tree Table 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="align-items: center;"
-            >
-              <span
-                class=""
-                style="cursor: pointer; padding-left: 0px;"
-                title="Toggle Expanded"
-              >
-                <ui5-icon
-                  class="AnalyticalTable--tableGroupExpandCollapseIcon-"
-                  src="sap-icon://navigation-right-arrow"
-                />
-              </span>
-              <div
-                class="AnalyticalTable--tableCellContent-"
-              >
-                Fra
-              </div>
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="align-items: center;"
-            >
-              <div
-                class="AnalyticalTable--tableCellContent-"
-              >
-                40
-              </div>
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="align-items: center;"
-            >
-              <div
-                class="AnalyticalTable--tableCellContent-"
-              >
-                MAR
-              </div>
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="align-items: center;"
-            >
-              <div
-                class="AnalyticalTable--tableCellContent-"
-              >
-                28
-              </div>
-            </div>
+            />
           </div>
           <div
             class="AnalyticalTable--tr-"
@@ -424,7 +390,6 @@ exports[`AnalyticalTable Tree Table 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 20
               </div>
@@ -435,7 +400,6 @@ exports[`AnalyticalTable Tree Table 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 Nei
               </div>
@@ -446,7 +410,6 @@ exports[`AnalyticalTable Tree Table 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 50
               </div>
@@ -795,7 +758,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 40
               </div>
@@ -806,7 +768,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 MAR
               </div>
@@ -817,7 +778,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 28
               </div>
@@ -843,7 +803,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 20
               </div>
@@ -854,7 +813,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 Nei
               </div>
@@ -865,7 +823,6 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             >
               <div
                 class="AnalyticalTable--tableCellContent-"
-                style="padding-left: 0px;"
               >
                 50
               </div>

--- a/packages/main/src/components/AnalyticalTable/demo/demo.stories.tsx
+++ b/packages/main/src/components/AnalyticalTable/demo/demo.stories.tsx
@@ -24,6 +24,7 @@ const columns = [
   {
     Header: () => <span>Friend Age</span>, // Custom header components!
     accessor: 'friend.age',
+    hAlign: TextAlign.End,
     filter: (rows, accessor, filterValue) => {
       if (filterValue === 'all') {
         return rows;
@@ -103,6 +104,7 @@ export const treeTable = () => {
       onSort={action('onSort')}
       subRowsKey={text('subRowsKey', 'subRows')}
       selectedRowKey={text('selectedRowKey', `row_5`)}
+      isTreeTable={boolean('isTreeTable', true)}
     />
   );
 };

--- a/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableBody.tsx
+++ b/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableBody.tsx
@@ -26,7 +26,8 @@ export const VirtualTableBody = (props) => {
     NoDataComponent,
     selectedRow,
     selectable,
-    reactWindowRef
+    reactWindowRef,
+    isTreeTable
   } = props;
 
   const innerDivRef = useRef(null);
@@ -68,7 +69,7 @@ export const VirtualTableBody = (props) => {
           {row.cells.map((cell, i) => {
             const cellProps = cell.getCellProps();
             const key = cellProps && cellProps.key ? cellProps.key : `cell-${i}`;
-            return <Cell key={key} row={row} cell={cell} index={i} classes={classes} />;
+            return <Cell key={key} row={row} cell={cell} columnIndex={i} classes={classes} isTreeTable={isTreeTable} />;
           })}
         </div>
       );

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,64 +4,64 @@
       "filename": "charts.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "charts",
-      "size": 18083,
-      "gzip": 5180
+      "size": 18079,
+      "gzip": 5172
     },
     {
       "filename": "charts.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "charts",
-      "size": 18083,
-      "gzip": 5180
+      "size": 18079,
+      "gzip": 5172
     },
     {
       "filename": "base.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "base",
-      "size": 67029,
-      "gzip": 16325
+      "size": 67525,
+      "gzip": 16501
     },
     {
       "filename": "base.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "base",
-      "size": 67029,
-      "gzip": 16325
+      "size": 67525,
+      "gzip": 16501
     },
     {
       "filename": "main.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "main",
-      "size": 115370,
-      "gzip": 30233
+      "size": 122912,
+      "gzip": 32219
     },
     {
       "filename": "main.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "main",
-      "size": 115370,
-      "gzip": 30233
+      "size": 122912,
+      "gzip": 32219
     },
     {
       "filename": "main.js",
       "bundleType": "NODE_ES",
       "packageName": "main",
-      "size": 213865,
-      "gzip": 41812
+      "size": 229466,
+      "gzip": 44699
     },
     {
       "filename": "base.js",
       "bundleType": "NODE_ES",
       "packageName": "base",
-      "size": 142153,
-      "gzip": 28260
+      "size": 143111,
+      "gzip": 28560
     },
     {
       "filename": "charts.js",
       "bundleType": "NODE_ES",
       "packageName": "charts",
-      "size": 36195,
-      "gzip": 6811
+      "size": 36191,
+      "gzip": 6804
     }
   ]
 }


### PR DESCRIPTION
Fixes Grouping and Aligment for grouped cells
BREAKING CHANGE: If used as a tree table, the prop `isTreeTable` is now mandatory

Closes #117