### PR TITLE
fix(Avatar): Don't crash onClick when no handler is passed

### DIFF
--- a/packages/main/src/components/Avatar/Avatar.test.tsx
+++ b/packages/main/src/components/Avatar/Avatar.test.tsx
@@ -59,6 +59,13 @@ describe('Avatar', () => {
     expect(callback.called).toBe(true);
   });
 
+  test('do not crash onClick w/o handler (#272)', () => {
+    expect(() => {
+      const wrapper = mountThemedComponent(<Avatar size={AvatarSize.XL} initials="JD" />);
+      wrapper.find(Avatar).simulate('click');
+    }).not.toThrow();
+  });
+
   test('enter key down', () => {
     const callback = sinon.spy();
     const wrapper = mountThemedComponent(<Avatar size={AvatarSize.XL} initials="JD" onClick={callback} />);

--- a/packages/main/src/components/Avatar/index.tsx
+++ b/packages/main/src/components/Avatar/index.tsx
@@ -76,7 +76,7 @@ const Avatar: FC<AvatarPropTypes> = forwardRef((props: AvatarPropTypes, ref: Ref
   const handleKeyDown = useCallback(
     (e) => {
       if (e.key === 'Enter') {
-        onClick(Event.of(null, e));
+        onClick?.(Event.of(null, e));
       }
     },
     [onClick]
@@ -84,7 +84,7 @@ const Avatar: FC<AvatarPropTypes> = forwardRef((props: AvatarPropTypes, ref: Ref
 
   const handleOnClick = useCallback(
     (e) => {
-      onClick(Event.of(null, e));
+      onClick?.(Event.of(null, e));
     },
     [onClick]
   );


### PR DESCRIPTION
Fixes #272

