### PR TITLE
fix(AnalyticalTable): fix minRows + loading behaviour

### DIFF
--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -405,43 +405,19 @@ exports[`AnalyticalTable Alternate Row Color 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -452,43 +428,19 @@ exports[`AnalyticalTable Alternate Row Color 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -499,43 +451,19 @@ exports[`AnalyticalTable Alternate Row Color 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -949,43 +877,19 @@ exports[`AnalyticalTable Loading - Loader 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -996,43 +900,19 @@ exports[`AnalyticalTable Loading - Loader 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -1043,43 +923,19 @@ exports[`AnalyticalTable Loading - Loader 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -1366,251 +1222,234 @@ exports[`AnalyticalTable Loading - Placeholder 1`] = `
           />
         </div>
       </header>
-      <div
-        class="AnalyticalTable--virtualTableBody-"
-        style="position: relative; height: 220px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      <svg
+        aria-label="Loading interface..."
+        preserveAspectRatio="none"
+        role="img"
+        style="width: 100%; height: 220px;"
+        viewBox="0 0 260 220"
       >
-        <div
-          class="AnalyticalTable--tbody-"
-          style="height: 220px; width: 100%;"
-        >
-          <div
-            aria-rowindex="0"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 0px; height: 44px; width: 100%;"
+        <title>
+          Loading interface...
+        </title>
+        <rect
+          clip-path="CLIP-PATH-URL"
+          height="220"
+          style="fill: url(#STYLE-URL);"
+          width="260"
+          x="0"
+          y="0"
+        />
+        <defs>
+          <clipPath
+            id="CLIP-PATH-URL"
           >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="1"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 44px; height: 44px; width: 100%;"
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="2"
+              y="22"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="67"
+              y="22"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="132"
+              y="22"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="197"
+              y="22"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="2"
+              y="66"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="67"
+              y="66"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="132"
+              y="66"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="197"
+              y="66"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="2"
+              y="110"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="67"
+              y="110"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="132"
+              y="110"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="197"
+              y="110"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="2"
+              y="154"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="67"
+              y="154"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="132"
+              y="154"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="197"
+              y="154"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="2"
+              y="198"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="67"
+              y="198"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="132"
+              y="198"
+            />
+            <rect
+              height="16"
+              rx="2"
+              ry="8"
+              width="61"
+              x="197"
+              y="198"
+            />
+          </clipPath>
+          <linearGradient
+            id="STYLE-URL"
           >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
+            <stop
+              offset="0%"
+              stop-color="var(--sapUiContentImagePlaceholderBackground)"
+              stop-opacity="var(--sapUiContentDisabledOpacity)"
             >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
+              <animate
+                attributeName="offset"
+                dur="2s"
+                keyTimes="0; 0.25; 1"
+                repeatCount="indefinite"
+                values="-2; -2; 1"
               />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
+            </stop>
+            <stop
+              offset="50%"
+              stop-color="var(--sapUiFieldPlaceholderTextColor)"
+              stop-opacity="1"
             >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
+              <animate
+                attributeName="offset"
+                dur="2s"
+                keyTimes="0; 0.25; 1"
+                repeatCount="indefinite"
+                values="-1; -1; 2"
               />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
+            </stop>
+            <stop
+              offset="100%"
+              stop-color="var(--sapUiContentImagePlaceholderBackground)"
+              stop-opacity="var(--sapUiContentDisabledOpacity)"
             >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
+              <animate
+                attributeName="offset"
+                dur="2s"
+                keyTimes="0; 0.25; 1"
+                repeatCount="indefinite"
+                values="0; 0; 3"
               />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="2"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="3"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="4"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-        </div>
-      </div>
+            </stop>
+          </linearGradient>
+        </defs>
+      </svg>
     </div>
   </div>
 </div>
@@ -2121,33 +1960,19 @@ exports[`AnalyticalTable Tree Table 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -2158,33 +1983,19 @@ exports[`AnalyticalTable Tree Table 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -2195,33 +2006,19 @@ exports[`AnalyticalTable Tree Table 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                style="padding-left: 0px;"
-              />
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -2635,43 +2432,19 @@ exports[`AnalyticalTable custom row height 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -2682,43 +2455,19 @@ exports[`AnalyticalTable custom row height 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -2729,43 +2478,19 @@ exports[`AnalyticalTable custom row height 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -3053,249 +2778,10 @@ exports[`AnalyticalTable render without data 1`] = `
         </div>
       </header>
       <div
-        class="AnalyticalTable--virtualTableBody-"
-        style="position: relative; height: 220px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+        class="AnalyticalTable--noDataContainer-"
+        style="height: 220px;"
       >
-        <div
-          class="AnalyticalTable--tbody-"
-          style="height: 220px; width: 100%;"
-        >
-          <div
-            aria-rowindex="0"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 0px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="1"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow- AnalyticalTable--alternateRowColor-"
-            role="row"
-            style="position: absolute; left: 0px; top: 44px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="2"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 88px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="3"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow- AnalyticalTable--alternateRowColor-"
-            role="row"
-            style="position: absolute; left: 0px; top: 132px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-          <div
-            aria-rowindex="4"
-            class="AnalyticalTable--tr- AnalyticalTable--emptyRow-"
-            role="row"
-            style="position: absolute; left: 0px; top: 176px; height: 44px; width: 100%;"
-          >
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-            <div
-              class="AnalyticalTable--tableCell-"
-              style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
-          </div>
-        </div>
+        No Data
       </div>
     </div>
   </div>
@@ -3707,43 +3193,19 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -3754,43 +3216,19 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -3801,43 +3239,19 @@ exports[`AnalyticalTable test Asc desc 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -4251,43 +3665,19 @@ exports[`AnalyticalTable test drag and drop of a draggable column 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="3"
@@ -4298,43 +3688,19 @@ exports[`AnalyticalTable test drag and drop of a draggable column 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
           <div
             aria-rowindex="4"
@@ -4345,43 +3711,19 @@ exports[`AnalyticalTable test drag and drop of a draggable column 1`] = `
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 0px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 150px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 300px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
             <div
               class="AnalyticalTable--tableCell-"
               style="position: absolute; top: 0px; left: 450px; width: 150px; align-items: center;"
-            >
-              <span
-                class="Text--text- Text--noWrap-"
-                style="width: 100%;"
-                title=""
-              />
-            </div>
+            />
           </div>
         </div>
       </div>

--- a/packages/main/src/components/AnalyticalTable/hooks/useColumnsDependencies.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useColumnsDependencies.ts
@@ -1,5 +1,5 @@
 export const useColumnsDependencies = (hooks) => {
   hooks.columnsDeps.push((deps, { instance: { state, webComponentsReactProperties } }) => {
-    return [state.tableClientWidth, state.hiddenColumns, webComponentsReactProperties.scaleWidthMode];
+    return [state.tableClientWidth, state.hiddenColumns, webComponentsReactProperties.scaleWidthMode, webComponentsReactProperties.loading];
   });
 };

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -205,8 +205,8 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
         onRowExpandChange,
         isTreeTable,
         alternateRowColor,
-        // tableClientWidth,
-        scaleWidthMode
+        scaleWidthMode,
+        loading
       },
       ...reactTableOptions
     },
@@ -360,8 +360,8 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
                 </header>
               );
             })}
-            {loading && busyIndicatorEnabled && data.length > 0 && <LoadingComponent />}
-            {loading && data.length === 0 && (
+            {loading && busyIndicatorEnabled && props.data?.length > 0 && <LoadingComponent />}
+            {loading && props.data?.length === 0 && (
               <TablePlaceholder
                 columns={
                   columns.filter((col) => (col.isVisible ?? true) && !tableState.hiddenColumns.includes(col.accessor))
@@ -372,10 +372,10 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
                 rowHeight={internalRowHeight}
               />
             )}
-            {!loading && data.length === 0 && (
+            {!loading && props.data?.length === 0 && (
               <NoDataComponent noDataText={noDataText} className={classes.noDataContainer} style={noDataStyles} />
             )}
-            {data.length > 0 && (
+            {props.data?.length > 0 && (
               <VirtualTableBody
                 classes={classes}
                 prepareRow={prepareRow}

--- a/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableRow.tsx
+++ b/packages/main/src/components/AnalyticalTable/virtualization/VirtualTableRow.tsx
@@ -13,6 +13,7 @@ export const VirtualTableRow = (props) => {
   return (
     <div {...row.getRowProps()} style={style} aria-rowindex={index}>
       {row.cells.map((cell) => {
+        if (row.original?.emptyRow) return <div {...cell.getCellProps()} />;
         let contentToRender = 'Cell';
         if (isTreeTable) {
           contentToRender = 'Expandable';


### PR DESCRIPTION
- if the table doesn´t have data and loading is true, it now shows the Placeholder loading again
- fixed weird looking table headers with scaleWidthMode Grow in loading state
- table cell renderer is now not being called for empty rows which were inserted because of the minRows prop