### PR TITLE
fix(AnalyticalTable): fix broken empty row visualization

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
+++ b/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
@@ -45,6 +45,7 @@ const styles = ({ parameters }: JSSTheme) => ({
       backgroundColor: parameters.sapUiListHeaderBackground
     }
   },
+  emptyRow: {},
   tr: {
     zIndex: 0,
     backgroundColor: parameters.sapUiListBackground,
@@ -67,11 +68,11 @@ const styles = ({ parameters }: JSSTheme) => ({
     }
   },
   selectable: {
-    '& $tr:hover': {
+    '& $tr:hover:not($emptyRow)': {
       backgroundColor: parameters.sapUiListHoverBackground,
       cursor: 'pointer'
     },
-    '& $tr:active:not([data-is-selected]):not($tableGroupHeader)': {
+    '& $tr:active:not([data-is-selected]):not($tableGroupHeader):not($emptyRow)': {
       backgroundColor: parameters.sapUiListActiveBackground,
       '& $tableCell': {
         borderRight: `1px solid ${parameters.sapUiListActiveBackground}`,

--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AnalyticalTable Alternate Row Color 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -414,58 +414,145 @@ exports[`AnalyticalTable Alternate Row Color 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -490,7 +577,7 @@ exports[`AnalyticalTable Loading - Loader 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -888,58 +975,145 @@ exports[`AnalyticalTable Loading - Loader 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -964,7 +1138,7 @@ exports[`AnalyticalTable Loading - Placeholder 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="0"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -1243,234 +1417,251 @@ exports[`AnalyticalTable Loading - Placeholder 1`] = `
           />
         </div>
       </header>
-      <svg
-        aria-label="Loading interface..."
-        preserveAspectRatio="none"
-        role="img"
-        style="width: 100%; height: 220px;"
-        viewBox="0 0 260 220"
+      <div
+        class="AnalyticalTable--virtualTableBody-"
+        style="position: relative; height: 220px; width: 240px; overflow: auto; will-change: transform; direction: ltr;"
       >
-        <title>
-          Loading interface...
-        </title>
-        <rect
-          clip-path="CLIP-PATH-URL"
-          height="220"
-          style="fill: url(#STYLE-URL);"
-          width="260"
-          x="0"
-          y="0"
-        />
-        <defs>
-          <clipPath
-            id="CLIP-PATH-URL"
+        <div
+          class="AnalyticalTable--tbody-"
+          style="height: 220px; width: 100%;"
+        >
+          <div
+            aria-rowindex="0"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 0px; height: 44px; width: 100%;"
           >
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="2"
-              y="22"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="67"
-              y="22"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="132"
-              y="22"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="197"
-              y="22"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="2"
-              y="66"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="67"
-              y="66"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="132"
-              y="66"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="197"
-              y="66"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="2"
-              y="110"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="67"
-              y="110"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="132"
-              y="110"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="197"
-              y="110"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="2"
-              y="154"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="67"
-              y="154"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="132"
-              y="154"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="197"
-              y="154"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="2"
-              y="198"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="67"
-              y="198"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="132"
-              y="198"
-            />
-            <rect
-              height="16"
-              rx="2"
-              ry="8"
-              width="61"
-              x="197"
-              y="198"
-            />
-          </clipPath>
-          <linearGradient
-            id="STYLE-URL"
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="1"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 44px; height: 44px; width: 100%;"
           >
-            <stop
-              offset="0%"
-              stop-color="var(--sapUiContentImagePlaceholderBackground)"
-              stop-opacity="var(--sapUiContentDisabledOpacity)"
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
             >
-              <animate
-                attributeName="offset"
-                dur="2s"
-                keyTimes="0; 0.25; 1"
-                repeatCount="indefinite"
-                values="-2; -2; 1"
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
               />
-            </stop>
-            <stop
-              offset="50%"
-              stop-color="var(--sapUiFieldPlaceholderTextColor)"
-              stop-opacity="1"
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
             >
-              <animate
-                attributeName="offset"
-                dur="2s"
-                keyTimes="0; 0.25; 1"
-                repeatCount="indefinite"
-                values="-1; -1; 2"
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
               />
-            </stop>
-            <stop
-              offset="100%"
-              stop-color="var(--sapUiContentImagePlaceholderBackground)"
-              stop-opacity="var(--sapUiContentDisabledOpacity)"
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
             >
-              <animate
-                attributeName="offset"
-                dur="2s"
-                keyTimes="0; 0.25; 1"
-                repeatCount="indefinite"
-                values="0; 0; 3"
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
               />
-            </stop>
-          </linearGradient>
-        </defs>
-      </svg>
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1492,7 +1683,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -2003,58 +2194,115 @@ exports[`AnalyticalTable Tree Table 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                style="padding-left: 0px;"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -2079,7 +2327,7 @@ exports[`AnalyticalTable custom row height 1`] = `
     class="AnalyticalTable--tableContainer- AnalyticalTable--modifiedRowHeight- AnalyticalTable--modifiedRowHeight-d0-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -2477,58 +2725,145 @@ exports[`AnalyticalTable custom row height 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 120px; height: 60px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 180px; height: 60px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 240px; height: 60px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -2553,7 +2888,7 @@ exports[`AnalyticalTable render without data 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="0"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -2833,10 +3168,249 @@ exports[`AnalyticalTable render without data 1`] = `
         </div>
       </header>
       <div
-        class="AnalyticalTable--noDataContainer-"
-        style="height: 220px;"
+        class="AnalyticalTable--virtualTableBody-"
+        style="position: relative; height: 220px; width: 240px; overflow: auto; will-change: transform; direction: ltr;"
       >
-        No Data
+        <div
+          class="AnalyticalTable--tbody- AnalyticalTable--alternateRowColor-"
+          style="height: 220px; width: 100%;"
+        >
+          <div
+            aria-rowindex="0"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 0px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="1"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 44px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+          <div
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
+            role="row"
+            style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
+          >
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+            <div
+              class="AnalyticalTable--tableCell-"
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -2859,7 +3433,7 @@ exports[`AnalyticalTable test Asc desc 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -3257,58 +3831,145 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -3333,7 +3994,7 @@ exports[`AnalyticalTable test drag and drop of a draggable column 1`] = `
     class="AnalyticalTable--tableContainer-"
   >
     <div
-      aria-rowcount="2"
+      aria-rowcount="5"
       class="AnalyticalTable--table-"
       role="table"
     >
@@ -3731,58 +4392,145 @@ exports[`AnalyticalTable test drag and drop of a draggable column 1`] = `
             </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="2"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="3"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
           <div
-            class="AnalyticalTable--tr-"
+            aria-rowindex="4"
+            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
             role="row"
             style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
           >
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 0px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 60px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 120px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
             <div
               class="AnalyticalTable--tableCell-"
-            />
+              style="position: absolute; top: 0px; left: 180px; width: 60px; align-items: center;"
+            >
+              <span
+                class="Text--text- Text--noWrap-"
+                style="width: 100%;"
+                title=""
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/main/src/components/AnalyticalTable/hooks/useTableRowStyling.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useTableRowStyling.ts
@@ -6,9 +6,14 @@ const ROW_SELECTION_ATTRIBUTE = 'data-is-selected';
 export const useTableRowStyling = (hooks) => {
   hooks.getRowProps.push((passedRowProps, { instance, row }) => {
     const { classes, selectionMode, onRowSelected } = instance.webComponentsReactProperties;
+    const isEmptyRow = row.original?.emptyRow;
     let className = classes.tr;
     if (row.isGrouped) {
       className += ` ${classes.tableGroupHeader}`;
+    }
+
+    if(isEmptyRow) {
+      className += ` ${classes.emptyRow}`;
     }
 
     const rowProps: any = {
@@ -16,7 +21,7 @@ export const useTableRowStyling = (hooks) => {
       className,
       role: 'row'
     };
-    if ([TableSelectionMode.SINGLE_SELECT, TableSelectionMode.MULTI_SELECT].includes(selectionMode)) {
+    if ([TableSelectionMode.SINGLE_SELECT, TableSelectionMode.MULTI_SELECT].includes(selectionMode) && !isEmptyRow) {
       rowProps.onClick = (e) => {
         if (row.isGrouped) {
           return;

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -133,7 +133,6 @@ const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(sty
 const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<HTMLDivElement>) => {
   const {
     columns,
-    data,
     className,
     style,
     tooltip,
@@ -179,6 +178,17 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
     }
     return DefaultColumn;
   }, [columnWidth]);
+
+  const data = useMemo(() => {
+    if (minRows > props.data.length) {
+      const missingRows = minRows - props.data.length;
+      // @ts-ignore
+      const emptyRows = [...Array(missingRows).keys()].map(() => ({ emptyRow: true }));
+
+      return [...props.data, ...emptyRows];
+    }
+    return props.data;
+  }, [props.data, minRows]);
 
   const {
     getTableProps,
@@ -293,8 +303,8 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
   const internalRowHeight = rowHeight ?? calcRowHeight;
 
   const tableBodyHeight = useMemo(() => {
-    return internalRowHeight * Math.max(rows.length < visibleRows ? rows.length : visibleRows, minRows);
-  }, [internalRowHeight, rows.length, minRows, visibleRows]);
+    return internalRowHeight * Math.min(Math.max(rows.length, minRows), visibleRows);
+  }, [internalRowHeight, rows.length, visibleRows, minRows]);
 
   const noDataStyles = useMemo(() => {
     return {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -303,7 +303,8 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
   const internalRowHeight = rowHeight ?? calcRowHeight;
 
   const tableBodyHeight = useMemo(() => {
-    return internalRowHeight * Math.min(Math.max(rows.length, minRows), visibleRows);
+    const rowNum = rows.length < visibleRows ? Math.max(rows.length, minRows) : visibleRows;
+    return internalRowHeight * rowNum;
   }, [internalRowHeight, rows.length, visibleRows, minRows]);
 
   const noDataStyles = useMemo(() => {

--- a/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableRow.tsx
+++ b/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableRow.tsx
@@ -3,21 +3,11 @@ import React from 'react';
 export const VirtualTableRow = (props) => {
   const { style, index, data } = props;
   const { additionalProps, rows } = data;
-  const { isTreeTable, classes, columns } = additionalProps;
+  const { isTreeTable } = additionalProps;
   const row = rows[index];
 
   if (!row) {
-    return (
-      <div key={`minRow-${index}`} className={classes.tr} style={style} role="row">
-        {columns.map((col, colIndex) => {
-          let classNames = classes.tableCell;
-          if (col.className) {
-            classNames += ` ${col.className}`;
-          }
-          return <div className={classNames} key={`minRow-${index}-${colIndex}`} />;
-        })}
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
Since we switched to the useBlockLayout hook, the visualization of empty rows which are added by the minRows prop was broken, as the cells now need specific styling provided by react-table, which the didn´t get. 

This is now fixed + the logic to determin table body height was adjusted. minRows should only be taken into account here, if the actual number of rows is lower than visibleRows.