### PR TITLE
fix(Bar): Alignment

### DIFF
--- a/packages/base/src/styling/CssSizeVariables.ts
+++ b/packages/base/src/styling/CssSizeVariables.ts
@@ -1,5 +1,6 @@
 export enum CssSizeVariablesNames {
   sapWcrBarHeight = 'sapWcrBarHeight',
+  sapWcrSubHeaderBarHeight = 'sapWcrSubHeaderBarHeight',
   sapWcrProgressIndicatorHeight = 'sapWcrProgressIndicatorHeight',
   sapWcrProgressIndicatorMargin = 'sapWcrProgressIndicatorMargin',
   sapWcrSegmentedButtonPadding = 'sapWcrSegmentedButtonPadding',
@@ -26,6 +27,7 @@ export const CssSizeVariables: Record<CssSizeVariablesNames, string> = Object.va
 export const cssVariablesStyles = `
 :root {
   --${CssSizeVariablesNames.sapWcrBarHeight}:2.75rem;
+  --${CssSizeVariablesNames.sapWcrSubHeaderBarHeight}:3rem;
   --${CssSizeVariablesNames.sapWcrProgressIndicatorHeight}:1rem;
   --${CssSizeVariablesNames.sapWcrProgressIndicatorMargin}:0.5rem 0;
   --${CssSizeVariablesNames.sapWcrSegmentedButtonPadding}:0.250rem 0;
@@ -45,6 +47,7 @@ export const cssVariablesStyles = `
 .ui5-content-density-compact,
 .sapUiSizeCompact {
   --${CssSizeVariablesNames.sapWcrBarHeight}:2.5rem;
+  --${CssSizeVariablesNames.sapWcrSubHeaderBarHeight}:2.25rem;
   --${CssSizeVariablesNames.sapWcrProgressIndicatorHeight}:1.125rem;
   --${CssSizeVariablesNames.sapWcrSegmentedButtonPadding}:0.1875rem 0;
   --${CssSizeVariablesNames.sapWcrSegmentedButtonHeight}:2rem;

--- a/packages/main/src/components/Bar/Bar.jss.ts
+++ b/packages/main/src/components/Bar/Bar.jss.ts
@@ -1,3 +1,5 @@
+import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
+
 const styles = ({ parameters }) => ({
   bar: {
     width: '100%',
@@ -5,7 +7,7 @@ const styles = ({ parameters }) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     overflow: 'hidden',
-    textOverflow:'ellipsis'
+    textOverflow: 'ellipsis'
   },
   left: {
     paddingLeft: '0.5rem',
@@ -20,23 +22,23 @@ const styles = ({ parameters }) => ({
     paddingRight: '0.5rem'
   },
   auto: {
-    height: '2.5rem',
+    height: CssSizeVariables.sapWcrBarHeight,
     background: parameters.sapUiPageHeaderBackground,
     boxShadow: parameters.sapUiShadowHeader
   },
   subHeader: {
-    height: '2.25rem',
+    height: CssSizeVariables.sapWcrSubHeaderBarHeight,
     background: parameters.sapUiPageHeaderBackground,
     boxShadow: parameters.sapUiShadowHeader,
     paddingBottom: ' 0.25rem'
   },
   footer: {
-    height: '2.5rem',
+    height: CssSizeVariables.sapWcrBarHeight,
     background: parameters.sapUiPageFooterBackground,
     borderTop: `0.0625rem solid ${parameters.sapUiPageFooterBorderColor}`
   },
   floatingFooter: {
-    height: '2.5rem',
+    height: CssSizeVariables.sapWcrBarHeight,
     background: parameters.sapUiPageFooterBackground,
     borderRadius: parameters.sapUiElementBorderCornerRadius,
     boxShadow: parameters.sapUiShadowLevel1,

--- a/packages/main/src/components/Bar/Bar.jss.ts
+++ b/packages/main/src/components/Bar/Bar.jss.ts
@@ -1,53 +1,48 @@
-import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-
-const styles = {
-  // outer container, controlling height and width
+const styles = ({ parameters }) => ({
   bar: {
     width: '100%',
-    display: 'block',
-    position: 'relative',
-    height: CssSizeVariables.sapWcrBarHeight,
-    lineHeight: CssSizeVariables.sapWcrBarHeight,
-    '& ui5-button': {
-      display: 'flex'
-    }
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    overflow: 'hidden',
+    textOverflow:'ellipsis'
   },
-  // left container
   left: {
-    position: 'absolute',
-    left: '0',
-    top: '0',
-    height: '100%',
     paddingLeft: '0.5rem',
-    textAlign: 'left',
-    display: 'flex',
     alignItems: 'center'
   },
-  // center container
   center: {
-    textAlign: 'center',
-    width: '100%',
-    height: '0',
-    top: '0',
-    left: '0'
+    alignItems: 'center',
+    padding: '0 0.5rem'
   },
-  // inner container around left, center, and right
-  inner: {
-    display: 'inline-block',
-    padding: '0 0.5rem 0 0.5rem',
-    height: CssSizeVariables.sapWcrBarHeight
-  },
-  // right container
   right: {
-    position: 'absolute',
-    right: '0',
-    top: '0',
-    height: '100%',
-    paddingRight: '0.5rem',
-    textAlign: 'right',
-    display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    paddingRight: '0.5rem'
+  },
+  auto: {
+    height: '2.5rem',
+    background: parameters.sapUiPageHeaderBackground,
+    boxShadow: parameters.sapUiShadowHeader
+  },
+  subHeader: {
+    height: '2.25rem',
+    background: parameters.sapUiPageHeaderBackground,
+    boxShadow: parameters.sapUiShadowHeader,
+    paddingBottom: ' 0.25rem'
+  },
+  footer: {
+    height: '2.5rem',
+    background: parameters.sapUiPageFooterBackground,
+    borderTop: `0.0625rem solid ${parameters.sapUiPageFooterBorderColor}`
+  },
+  floatingFooter: {
+    height: '2.5rem',
+    background: parameters.sapUiPageFooterBackground,
+    borderRadius: parameters.sapUiElementBorderCornerRadius,
+    boxShadow: parameters.sapUiShadowLevel1,
+    border: 'none',
+    opacity: 1
   }
-};
+});
 
 export default styles;

--- a/packages/main/src/components/Bar/Bar.jss.ts
+++ b/packages/main/src/components/Bar/Bar.jss.ts
@@ -1,50 +1,86 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }) => ({
+const styles = {
+  // outer container, controlling height and width
   bar: {
     width: '100%',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    display: 'block',
+    position: 'relative',
+    height: CssSizeVariables.sapWcrBarHeight
   },
+  // left container
   left: {
+    position: 'absolute',
+    left: '0',
+    top: '0',
+    height: '100%',
     paddingLeft: '0.5rem',
+    textAlign: 'left',
+    display: 'flex',
     alignItems: 'center'
   },
+  // center container
   center: {
-    alignItems: 'center',
-    padding: '0 0.5rem'
+    textAlign: 'center',
+    width: '100%',
+    height: '0',
+    top: '0',
+    left: '0'
   },
+  // inner container around left, center, and right
+  inner: {
+    display: 'inline-flex',
+    padding: '0 0.5rem 0 0.5rem',
+    alignItems: 'center'
+  },
+  // right container
   right: {
-    alignItems: 'center',
-    paddingRight: '0.5rem'
+    position: 'absolute',
+    right: '0',
+    top: '0',
+    height: '100%',
+    paddingRight: '0.5rem',
+    textAlign: 'right',
+    display: 'flex',
+    alignItems: 'center'
   },
   auto: {
     height: CssSizeVariables.sapWcrBarHeight,
-    background: parameters.sapUiPageHeaderBackground,
-    boxShadow: parameters.sapUiShadowHeader
+    background: ThemingParameters.sapUiPageHeaderBackground,
+    boxShadow: ThemingParameters.sapUiShadowHeader,
+    '& $inner': {
+      height: CssSizeVariables.sapWcrBarHeight
+    }
   },
   subHeader: {
     height: CssSizeVariables.sapWcrSubHeaderBarHeight,
-    background: parameters.sapUiPageHeaderBackground,
-    boxShadow: parameters.sapUiShadowHeader,
-    paddingBottom: ' 0.25rem'
+    background: ThemingParameters.sapUiPageHeaderBackground,
+    boxShadow: ThemingParameters.sapUiShadowHeader,
+    paddingBottom: ' 0.25rem',
+    '& $inner': {
+      height: CssSizeVariables.sapWcrSubHeaderBarHeight
+    }
   },
   footer: {
     height: CssSizeVariables.sapWcrBarHeight,
-    background: parameters.sapUiPageFooterBackground,
-    borderTop: `0.0625rem solid ${parameters.sapUiPageFooterBorderColor}`
+    background: ThemingParameters.sapUiPageFooterBackground,
+    borderTop: `0.0625rem solid ${ThemingParameters.sapUiPageFooterBorderColor}`,
+    '& $inner': {
+      height: CssSizeVariables.sapWcrBarHeight
+    }
   },
   floatingFooter: {
     height: CssSizeVariables.sapWcrBarHeight,
-    background: parameters.sapUiPageFooterBackground,
-    borderRadius: parameters.sapUiElementBorderCornerRadius,
-    boxShadow: parameters.sapUiShadowLevel1,
+    background: ThemingParameters.sapUiPageFooterBackground,
+    // borderRadius: ThemingParameters.sapUiElementBorderCornerRadius,
+    boxShadow: ThemingParameters.sapUiShadowLevel1,
     border: 'none',
-    opacity: 1
+    opacity: 1,
+    '& $inner': {
+      height: CssSizeVariables.sapWcrBarHeight
+    }
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
+++ b/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
@@ -17,12 +17,8 @@ exports[`Bar Render all content 1`] = `
     class="Bar--center-"
     data-bar-part="Center"
   >
-    <div
-      class="Bar--inner-"
-    >
-      <div>
-        Content Middle
-      </div>
+    <div>
+      Content Middle
     </div>
   </div>
   <div
@@ -48,11 +44,7 @@ exports[`Bar Renders with default Props 1`] = `
   <div
     class="Bar--center-"
     data-bar-part="Center"
-  >
-    <div
-      class="Bar--inner-"
-    />
-  </div>
+  />
   <div
     class="Bar--right-"
     data-bar-part="Right"

--- a/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
+++ b/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Bar Render all content 1`] = `
 <div
-  class="Bar--bar-"
+  class="Bar--bar- Bar--auto-"
   data-bar-part="Root"
 >
   <div
@@ -34,7 +34,7 @@ exports[`Bar Render all content 1`] = `
 
 exports[`Bar Renders with default Props 1`] = `
 <div
-  class="Bar--bar-"
+  class="Bar--bar- Bar--auto-"
   data-bar-part="Root"
 >
   <div

--- a/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
+++ b/packages/main/src/components/Bar/__snapshots__/Bar.test.tsx.snap
@@ -17,8 +17,12 @@ exports[`Bar Render all content 1`] = `
     class="Bar--center-"
     data-bar-part="Center"
   >
-    <div>
-      Content Middle
+    <div
+      class="Bar--inner-"
+    >
+      <div>
+        Content Middle
+      </div>
     </div>
   </div>
   <div
@@ -44,7 +48,11 @@ exports[`Bar Renders with default Props 1`] = `
   <div
     class="Bar--center-"
     data-bar-part="Center"
-  />
+  >
+    <div
+      class="Bar--inner-"
+    />
+  </div>
   <div
     class="Bar--right-"
     data-bar-part="Right"

--- a/packages/main/src/components/Bar/demo.stories.tsx
+++ b/packages/main/src/components/Bar/demo.stories.tsx
@@ -1,10 +1,13 @@
+import { select } from '@storybook/addon-knobs';
 import { Bar } from '@ui5/webcomponents-react/lib/Bar';
+import { BarDesign } from '@ui5/webcomponents-react/lib/BarDesign';
 import { Label } from '@ui5/webcomponents-react/lib/Label';
 import React from 'react';
 
 export const defaultStory = () => {
   return (
     <Bar
+      design={select('design', BarDesign, BarDesign.Auto)}
       renderContentLeft={() => <Label>Content Left</Label>}
       renderContentMiddle={() => <Label>Content Middle</Label>}
       renderContentRight={() => <Label>Content Right</Label>}

--- a/packages/main/src/components/Bar/index.tsx
+++ b/packages/main/src/components/Bar/index.tsx
@@ -3,12 +3,14 @@ import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePa
 import React, { FC, forwardRef, Ref } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '../../interfaces/CommonProps';
+import { BarDesign } from '../../lib/BarDesign';
 import styles from './Bar.jss';
 
 export interface BarPropTypes extends CommonProps {
   renderContentLeft?: () => JSX.Element;
   renderContentMiddle?: () => JSX.Element;
   renderContentRight?: () => JSX.Element;
+  design?: BarDesign;
 }
 
 const useStyles = createUseStyles(styles, { name: 'Bar' });
@@ -17,13 +19,30 @@ const useStyles = createUseStyles(styles, { name: 'Bar' });
  * <code>import { Bar } from '@ui5/webcomponents-react/lib/Bar';</code>
  */
 const Bar: FC<BarPropTypes> = forwardRef((props: BarPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { renderContentLeft, renderContentMiddle, renderContentRight, className, style, tooltip, slot } = props;
+  const { renderContentLeft, renderContentMiddle, renderContentRight, className, style, tooltip, slot, design } = props;
 
   const classes = useStyles();
 
   const cssClasses = StyleClassHelper.of(classes.bar);
+  const barDesignClass = () => {
+    switch (design) {
+      case BarDesign.Footer:
+        return classes.footer;
+      case BarDesign.SubHeader:
+        return classes.subHeader;
+      case BarDesign.FloatingFooter:
+        return classes.floatingFooter;
+      case BarDesign.Header:
+      case BarDesign.Auto:
+      default:
+        return classes.auto;
+    }
+  };
   if (className) {
     cssClasses.put(className);
+  }
+  if (design) {
+    cssClasses.put(barDesignClass());
   }
 
   const passThroughProps = usePassThroughHtmlProps(props);
@@ -42,7 +61,7 @@ const Bar: FC<BarPropTypes> = forwardRef((props: BarPropTypes, ref: Ref<HTMLDivE
         {renderContentLeft()}
       </div>
       <div data-bar-part="Center" className={classes.center}>
-        <div className={classes.inner}>{renderContentMiddle()}</div>
+        {renderContentMiddle()}
       </div>
       <div data-bar-part="Right" className={classes.right}>
         {renderContentRight()}
@@ -53,6 +72,7 @@ const Bar: FC<BarPropTypes> = forwardRef((props: BarPropTypes, ref: Ref<HTMLDivE
 
 Bar.displayName = 'Bar';
 Bar.defaultProps = {
+  design: BarDesign.Auto,
   renderContentLeft: () => null,
   renderContentMiddle: () => null,
   renderContentRight: () => null

--- a/packages/main/src/components/Bar/index.tsx
+++ b/packages/main/src/components/Bar/index.tsx
@@ -24,25 +24,23 @@ const Bar: FC<BarPropTypes> = forwardRef((props: BarPropTypes, ref: Ref<HTMLDivE
   const classes = useStyles();
 
   const cssClasses = StyleClassHelper.of(classes.bar);
-  const barDesignClass = () => {
-    switch (design) {
-      case BarDesign.Footer:
-        return classes.footer;
-      case BarDesign.SubHeader:
-        return classes.subHeader;
-      case BarDesign.FloatingFooter:
-        return classes.floatingFooter;
-      case BarDesign.Header:
-      case BarDesign.Auto:
-      default:
-        return classes.auto;
-    }
-  };
+  switch (design) {
+    case BarDesign.Footer:
+      cssClasses.put(classes.footer);
+      break;
+    case BarDesign.SubHeader:
+      cssClasses.put(classes.subHeader);
+      break;
+    case BarDesign.FloatingFooter:
+      cssClasses.put(classes.floatingFooter);
+      break;
+    case BarDesign.Header:
+    case BarDesign.Auto:
+    default:
+      cssClasses.put(classes.auto);
+  }
   if (className) {
     cssClasses.put(className);
-  }
-  if (design) {
-    cssClasses.put(barDesignClass());
   }
 
   const passThroughProps = usePassThroughHtmlProps(props);
@@ -61,7 +59,7 @@ const Bar: FC<BarPropTypes> = forwardRef((props: BarPropTypes, ref: Ref<HTMLDivE
         {renderContentLeft()}
       </div>
       <div data-bar-part="Center" className={classes.center}>
-        {renderContentMiddle()}
+        <div className={classes.inner}>{renderContentMiddle()}</div>
       </div>
       <div data-bar-part="Right" className={classes.right}>
         {renderContentRight()}

--- a/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -27,11 +27,15 @@ exports[`Page Basic Page 1`] = `
           class="Bar--center-"
           data-bar-part="Center"
         >
-          <ui5-title
-            level="H5"
+          <div
+            class="Bar--inner-"
           >
-            Page Demo
-          </ui5-title>
+            <ui5-title
+              level="H5"
+            >
+              Page Demo
+            </ui5-title>
+          </div>
         </div>
         <div
           class="Bar--right-"
@@ -73,11 +77,15 @@ exports[`Page Basic Page w/o back button 1`] = `
           class="Bar--center-"
           data-bar-part="Center"
         >
-          <ui5-title
-            level="H5"
+          <div
+            class="Bar--inner-"
           >
-            Page Demo
-          </ui5-title>
+            <ui5-title
+              level="H5"
+            >
+              Page Demo
+            </ui5-title>
+          </div>
         </div>
         <div
           class="Bar--right-"

--- a/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Page Basic Page 1`] = `
       class="Page--pageHeader- Page--baseBar-"
     >
       <div
-        class="Bar--bar-"
+        class="Bar--bar- Bar--auto-"
         data-bar-part="Root"
       >
         <div
@@ -62,7 +62,7 @@ exports[`Page Basic Page w/o back button 1`] = `
       class="Page--pageHeader- Page--baseBar-"
     >
       <div
-        class="Bar--bar-"
+        class="Bar--bar- Bar--auto-"
         data-bar-part="Root"
       >
         <div

--- a/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -27,15 +27,11 @@ exports[`Page Basic Page 1`] = `
           class="Bar--center-"
           data-bar-part="Center"
         >
-          <div
-            class="Bar--inner-"
+          <ui5-title
+            level="H5"
           >
-            <ui5-title
-              level="H5"
-            >
-              Page Demo
-            </ui5-title>
-          </div>
+            Page Demo
+          </ui5-title>
         </div>
         <div
           class="Bar--right-"
@@ -77,15 +73,11 @@ exports[`Page Basic Page w/o back button 1`] = `
           class="Bar--center-"
           data-bar-part="Center"
         >
-          <div
-            class="Bar--inner-"
+          <ui5-title
+            level="H5"
           >
-            <ui5-title
-              level="H5"
-            >
-              Page Demo
-            </ui5-title>
-          </div>
+            Page Demo
+          </ui5-title>
         </div>
         <div
           class="Bar--right-"

--- a/packages/main/src/enums/BarDesign.ts
+++ b/packages/main/src/enums/BarDesign.ts
@@ -1,0 +1,7 @@
+export enum BarDesign {
+    Auto = 'Auto',
+    Footer = 'Footer',
+    Header = 'Header',
+    SubHeader = 'SubHeader',
+    FloatingFooter = 'FloatingFooter'
+}

--- a/packages/main/src/lib/BarDesign.ts
+++ b/packages/main/src/lib/BarDesign.ts
@@ -1,0 +1,3 @@
+import { BarDesign } from '../enums/BarDesign';
+
+export { BarDesign };

--- a/packages/main/src/webComponents/Icon/demo.stories.tsx
+++ b/packages/main/src/webComponents/Icon/demo.stories.tsx
@@ -1,4 +1,3 @@
-import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import '@ui5/webcomponents-icons/dist/icons/add.js';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';


### PR DESCRIPTION
I don't know why the containers were absolute positioned. I refactored them so they are using `space-between` now. If my changes would break functionality feel free to roll them back.
What definitely has to be adjusted is the following line `lineHeight: CssSizeVariables.sapWcrBarHeight` as this breaks the alignment of the label inside of the `Input` and I guess there are even more components affected by this.


Fixes #319
