### PR TITLE
chore: use static styling instead of function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
     'eol-last': 'off',
     eqeqeq: ['error', 'smart'],
     'guard-for-in': 'error',
-    'id-blacklist': ['error', 'any', 'number', 'string', 'boolean', 'undefined'],
     'id-match': 'error',
     'linebreak-style': 'off',
     'max-classes-per-file': ['error', 1],

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -29,7 +29,8 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0",
+    "react-jss": "^10.0.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -2,6 +2,7 @@
  * Created by d059190 at 16.03.18
  */
 import { createGenerateClassName } from './lib/createGenerateClassName';
+import { createComponentStyles } from './lib/createComponentStyles';
 import { CssSizeVariables, CssSizeVariablesNames, cssVariablesStyles } from './lib/CssSizeVariables';
 import { Device } from './lib/Device';
 import { Event } from './lib/Event';
@@ -17,6 +18,7 @@ import { usePassThroughHtmlProps } from './lib/usePassThroughHtmlProps';
 import { deprecationNotice, getScrollBarWidth } from './lib/Utils';
 
 export {
+  createComponentStyles,
   StyleClassHelper,
   Optional,
   deprecationNotice,

--- a/packages/base/src/lib/createComponentStyles.ts
+++ b/packages/base/src/lib/createComponentStyles.ts
@@ -1,0 +1,3 @@
+import { createComponentStyles } from '../styling/createComponentStyles';
+
+export { createComponentStyles };

--- a/packages/base/src/styling/createComponentStyles.ts
+++ b/packages/base/src/styling/createComponentStyles.ts
@@ -1,0 +1,39 @@
+import { createUseStyles } from 'react-jss';
+
+declare global {
+  interface Window {
+    CSSVarsPonyfill: {
+      cssVars: (options: any) => void;
+    };
+  }
+}
+
+const ponyfillNeeded = () => !!window.CSSVarsPonyfill;
+let ponyfillTimer;
+
+const runPonyfill = () => {
+  ponyfillTimer = undefined;
+
+  window.CSSVarsPonyfill.cssVars({
+    rootElement: document.head,
+    include: 'style[data-jss]',
+    silent: true
+  });
+};
+
+const schedulePonyfill = () => {
+  if (ponyfillTimer) {
+    window.clearTimeout(ponyfillTimer);
+    ponyfillTimer = null;
+  }
+  ponyfillTimer = window.setTimeout(runPonyfill, 0);
+};
+
+export const createComponentStyles: typeof createUseStyles = (styles, options) => {
+  const useStyles = createUseStyles(styles, options);
+
+  // if (ponyfillNeeded()) {
+  //   schedulePonyfill();
+  // }
+  return useStyles;
+};

--- a/packages/main/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/main/src/components/ActionSheet/ActionSheet.test.tsx
@@ -1,10 +1,10 @@
 import { createPassThroughPropsTest, mountThemedComponent } from '@shared/tests/utils';
 import { ActionSheet } from '@ui5/webcomponents-react/lib/ActionSheet';
-import { Label } from '@ui5/webcomponents-react/lib/Label';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
+import { Label } from '@ui5/webcomponents-react/lib/Label';
 import React, { createRef, RefObject } from 'react';
-import { Ui5PopoverDomRef } from '../../interfaces/Ui5PopoverDomRef';
 import sinon from 'sinon';
+import { Ui5PopoverDomRef } from '../../interfaces/Ui5PopoverDomRef';
 
 describe('ActionSheet', () => {
   test('Render without Crashing', () => {

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -7,7 +7,7 @@ import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import { Popover } from '@ui5/webcomponents-react/lib/Popover';
 import React, { Children, cloneElement, FC, forwardRef, ReactElement, ReactNode, RefObject } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5PopoverDomRef } from '../../interfaces/Ui5PopoverDomRef';
 import { ButtonPropTypes } from '../../webComponents/Button';
@@ -19,7 +19,7 @@ export interface ActionSheetPropTypes extends CommonProps {
   children?: ReactElement<ButtonPropTypes> | ReactElement<ButtonPropTypes>[];
 }
 
-const useStyles = createUseStyles(styles, { name: 'ActionSheet' });
+const useStyles = createComponentStyles(styles, { name: 'ActionSheet' });
 
 addCustomCSS(
   'ui5-button',

--- a/packages/main/src/components/AnalyticalCard/AnalyticalCard.jss.ts
+++ b/packages/main/src/components/AnalyticalCard/AnalyticalCard.jss.ts
@@ -1,20 +1,20 @@
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import * as spacing from '@ui5/webcomponents-react-base/lib/spacing';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   card: {
-    backgroundColor: parameters.sapUiTileBackground,
+    backgroundColor: ThemingParameters.sapUiTileBackground,
     // TODO There is a border mentioned in the specs, but this one looks weird.
-    // border: `0.625rem solid ${parameters.sapUiTileBorderColor}`,
-    boxShadow: parameters.sapUiShadowLevel0,
+    // border: `0.625rem solid ${ThemingParameters.sapUiTileBorderColor}`,
+    boxShadow: ThemingParameters.sapUiShadowLevel0,
     borderRadius: '0.25rem',
     textAlign: 'start',
     overflow: 'hidden',
     position: 'relative',
-    fontFamily: parameters.sapUiFontFamily,
+    fontFamily: ThemingParameters.sapUiFontFamily,
     boxSizing: 'border-box'
   },
   content: spacing.sapUiContentPadding
-});
+};
 
 export default styles;

--- a/packages/main/src/components/AnalyticalCard/index.tsx
+++ b/packages/main/src/components/AnalyticalCard/index.tsx
@@ -1,9 +1,8 @@
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import React, { CSSProperties, FC, forwardRef, ReactNode, ReactNodeArray, Ref, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 
 import styles from './AnalyticalCard.jss';
 
@@ -19,7 +18,7 @@ export interface AnalyticalCardTypes extends CommonProps {
   width?: CSSProperties['width'];
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'AnalyticalCard' });
+const useStyles = createComponentStyles(styles, { name: 'AnalyticalCard' });
 
 /**
  * <code>import { AnalyticalCard } from '@ui5/webcomponents-react/lib/AnalyticalCard';</code>

--- a/packages/main/src/components/AnalyticalCardHeader/AnalyticalCardHeader.jss.ts
+++ b/packages/main/src/components/AnalyticalCardHeader/AnalyticalCardHeader.jss.ts
@@ -1,24 +1,24 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   helpText: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    color: parameters.sapUiBaseText
+    color: ThemingParameters.sapUiBaseText
   },
   cardHeader: {
     paddingTop: '1rem',
     paddingBottom: '1rem',
     outlineOffset: '-0.125rem',
-    borderBottom: `0.0625rem solid ${parameters.sapUiTileBackgroundDarken20}`,
-    backgroundColor: parameters.sapUiTileBackground,
-    fontFamily: parameters.sapUiFontHeaderFamily,
+    borderBottom: `0.0625rem solid ${ThemingParameters.sapUiTileBackgroundDarken20}`,
+    backgroundColor: ThemingParameters.sapUiTileBackground,
+    fontFamily: ThemingParameters.sapUiFontHeaderFamily,
     '&:hover': {
-      backgroundColor: parameters.sapUiListHoverBackground // TODO sapUiTileHoverBackground '#fafafa'
+      backgroundColor: ThemingParameters.sapUiListHoverBackground // TODO sapUiTileHoverBackground '#fafafa'
     },
     '&:active': {
-      backgroundColor: parameters.sapUiListHoverBackground // TODO sapUiTileHoverBackground '#fafafa'
+      backgroundColor: ThemingParameters.sapUiListHoverBackground // TODO sapUiTileHoverBackground '#fafafa'
     }
   },
   arrowIndicatorShape: {
@@ -55,10 +55,10 @@ const styles = ({ parameters }: JSSTheme) => ({
     wordWrap: 'break-word'
   },
   headerText: {
-    fontFamily: parameters.sapUiFontHeaderFamily,
-    fontWeight: parameters.sapUiFontHeaderWeight,
-    fontSize: parameters.sapMFontHeader5Size,
-    color: parameters.sapUiTileTitleTextColor,
+    fontFamily: ThemingParameters.sapUiFontHeaderFamily,
+    fontWeight: ThemingParameters.sapUiFontHeaderWeight,
+    fontSize: ThemingParameters.sapMFontHeader5Size,
+    color: ThemingParameters.sapUiTileTitleTextColor,
     overflow: 'hidden',
     display: '-webkit-box',
     lineHeight: '18px',
@@ -68,10 +68,10 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   subHeaderText: {
     overflow: 'hidden',
-    fontFamily: parameters.sapUiFontFamily,
+    fontFamily: ThemingParameters.sapUiFontFamily,
     fontWeight: 'normal',
-    fontSize: parameters.sapMFontMediumSize,
-    color: parameters.sapUiTileTextColor,
+    fontSize: ThemingParameters.sapMFontMediumSize,
+    color: ThemingParameters.sapUiTileTextColor,
     textAlign: 'left',
     whiteSpace: 'normal',
     wordWrap: 'break-word',
@@ -85,16 +85,16 @@ const styles = ({ parameters }: JSSTheme) => ({
     WebkitBoxOrient: 'vertical'
   },
   counter: {
-    fontSize: parameters.sapMFontSmallSize,
+    fontSize: ThemingParameters.sapMFontSmallSize,
     margin: '0.188rem 0  0 1rem',
     lineHeight: 'normal',
     textAlign: 'right'
   },
   currency: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    color: parameters.sapUiTileTextColor,
+    color: ThemingParameters.sapUiTileTextColor,
     overflow: 'hidden',
     marginLeft: '0.25rem',
     textAlign: 'right'
@@ -107,14 +107,14 @@ const styles = ({ parameters }: JSSTheme) => ({
   kpiContent: {
     fontWeight: 'normal',
     marginTop: '0.5rem',
-    color: parameters.sapUiTileTextColor,
+    color: ThemingParameters.sapUiTileTextColor,
     width: '100%',
     boxSizing: 'border-box'
   },
   valueAndUnit: {
     display: 'flex',
     alignItems: 'end',
-    color: parameters.sapUiNeutralText
+    color: ThemingParameters.sapUiNeutralText
   },
   value: {
     fontSize: '2rem',
@@ -139,24 +139,24 @@ const styles = ({ parameters }: JSSTheme) => ({
     width: '60%',
     paddingBottom: '0.25rem',
     textAlign: 'right',
-    fontSize: parameters.sapMFontSmallSize,
-    color: parameters.sapUiTileTextColor
+    fontSize: ThemingParameters.sapMFontSmallSize,
+    color: ThemingParameters.sapUiTileTextColor
   },
   targetAndDeviationColumn: {
     maxWidth: '45%',
     marginLeft: '1rem'
   },
   targetAndDeviationValue: {
-    color: parameters.sapUiTileTitleTextColor,
+    color: ThemingParameters.sapUiTileTitleTextColor,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
   },
   description: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontSmallSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontSmallSize,
     fontWeight: 'normal',
-    color: parameters.sapUiTileTextColor,
+    color: ThemingParameters.sapUiTileTextColor,
     whiteSpace: 'normal',
     overflow: 'hidden',
     textAlign: 'left',
@@ -170,17 +170,17 @@ const styles = ({ parameters }: JSSTheme) => ({
     WebkitBoxOrient: 'vertical'
   },
   good: {
-    color: parameters.sapUiPositiveText
+    color: ThemingParameters.sapUiPositiveText
   },
   error: {
-    color: parameters.sapUiNegativeText
+    color: ThemingParameters.sapUiNegativeText
   },
   critical: {
-    color: parameters.sapUiCriticalText
+    color: ThemingParameters.sapUiCriticalText
   },
   none: {
-    color: parameters.sapUiNeutralText
+    color: ThemingParameters.sapUiNeutralText
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -10,9 +10,8 @@ import { FlexBoxWrap } from '@ui5/webcomponents-react/lib/FlexBoxWrap';
 import { ObjectStatus } from '@ui5/webcomponents-react/lib/ObjectStatus';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import React, { FC, forwardRef, Ref, useCallback, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './AnalyticalCardHeader.jss';
 
 export interface AnalyticalCardHeaderPropTypes extends CommonProps {
@@ -33,7 +32,7 @@ export interface AnalyticalCardHeaderPropTypes extends CommonProps {
   currency?: string;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, {
+const useStyles = createComponentStyles(styles, {
   name: 'AnalyticalCardHeader'
 });
 

--- a/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
+++ b/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
@@ -1,7 +1,7 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   tableContainer: {
     width: '100%',
     height: `calc(100% - ${CssSizeVariables.sapWcrAnalyticalTableRowHeight})`,
@@ -20,47 +20,47 @@ const styles = ({ parameters }: JSSTheme) => ({
     position: 'relative'
   },
   th: {
-    backgroundColor: parameters.sapUiListHeaderBackground,
+    backgroundColor: ThemingParameters.sapUiListHeaderBackground,
     height: CssSizeVariables.sapWcrAnalyticalTableRowHeight,
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    color: parameters.sapUiListHeaderTextColor,
-    borderTop: `1px solid ${parameters.sapUiListBorderColor}`,
-    borderBottom: `1px solid ${parameters.sapUiListBorderColor}`,
-    borderRight: `1px solid ${parameters.sapUiListVerticalBorderColor}`,
+    color: ThemingParameters.sapUiListHeaderTextColor,
+    borderTop: `1px solid ${ThemingParameters.sapUiListBorderColor}`,
+    borderBottom: `1px solid ${ThemingParameters.sapUiListBorderColor}`,
+    borderRight: `1px solid ${ThemingParameters.sapUiListVerticalBorderColor}`,
     textAlign: 'start',
     boxSizing: 'border-box',
     '&:first-child': {
-      borderLeft: `1px solid ${parameters.sapUiListVerticalBorderColor}`
+      borderLeft: `1px solid ${ThemingParameters.sapUiListVerticalBorderColor}`
     }
   },
   tbody: {
     position: 'relative',
     zIndex: 0,
-    backgroundColor: parameters.sapUiListBackground,
+    backgroundColor: ThemingParameters.sapUiListBackground,
     overflowX: 'hidden !important',
     overflowY: 'auto !important'
   },
   alternateRowColor: {
-    backgroundColor: parameters.sapUiListHeaderBackground
+    backgroundColor: ThemingParameters.sapUiListHeaderBackground
   },
   emptyRow: {},
   tr: {
     zIndex: 0,
-    color: parameters.sapUiListTextColor,
+    color: ThemingParameters.sapUiListTextColor,
     '&[data-is-selected]': {
-      backgroundColor: `${parameters.sapUiListSelectionBackgroundColor} !important`
+      backgroundColor: `${ThemingParameters.sapUiListSelectionBackgroundColor} !important`
     },
     '&[data-is-selected]:hover': {
-      backgroundColor: `${parameters.sapUiListSelectionHoverBackground} !important`
+      backgroundColor: `${ThemingParameters.sapUiListSelectionHoverBackground} !important`
     }
   },
   tableGroupHeader: {
     '&$tr': {
-      backgroundColor: `${parameters.sapUiListTableGroupHeaderBackground} !important`,
-      border: `1px solid ${parameters.sapUiListTableGroupHeaderBorderColor}`,
-      color: parameters.sapUiListTextColor,
+      backgroundColor: `${ThemingParameters.sapUiListTableGroupHeaderBackground} !important`,
+      border: `1px solid ${ThemingParameters.sapUiListTableGroupHeaderBorderColor}`,
+      color: ThemingParameters.sapUiListTextColor,
       '& $tableCell': {
         borderRight: 'none'
       }
@@ -68,30 +68,30 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   selectable: {
     '& $tr:hover:not($emptyRow)': {
-      backgroundColor: parameters.sapUiListHoverBackground,
+      backgroundColor: ThemingParameters.sapUiListHoverBackground,
       cursor: 'pointer'
     },
     '& $tr:active:not([data-is-selected]):not($tableGroupHeader):not($emptyRow)': {
-      backgroundColor: parameters.sapUiListActiveBackground,
+      backgroundColor: ThemingParameters.sapUiListActiveBackground,
       '& $tableCell': {
-        borderRight: `1px solid ${parameters.sapUiListActiveBackground}`,
-        color: `${parameters.sapUiListActiveTextColor}`,
-        '--sapUiBaseText': parameters.sapUiListActiveTextColor
+        borderRight: `1px solid ${ThemingParameters.sapUiListActiveBackground}`,
+        color: `${ThemingParameters.sapUiListActiveTextColor}`,
+        '--sapUiBaseText': ThemingParameters.sapUiListActiveTextColor
       }
     }
   },
   tableCell: {
     height: CssSizeVariables.sapWcrAnalyticalTableRowHeight,
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    borderBottom: `1px solid ${parameters.sapUiListBorderColor}`,
+    borderBottom: `1px solid ${ThemingParameters.sapUiListBorderColor}`,
     boxSizing: 'border-box',
-    borderRight: `1px solid ${parameters.sapUiListVerticalBorderColor}`,
+    borderRight: `1px solid ${ThemingParameters.sapUiListVerticalBorderColor}`,
     display: 'flex',
     padding: '0 0.5rem',
     '&:first-child': {
-      borderLeft: `1px solid ${parameters.sapUiListVerticalBorderColor}`
+      borderLeft: `1px solid ${ThemingParameters.sapUiListVerticalBorderColor}`
     },
     overflow: 'hidden',
     position: 'relative',
@@ -104,20 +104,20 @@ const styles = ({ parameters }: JSSTheme) => ({
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',
-    backgroundColor: parameters.sapUiListBackground,
+    backgroundColor: ThemingParameters.sapUiListBackground,
     width: '100%',
     boxSizing: 'border-box',
-    color: parameters.sapUiListTextColor,
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    color: ThemingParameters.sapUiListTextColor,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    borderBottom: `1px solid ${parameters.sapUiListBorderColor}`
+    borderBottom: `1px solid ${ThemingParameters.sapUiListBorderColor}`
   },
   modifiedRowHeight: {
     '& $tableCell': {
       height: (props) => `${props.rowHeight}px`
     }
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -2,11 +2,12 @@ import '@ui5/webcomponents-icons/dist/icons/filter';
 import '@ui5/webcomponents-icons/dist/icons/group-2';
 import '@ui5/webcomponents-icons/dist/icons/sort-ascending';
 import '@ui5/webcomponents-icons/dist/icons/sort-descending';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import React, { CSSProperties, DragEventHandler, FC, ReactNode, ReactNodeArray, useMemo } from 'react';
-import { createUseStyles, useTheme } from 'react-jss';
 import { JSSTheme } from '../../../interfaces/JSSTheme';
 import { ColumnType } from '../types/ColumnType';
 import { ColumnHeaderModal } from './ColumnHeaderModal';
@@ -36,7 +37,7 @@ export interface ColumnHeaderProps {
   isDraggable: boolean;
 }
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   header: {
     padding: `0 0.5rem`,
     height: '100%',
@@ -44,11 +45,11 @@ const styles = ({ parameters }: JSSTheme) => ({
     justifyContent: 'begin',
     alignItems: 'center',
     textAlign: 'left',
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    color: parameters.sapUiListTextColor,
-    background: parameters.sapUiListHeaderBackground,
+    color: ThemingParameters.sapUiListTextColor,
+    background: ThemingParameters.sapUiListHeaderBackground,
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     maxWidth: '100%',
@@ -57,7 +58,7 @@ const styles = ({ parameters }: JSSTheme) => ({
   iconContainer: {
     display: 'inline-block',
     position: 'absolute',
-    color: parameters.sapUiContentIconColor,
+    color: ThemingParameters.sapUiContentIconColor,
     right: '0',
     marginRight: '0.5rem',
     '& :last-child': {
@@ -77,9 +78,9 @@ const styles = ({ parameters }: JSSTheme) => ({
   lastColumn: {
     right: '8px'
   }
-});
+};
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'TableColumnHeader' });
+const useStyles = createComponentStyles(styles, { name: 'TableColumnHeader' });
 
 /**
  * <code>import { ColumnHeader } from '@ui5/webcomponents-react/lib/ColumnHeader';</code>
@@ -161,7 +162,6 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
   ]);
 
   const isResizable = !isLastColumn && column.canResize;
-  const theme = useTheme() as JSSTheme;
   const innerStyle: CSSProperties = useMemo(() => {
     const modifiedStyles: CSSProperties = {
       width: '100%',
@@ -174,7 +174,7 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
       modifiedStyles.maxWidth = `calc(100% - 16px)`;
     }
     if (dragOver) {
-      modifiedStyles.borderLeft = `3px solid ${theme.parameters.sapSelectedColor}`;
+      modifiedStyles.borderLeft = `3px solid ${ThemingParameters.sapSelectedColor}`;
     }
     return modifiedStyles;
   }, [isResizable, dragOver]);

--- a/packages/main/src/components/AnalyticalTable/defaults/LoadingComponent/TablePlaceholder.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/LoadingComponent/TablePlaceholder.tsx
@@ -1,4 +1,4 @@
-import * as parameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import React, { CSSProperties, FC, useMemo } from 'react';
 import ContentLoader from 'react-content-loader';
 
@@ -29,11 +29,11 @@ export const TablePlaceholder: FC<Props> = (props: Props) => {
 
   const innerStyles = useMemo(() => {
     return {
-      backgroundColor: parameters.sapUiListBackground,
+      backgroundColor: ThemingParameters.sapUiListBackground,
       width: '100%',
       ...style
     };
-  }, [style, parameters.sapUiListBackground]);
+  }, [style, ThemingParameters.sapUiListBackground]);
 
   return (
     <ContentLoader
@@ -41,9 +41,9 @@ export const TablePlaceholder: FC<Props> = (props: Props) => {
       height={height}
       width={width}
       speed={2}
-      backgroundColor={parameters.sapContent_ImagePlaceholderBackground}
-      foregroundColor={parameters.sapContent_ImagePlaceholderForegroundColor}
-      backgroundOpacity={parameters.sapContent_DisabledOpacity as any}
+      backgroundColor={ThemingParameters.sapContent_ImagePlaceholderBackground}
+      foregroundColor={ThemingParameters.sapContent_ImagePlaceholderForegroundColor}
+      backgroundOpacity={ThemingParameters.sapContent_DisabledOpacity as any}
     >
       {getArrayOfLength(rows).map((_, index) => (
         <TableRow key={index} columns={columns} y={rowHeight * index + rowHeight / 2} row={index} />

--- a/packages/main/src/components/AnalyticalTable/demo/demo.stories.tsx
+++ b/packages/main/src/components/AnalyticalTable/demo/demo.stories.tsx
@@ -6,8 +6,8 @@ import { TableSelectionMode } from '@ui5/webcomponents-react/lib/TableSelectionM
 import { TextAlign } from '@ui5/webcomponents-react/lib/TextAlign';
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import React from 'react';
-import generateData from './generateData';
 import { TableScaleWidthMode } from '../../../enums/TableScaleWidthMode';
+import generateData from './generateData';
 
 const columns = [
   {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -1,3 +1,4 @@
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { Event } from '@ui5/webcomponents-react-base/lib/Event';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
@@ -17,7 +18,6 @@ import React, {
   useMemo,
   useRef
 } from 'react';
-import { createUseStyles } from 'react-jss';
 import {
   Column,
   PluginHook,
@@ -31,6 +31,7 @@ import {
   useSortBy,
   useTable
 } from 'react-table';
+import { TableScaleWidthMode } from '../../enums/TableScaleWidthMode';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './AnayticalTable.jss';
@@ -39,7 +40,9 @@ import { DefaultColumn } from './defaults/Column';
 import { DefaultLoadingComponent } from './defaults/LoadingComponent';
 import { TablePlaceholder } from './defaults/LoadingComponent/TablePlaceholder';
 import { DefaultNoDataComponent } from './defaults/NoDataComponent';
+import { useColumnsDependencies } from './hooks/useColumnsDependencies';
 import { useDragAndDrop } from './hooks/useDragAndDrop';
+import { useDynamicColumnWidths } from './hooks/useDynamicColumnWidths';
 import { useRowSelectionColumn } from './hooks/useRowSelectionColumn';
 import { useTableCellStyling } from './hooks/useTableCellStyling';
 import { useTableHeaderGroupStyling } from './hooks/useTableHeaderGroupStyling';
@@ -50,11 +53,8 @@ import { useTableStyling } from './hooks/useTableStyling';
 import { useToggleRowExpand } from './hooks/useToggleRowExpand';
 import { stateReducer } from './tableReducer/stateReducer';
 import { TitleBar } from './TitleBar';
-import { VirtualTableBody } from './virtualization/VirtualTableBody';
-import { useDynamicColumnWidths } from './hooks/useDynamicColumnWidths';
-import { TableScaleWidthMode } from '../../enums/TableScaleWidthMode';
-import { useColumnsDependencies } from './hooks/useColumnsDependencies';
 import { orderByFn } from './util';
+import { VirtualTableBody } from './virtualization/VirtualTableBody';
 
 export interface ColumnConfiguration extends Column {
   accessor?: string;
@@ -129,7 +129,7 @@ export interface TableProps extends CommonProps {
   LoadingComponent?: ComponentType<any>;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'AnalyticalTable' });
+const useStyles = createComponentStyles(styles, { name: 'AnalyticalTable' });
 
 /**
  * <code>import { AnalyticalTable } from '@ui5/webcomponents-react/lib/AnalyticalTable';</code>

--- a/packages/main/src/components/Avatar/Avatar.jss.ts
+++ b/packages/main/src/components/Avatar/Avatar.jss.ts
@@ -1,5 +1,5 @@
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { CSSProperties } from 'react';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 
 const size = (s): CSSProperties => ({
   height: s,
@@ -10,19 +10,19 @@ const size = (s): CSSProperties => ({
   textAlign: 'center'
 });
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   // outer flexbox
   avatar: {
-    backgroundColor: parameters.sapAccentColor7,
-    color: parameters.sapUiContentContrastTextColor,
-    fontFamily: parameters.sapUiFontFamily,
+    backgroundColor: ThemingParameters.sapAccentColor7,
+    color: ThemingParameters.sapUiContentContrastTextColor,
+    fontFamily: ThemingParameters.sapUiFontFamily,
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     backgroundSize: 'cover',
     backgroundPosition: 'center',
     borderRadius: '0.25rem',
-    '--sapUiContentNonInteractiveIconColor': parameters.sapContent_ContrastIconColor
+    '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapContent_ContrastIconColor
   },
   // borderRadius 100%
   circle: {
@@ -81,6 +81,6 @@ const styles = ({ parameters }: JSSTheme) => ({
       height: customFontSize
     }
   })
-});
+};
 
 export default styles;

--- a/packages/main/src/components/Avatar/index.tsx
+++ b/packages/main/src/components/Avatar/index.tsx
@@ -1,9 +1,9 @@
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { Event } from '@ui5/webcomponents-react-base/lib/Event';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { AvatarShape } from '@ui5/webcomponents-react/lib/AvatarShape';
 import { AvatarSize } from '@ui5/webcomponents-react/lib/AvatarSize';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './Avatar.jss';
@@ -19,7 +19,7 @@ export interface AvatarPropTypes extends CommonProps {
   customFontSize?: CSSProperties['width'];
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'Avatar' });
+const useStyles = createComponentStyles(styles, { name: 'Avatar' });
 
 /**
  * <code>import { Avatar } from '@ui5/webcomponents-react/lib/Avatar';</code>

--- a/packages/main/src/components/Bar/index.tsx
+++ b/packages/main/src/components/Bar/index.tsx
@@ -1,7 +1,7 @@
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import React, { FC, forwardRef, Ref } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { BarDesign } from '../../lib/BarDesign';
 import styles from './Bar.jss';
@@ -13,7 +13,7 @@ export interface BarPropTypes extends CommonProps {
   design?: BarDesign;
 }
 
-const useStyles = createUseStyles(styles, { name: 'Bar' });
+const useStyles = createComponentStyles(styles, { name: 'Bar' });
 
 /**
  * <code>import { Bar } from '@ui5/webcomponents-react/lib/Bar';</code>

--- a/packages/main/src/components/Carousel/Carousel.jss.ts
+++ b/packages/main/src/components/Carousel/Carousel.jss.ts
@@ -1,6 +1,6 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   carousel: {
     position: 'relative',
     overflow: 'hidden',
@@ -8,8 +8,8 @@ const styles = ({ parameters }: JSSTheme) => ({
     border: '1px solid transparent',
     touchAction: 'pan-y',
     minWidth: '15.5rem',
-    fontFamily: parameters.sapUiFontFamily,
-    backgroundColor: parameters.sapUiBaseBG,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    backgroundColor: ThemingParameters.sapUiBaseBG,
     '&:focus': {
       outline: 'none',
       '&:before': {
@@ -68,6 +68,6 @@ const styles = ({ parameters }: JSSTheme) => ({
       width: 'calc(100% - 8rem)'
     }
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/Carousel/CarouselPagination.jss.ts
+++ b/packages/main/src/components/Carousel/CarouselPagination.jss.ts
@@ -1,7 +1,7 @@
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { ZIndex } from '../../enums/ZIndex';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   pagination: {
     display: 'flex',
     width: 'calc(100% - 2rem)',
@@ -9,13 +9,13 @@ const styles = ({ parameters }: JSSTheme) => ({
     alignItems: 'center',
     height: '3.5rem',
     padding: '0 1rem',
-    backgroundColor: parameters.sapUiPageFooterBackground
+    backgroundColor: ThemingParameters.sapUiPageFooterBackground
   },
   paginationTop: {
-    borderBottom: `1px solid ${parameters.sapUiPageFooterBorderColor}`
+    borderBottom: `1px solid ${ThemingParameters.sapUiPageFooterBorderColor}`
   },
   paginationBottom: {
-    borderTop: `1px solid ${parameters.sapUiPageFooterBorderColor}`
+    borderTop: `1px solid ${ThemingParameters.sapUiPageFooterBorderColor}`
   },
   paginationIndicator: {
     padding: '0rem 1rem',
@@ -39,19 +39,19 @@ const styles = ({ parameters }: JSSTheme) => ({
     borderRadius: '50%',
     alignSelf: 'center',
     boxSizing: 'border-box',
-    backgroundColor: parameters.sapUiContentNonInteractiveIconColor
+    backgroundColor: ThemingParameters.sapUiContentNonInteractiveIconColor
   },
   paginationIconActive: {
     margin: '0 0.25rem',
     width: '0.5rem',
     height: '0.5rem',
-    backgroundColor: parameters.sapUiSelected
+    backgroundColor: ThemingParameters.sapUiSelected
   },
   paginationArrow: {
     boxShadow: 'none',
-    border: `1px solid ${parameters.sapUiButtonBorderColor}`,
-    backgroundColor: parameters.sapUiButtonBackground,
-    color: parameters.sapUiButtonBorderColor,
+    border: `1px solid ${ThemingParameters.sapUiButtonBorderColor}`,
+    backgroundColor: ThemingParameters.sapUiButtonBackground,
+    color: ThemingParameters.sapUiButtonBorderColor,
     height: '2rem',
     width: '2rem',
     borderRadius: '50%',
@@ -60,9 +60,9 @@ const styles = ({ parameters }: JSSTheme) => ({
     alignItems: 'center',
     cursor: 'pointer',
     '&:active': {
-      border: `1px solid ${parameters.sapUiButtonEmphasizedActiveBorderColor}`,
-      backgroundColor: parameters.sapUiButtonEmphasizedActiveBackground,
-      color: parameters.sapUiButtonEmphasizedTextColor
+      border: `1px solid ${ThemingParameters.sapUiButtonEmphasizedActiveBorderColor}`,
+      backgroundColor: ThemingParameters.sapUiButtonEmphasizedActiveBackground,
+      color: ThemingParameters.sapUiButtonEmphasizedTextColor
     }
   },
   '@global html[dir="rtl"] div[data-value="paginationArrow"] ui5-icon': {
@@ -70,7 +70,7 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   paginationArrowContent: {
     '& $paginationArrow': {
-      boxShadow: parameters.sapUiShadowLevel1,
+      boxShadow: ThemingParameters.sapUiShadowLevel1,
       '&:first-child': {
         position: 'absolute',
         top: 'calc(50% - 2.75rem)',
@@ -98,6 +98,6 @@ const styles = ({ parameters }: JSSTheme) => ({
       }
     }
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/Carousel/CarouselPagination.tsx
+++ b/packages/main/src/components/Carousel/CarouselPagination.tsx
@@ -6,11 +6,10 @@ import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import { Label } from '@ui5/webcomponents-react/lib/Label';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import React, { Children, FC, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import styles from './CarouselPagination.jss';
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'CarouselPagination' });
+const useStyles = createComponentStyles(styles, { name: 'CarouselPagination' });
 
 export interface CarouselPaginationPropTypes {
   /**

--- a/packages/main/src/components/Carousel/index.tsx
+++ b/packages/main/src/components/Carousel/index.tsx
@@ -15,9 +15,8 @@ import React, {
   useEffect,
   useState
 } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './Carousel.jss';
 import { CarouselPagination, CarouselPaginationPropTypes } from './CarouselPagination';
 
@@ -48,7 +47,7 @@ export interface CarouselPropTypes
   loop?: boolean;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'Carousel' });
+const useStyles = createComponentStyles(styles, { name: 'Carousel' });
 
 /**
  * <code>import { Carousel } from '@ui5/webcomponents-react/lib/Carousel';</code>

--- a/packages/main/src/components/FilterBar/FilterBar.jss.ts
+++ b/packages/main/src/components/FilterBar/FilterBar.jss.ts
@@ -1,74 +1,72 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => {
-  return {
-    outerContainer: {
-      paddingTop: '0.5rem',
-      paddingLeft: '2rem',
-      paddingRight: '2rem',
-      paddingBottom: '1px',
-      background: parameters.sapUiObjectHeaderBackground,
-      boxShadow: parameters.sapUiShadowHeader
-    },
-    filterBarHeader: {
-      alignItems: 'center',
-      display: 'flex',
-      background: parameters.sapUiObjectHeaderBackground,
-      minHeight: '3rem',
-      paddingBottom: '0.5rem',
-      boxShadow: 'none',
-      flexWrap: 'wrap'
-    },
-    vLine: {
-      borderLeft: '1px solid gray',
-      paddingLeft: '0.5rem'
-    },
-    filterArea: {
-      display: 'flex',
-      flexWrap: 'wrap',
-      paddingTop: '1rem',
-      paddingBottom: '1rem',
-      background: parameters.sapUiObjectHeaderBackground,
-      transition: 'max-height 0.2s ease-out, opacity 0.2s ease-in'
-    },
-    filterAreaClosed: {
-      maxHeight: '0',
-      opacity: 0,
-      padding: 0,
-      overflowY: 'auto'
-    },
-    filterAreaOpen: {
-      maxHeight: '500px',
-      opacity: 1,
-      overflowY: 'auto'
-    },
-    headerRowRight: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      flexGrow: 1
-    },
-    // is being applied to the span which represents the InfoLabel Text
-    label: {
-      fontSize: parameters.sapMFontSmallSize,
-      fontFamily: parameters.sapUiFontFamily,
-      lineHeight: '1.125rem',
-      fontWeight: 600,
-      letterSpacing: '0.0125rem',
-      textTransform: 'uppercase',
-      textAlign: 'center',
-      verticalAlign: 'top',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-      display: 'inline-block',
-      color: parameters.sapUiBaseText
-    },
-    // specific padding needed for purely numeric input
-    numeric: {},
-    // specific padding needed for text input
-    text: {},
-    // displayOnly mode
-    displayOnly: {}
-  };
+const styles = {
+  outerContainer: {
+    paddingTop: '0.5rem',
+    paddingLeft: '2rem',
+    paddingRight: '2rem',
+    paddingBottom: '1px',
+    background: ThemingParameters.sapUiObjectHeaderBackground,
+    boxShadow: ThemingParameters.sapUiShadowHeader
+  },
+  filterBarHeader: {
+    alignItems: 'center',
+    display: 'flex',
+    background: ThemingParameters.sapUiObjectHeaderBackground,
+    minHeight: '3rem',
+    paddingBottom: '0.5rem',
+    boxShadow: 'none',
+    flexWrap: 'wrap'
+  },
+  vLine: {
+    borderLeft: '1px solid gray',
+    paddingLeft: '0.5rem'
+  },
+  filterArea: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    paddingTop: '1rem',
+    paddingBottom: '1rem',
+    background: ThemingParameters.sapUiObjectHeaderBackground,
+    transition: 'max-height 0.2s ease-out, opacity 0.2s ease-in'
+  },
+  filterAreaClosed: {
+    maxHeight: '0',
+    opacity: 0,
+    padding: 0,
+    overflowY: 'auto'
+  },
+  filterAreaOpen: {
+    maxHeight: '500px',
+    opacity: 1,
+    overflowY: 'auto'
+  },
+  headerRowRight: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    flexGrow: 1
+  },
+  // is being applied to the span which represents the InfoLabel Text
+  label: {
+    fontSize: ThemingParameters.sapMFontSmallSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    lineHeight: '1.125rem',
+    fontWeight: 600,
+    letterSpacing: '0.0125rem',
+    textTransform: 'uppercase',
+    textAlign: 'center',
+    verticalAlign: 'top',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    display: 'inline-block',
+    color: ThemingParameters.sapUiBaseText
+  },
+  // specific padding needed for purely numeric input
+  numeric: {},
+  // specific padding needed for text input
+  text: {},
+  // displayOnly mode
+  displayOnly: {}
 };
 
 export default styles;

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -3,10 +3,9 @@ import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePa
 import { Button } from '@ui5/webcomponents-react/lib/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
 import React, { FC, forwardRef, ReactNode, ReactNodeArray, RefObject, useCallback, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { ClassProps } from '../../interfaces/ClassProps';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './FilterBar.jss';
 
 export interface FilterBarPropTypes extends CommonProps {
@@ -17,7 +16,7 @@ export interface FilterBarPropTypes extends CommonProps {
 
 interface FilterBarInternalProps extends FilterBarPropTypes, ClassProps {}
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'FilterBar' });
+const useStyles = createComponentStyles(styles, { name: 'FilterBar' });
 
 /**
  * <code>import { FilterBar } from '@ui5/webcomponents-react/lib/FilterBar';</code>

--- a/packages/main/src/components/FilterItem/index.tsx
+++ b/packages/main/src/components/FilterItem/index.tsx
@@ -11,7 +11,7 @@ import { Option } from '@ui5/webcomponents-react/lib/Option';
 import { Select } from '@ui5/webcomponents-react/lib/Select';
 import { StandardListItem } from '@ui5/webcomponents-react/lib/StandardListItem';
 import React, { FC, forwardRef, ReactNode, RefObject, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import styles from './FilterItem.jss';
 
@@ -28,7 +28,7 @@ export interface FilterItemPropTypes extends CommonProps {
   changeEventName?: string;
 }
 
-const useStyles = createUseStyles(styles, { name: 'FilterItem' });
+const useStyles = createComponentStyles(styles, { name: 'FilterItem' });
 
 /**
  * <code>import { FilterItem } from '@ui5/webcomponents-react/lib/FilterItem';</code>

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -5,11 +5,11 @@ import { FlexBoxDirection } from '@ui5/webcomponents-react/lib/FlexBoxDirection'
 import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/lib/FlexBoxJustifyContent';
 import { FlexBoxWrap } from '@ui5/webcomponents-react/lib/FlexBoxWrap';
 import React, { CSSProperties, FC, forwardRef, ReactNode, ReactNodeArray, Ref, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { styles } from './Flexbox.jss';
 
-const useStyles = createUseStyles(styles, { name: 'FlexBox' });
+const useStyles = createComponentStyles(styles, { name: 'FlexBox' });
 
 export interface FlexBoxPropTypes extends CommonProps {
   alignItems?: FlexBoxAlignItems;

--- a/packages/main/src/components/Form/Form.jss.ts
+++ b/packages/main/src/components/Form/Form.jss.ts
@@ -1,8 +1,8 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   formTitle: {
-    borderBottom: `1px solid ${parameters.sapUiGroupTitleBorderColor}`
+    borderBottom: `1px solid ${ThemingParameters.sapUiGroupTitleBorderColor}`
   },
   formTitlePaddingBottom: {
     paddingBottom: '2em'
@@ -23,6 +23,6 @@ const styles = ({ parameters }: JSSTheme) => ({
   formElement: {
     display: 'block'
   }
-});
+};
 
 export { styles };

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -6,9 +6,8 @@ import { Grid } from '@ui5/webcomponents-react/lib/Grid';
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/lib/TitleLevel';
 import React, { FC, forwardRef, ReactElement, Ref, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { styles } from './Form.jss';
 
 export interface FormPropTypes extends CommonProps {
@@ -22,7 +21,7 @@ export interface FormPropTypes extends CommonProps {
   title?: string;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'Form' });
+const useStyles = createComponentStyles(styles, { name: 'Form' });
 
 /**
  * <code>import { Form } from '@ui5/webcomponents-react/lib/Form';</code>

--- a/packages/main/src/components/FormGroup/index.tsx
+++ b/packages/main/src/components/FormGroup/index.tsx
@@ -5,9 +5,8 @@ import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/lib/FlexBoxJusti
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/lib/TitleLevel';
 import React, { Children, FC, forwardRef, ReactNode, ReactNodeArray, Ref } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { styles } from '../Form/Form.jss';
 
 export interface FormGroupProps extends CommonProps {
@@ -15,7 +14,7 @@ export interface FormGroupProps extends CommonProps {
   children: ReactNode | ReactNodeArray;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'FormGroup' });
+const useStyles = createComponentStyles(styles, { name: 'FormGroup' });
 
 /**
  * <code>import { FormGroup } from '@ui5/webcomponents-react/lib/FormGroup';</code>

--- a/packages/main/src/components/FormItem/index.tsx
+++ b/packages/main/src/components/FormItem/index.tsx
@@ -12,9 +12,8 @@ import React, {
   useContext,
   useMemo
 } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { styles } from '../Form/Form.jss';
 
 export interface FormItemProps extends CommonProps {
@@ -30,7 +29,7 @@ const calculateWidth = (rate) => {
   return Math.floor((100 / 12) * rate) + '%';
 };
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'FormItem' });
+const useStyles = createComponentStyles(styles, { name: 'FormItem' });
 
 /**
  * <code>import { FormItem } from '@ui5/webcomponents-react/lib/FormItem';</code>

--- a/packages/main/src/components/Grid/index.tsx
+++ b/packages/main/src/components/Grid/index.tsx
@@ -12,7 +12,7 @@ import React, {
   Ref,
   useMemo
 } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { styles } from './Grid.jss';
 
@@ -89,7 +89,7 @@ const getIndentFromString = (indent) => {
     : [undefined, 0, 0, 0, 0][currentSpan];
 };
 
-const useStyles = createUseStyles(styles, { name: 'Grid' });
+const useStyles = createComponentStyles(styles, { name: 'Grid' });
 
 /**
  * <code>import { Grid } from '@ui5/webcomponents-react/lib/Grid';</code>

--- a/packages/main/src/components/Loader/Loader.jss.ts
+++ b/packages/main/src/components/Loader/Loader.jss.ts
@@ -1,7 +1,7 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
 //todo use theme colors when available
-export const styles = ({ parameters }: JSSTheme) => ({
+export const styles = {
   '@keyframes scroll': {
     '0%': { backgroundPosition: '-100% 0' },
     '100%': { backgroundPosition: '200% 0' }
@@ -10,7 +10,7 @@ export const styles = ({ parameters }: JSSTheme) => ({
     height: '0.25rem',
     width: '100%',
     '&$loaderDeterminate': {
-      background: `linear-gradient(to right, ${parameters.sapUiContentIconColor}, ${parameters.sapUiContentIconColor})`,
+      background: `linear-gradient(to right, ${ThemingParameters.sapUiContentIconColor}, ${ThemingParameters.sapUiContentIconColor})`,
       backgroundColor: 'rgba(8, 84, 160, 0.15)',
       backgroundRepeat: 'repeat-y'
     },
@@ -19,8 +19,8 @@ export const styles = ({ parameters }: JSSTheme) => ({
       to right,
       rgba(8, 84, 160, 0) 0px,
       rgba(8, 84, 160, 1) calc(50% - 2rem),
-      ${parameters.sapUiContentIconColor} calc(50% - 2rem),
-      ${parameters.sapUiContentIconColor} calc(50% + 2rem),
+      ${ThemingParameters.sapUiContentIconColor} calc(50% - 2rem),
+      ${ThemingParameters.sapUiContentIconColor} calc(50% + 2rem),
       rgba(8, 84, 160, 1) calc(50% + 2rem),
       rgba(8, 84, 160, 0) 100%
     )`,
@@ -32,4 +32,4 @@ export const styles = ({ parameters }: JSSTheme) => ({
   },
   loaderDeterminate: {},
   loaderIndeterminate: {}
-});
+};

--- a/packages/main/src/components/Loader/index.tsx
+++ b/packages/main/src/components/Loader/index.tsx
@@ -2,9 +2,8 @@ import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHe
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { LoaderType } from '@ui5/webcomponents-react/lib/LoaderType';
 import React, { CSSProperties, FC, forwardRef, RefObject, useEffect, useMemo, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { styles } from './Loader.jss';
 
 export interface LoaderProps extends CommonProps {
@@ -16,7 +15,7 @@ export interface LoaderProps extends CommonProps {
   progress?: CSSProperties['width'];
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'Loader' });
+const useStyles = createComponentStyles(styles, { name: 'Loader' });
 
 /**
  * <code>import { Loader } from '@ui5/webcomponents-react/lib/Loader';</code>

--- a/packages/main/src/components/MessageBox/MessageBox.jss.ts
+++ b/packages/main/src/components/MessageBox/MessageBox.jss.ts
@@ -1,7 +1,7 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const style = ({ parameters }: JSSTheme) => ({
+const style = {
   header: {
     display: 'flex',
     height: CssSizeVariables.sapWcrBarHeight,
@@ -18,48 +18,48 @@ const style = ({ parameters }: JSSTheme) => ({
     padding: '0.25rem 1rem',
     boxSizing: 'border-box',
     borderBottom: `1px solid var(--messageBoxBorderColor)`,
-    color: parameters.sapUiContentLabelColor,
+    color: ThemingParameters.sapUiContentLabelColor,
     fontSize: '1rem',
     '&[data-type="Error"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiErrorBorder,
-      '--messageBoxBorderColor': parameters.sapUiErrorBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiErrorBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiErrorBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiNegativeElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiNegativeElement
       }
     },
     '&[data-type="Warning"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiWarningBorder,
-      '--messageBoxBorderColor': parameters.sapUiWarningBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiWarningBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiWarningBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiCriticalElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiCriticalElement
       }
     },
     '&[data-type="Success"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiSuccessBorder,
-      '--messageBoxBorderColor': parameters.sapUiSuccessBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiSuccessBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiSuccessBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiPositiveElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiPositiveElement
       }
     },
     '&[data-type="Confirm"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiNeutralBorder,
-      '--messageBoxBorderColor': parameters.sapUiNeutralBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiNeutralBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiNeutralBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiNeutralElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiNeutralElement
       }
     },
     '&[data-type="Information"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiNeutralBorder,
-      '--messageBoxBorderColor': parameters.sapUiNeutralBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiNeutralBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiNeutralBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiNeutralElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiNeutralElement
       }
     },
     '&[data-type="Highlight"]': {
-      '--sapUiPageFooterBorderColor': parameters.sapUiInformationBorder,
-      '--messageBoxBorderColor': parameters.sapUiInformationBorder,
+      '--sapUiPageFooterBorderColor': ThemingParameters.sapUiInformationBorder,
+      '--messageBoxBorderColor': ThemingParameters.sapUiInformationBorder,
       '& $icon': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiInformativeElement
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiInformativeElement
       }
     }
   },
@@ -84,6 +84,6 @@ const style = ({ parameters }: JSSTheme) => ({
       display: 'flex'
     }
   }
-});
+};
 
 export default style;

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -16,9 +16,8 @@ import { Text } from '@ui5/webcomponents-react/lib/Text';
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/lib/TitleLevel';
 import React, { FC, forwardRef, isValidElement, ReactNode, Ref, useCallback, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { Ui5DialogDomRef } from '../../interfaces/Ui5DialogDomRef';
 import styles from './MessageBox.jss';
 
@@ -32,7 +31,7 @@ export interface MessageBoxPropTypes extends CommonProps {
   onClose: (event: Event) => void;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'MessageBox' });
+const useStyles = createComponentStyles(styles, { name: 'MessageBox' });
 
 /**
  * <code>import { MessageBox } from '@ui5/webcomponents-react/lib/MessageBox';</code>

--- a/packages/main/src/components/MessageToast/MessageToast.jss.ts
+++ b/packages/main/src/components/MessageToast/MessageToast.jss.ts
@@ -1,30 +1,30 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-export default ({ parameters }: JSSTheme) => ({
+export default {
   messageToast: {
     padding: '0 !important',
     borderRadius: '0.25rem !important',
     textAlign: 'center !important',
-    boxShadow: parameters.sapUiShadowLevel2,
+    boxShadow: ThemingParameters.sapUiShadowLevel2,
     cursor: 'text',
     minHeight: 'auto !important',
-    background: `${parameters.sapUiListBackground} !important`
+    background: `${ThemingParameters.sapUiListBackground} !important`
   },
   messageToastContainer: {
     maxWidth: '15rem !important'
   },
   messageToastBody: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
     textAlign: 'center',
     textOverflow: 'ellipsis',
     whiteSpace: 'pre-line',
     wordWrap: 'break-word',
     padding: '1rem !important',
-    color: `${parameters.sapUiListTextColor} !important`,
+    color: `${ThemingParameters.sapUiListTextColor} !important`,
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center'
   }
-});
+};

--- a/packages/main/src/components/MessageToast/index.tsx
+++ b/packages/main/src/components/MessageToast/index.tsx
@@ -1,17 +1,17 @@
 import '@ui5/webcomponents-icons/dist/icons/message-error';
 import '@ui5/webcomponents-icons/dist/icons/message-warning';
 import '@ui5/webcomponents-icons/dist/icons/sys-enter';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { toast, ToastContainer, ToastContent, ToastOptions } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.min.css';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './MessageToast.jss';
 
-const coloredStyles = ({ parameters }: JSSTheme) => ({
+const coloredStyles = {
   base: {
     width: '1.375rem',
     minWidth: '1.375rem',
@@ -19,17 +19,17 @@ const coloredStyles = ({ parameters }: JSSTheme) => ({
     minHeight: '1.375rem'
   },
   Success: {
-    color: parameters.sapUiPositiveElement
+    color: ThemingParameters.sapUiPositiveElement
   },
   Error: {
-    color: parameters.sapUiNegativeElement
+    color: ThemingParameters.sapUiNegativeElement
   },
   Warning: {
-    color: parameters.sapUiCriticalElement
+    color: ThemingParameters.sapUiCriticalElement
   }
-});
+};
 
-const useIconStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof coloredStyles>>(coloredStyles, {
+const useIconStyles = createComponentStyles(coloredStyles, {
   name: 'MessageToastIcon'
 });
 
@@ -38,7 +38,7 @@ const ColoredIcon = ({ name, state }) => {
   return <Icon name={name} className={`${classes.base} ${classes[state]}`} />;
 };
 
-const useMessageToastStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, {
+const useMessageToastStyles = createComponentStyles(styles, {
   name: 'MessageToast'
 });
 

--- a/packages/main/src/components/Notification/Notification.jss.ts
+++ b/packages/main/src/components/Notification/Notification.jss.ts
@@ -1,29 +1,29 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const style = ({ parameters }: JSSTheme) => ({
+const style = {
   notificationContainer: {
     width: '100%',
     maxWidth: '60rem',
-    backgroundColor: parameters.sapUiListBackground,
-    boxShadow: parameters.sapUiShadowLevel0,
+    backgroundColor: ThemingParameters.sapUiListBackground,
+    boxShadow: ThemingParameters.sapUiShadowLevel0,
     display: 'flex',
     flexDirection: 'row',
     position: 'relative',
     overflow: 'hidden',
     '&:hover': {
-      backgroundColor: parameters.sapUiListHoverBackground
+      backgroundColor: ThemingParameters.sapUiListHoverBackground
     },
     '&:active': {
-      backgroundColor: parameters.sapUiListHoverBackground
+      backgroundColor: ThemingParameters.sapUiListHoverBackground
     }
   },
   notificationContainerChild: {
-    backgroundColor: parameters.sapUiListHeaderBackground
+    backgroundColor: ThemingParameters.sapUiListHeaderBackground
   },
   header: {
     display: 'flex',
     flexDirection: 'row',
-    boxShadow: `inset 0 -0.0625rem ${parameters.sapUiPageHeaderBorderColor}`,
+    boxShadow: `inset 0 -0.0625rem ${ThemingParameters.sapUiPageHeaderBorderColor}`,
     padding: '1rem 0 1rem 1.25rem',
     alignItems: 'center'
   },
@@ -38,9 +38,9 @@ const style = ({ parameters }: JSSTheme) => ({
     paddingRight: '40px'
   },
   title: {
-    color: parameters.sapUiGroupTitleTextColor,
-    fontFamily: parameters.sapUiFontHeaderFamily,
-    textShadow: parameters.sapUiShadowText,
+    color: ThemingParameters.sapUiGroupTitleTextColor,
+    fontFamily: ThemingParameters.sapUiFontHeaderFamily,
+    textShadow: ThemingParameters.sapUiShadowText,
     fontSize: '14px',
     paddingRight: '40px'
   },
@@ -69,7 +69,7 @@ const style = ({ parameters }: JSSTheme) => ({
     paddingRight: '0.375rem'
   },
   descriptionEllipsised: {
-    color: parameters.sapUiContentLabelColor,
+    color: ThemingParameters.sapUiContentLabelColor,
     overflow: 'hidden',
     textAlign: 'left',
     textOverflow: 'ellipsis',
@@ -80,13 +80,13 @@ const style = ({ parameters }: JSSTheme) => ({
     WebkitBoxOrient: 'vertical'
   },
   descriptionFull: {
-    color: parameters.sapUiContentLabelColor
+    color: ThemingParameters.sapUiContentLabelColor
   },
   metadata: {
     paddingTop: '0.375rem',
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
-    color: parameters.sapUiContentLabelColor,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
+    color: ThemingParameters.sapUiContentLabelColor,
     fontWeight: 'normal',
     display: 'flex',
     flexWrap: 'wrap',
@@ -100,23 +100,23 @@ const style = ({ parameters }: JSSTheme) => ({
     minWidth: '0.375rem',
     height: 'auto'
   },
-  high: { backgroundColor: parameters.sapUiErrorBorder },
-  medium: { backgroundColor: parameters.sapUiWarningBorder },
-  low: { backgroundColor: parameters.sapUiSuccessBorder },
-  none: { backgroundColor: parameters.sapUiNeutralBorder },
+  high: { backgroundColor: ThemingParameters.sapUiErrorBorder },
+  medium: { backgroundColor: ThemingParameters.sapUiWarningBorder },
+  low: { backgroundColor: ThemingParameters.sapUiSuccessBorder },
+  none: { backgroundColor: ThemingParameters.sapUiNeutralBorder },
   semanticIcon: {
     paddingRight: '0.375rem',
     width: '1rem',
     display: 'flex'
   },
   error: {
-    color: parameters.sapUiNegativeElement
+    color: ThemingParameters.sapUiNegativeElement
   },
   warning: {
-    color: parameters.sapUiCriticalElement
+    color: ThemingParameters.sapUiCriticalElement
   },
   success: {
-    color: parameters.sapUiPositiveElement
+    color: ThemingParameters.sapUiPositiveElement
   },
   contentAction: {
     display: 'flex',
@@ -139,6 +139,6 @@ const style = ({ parameters }: JSSTheme) => ({
     paddingLeft: '1rem',
     alignSelf: 'flex-start'
   }
-});
+};
 
 export default style;

--- a/packages/main/src/components/Notification/index.tsx
+++ b/packages/main/src/components/Notification/index.tsx
@@ -14,9 +14,8 @@ import { Label } from '@ui5/webcomponents-react/lib/Label';
 import { Priority } from '@ui5/webcomponents-react/lib/Priority';
 import { Text } from '@ui5/webcomponents-react/lib/Text';
 import React, { FC, forwardRef, ReactNode, RefObject, useCallback, useEffect, useMemo, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './Notification.jss';
 
 export interface NotificationProptypes extends CommonProps {
@@ -39,7 +38,7 @@ export interface NotificationProptypes extends CommonProps {
   autoPriority?: boolean;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'Notification' });
+const useStyles = createComponentStyles(styles, { name: 'Notification' });
 
 const WEIGHT = { None: 0, Low: 1, Medium: 2, High: 3 };
 

--- a/packages/main/src/components/ObjectPage/CollapsedAvatar.tsx
+++ b/packages/main/src/components/ObjectPage/CollapsedAvatar.tsx
@@ -1,7 +1,7 @@
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { AvatarSize } from '@ui5/webcomponents-react/lib/AvatarSize';
-import React, { useLayoutEffect, useMemo, useRef, useState, ReactElement } from 'react';
-import { createUseStyles } from 'react-jss';
+import React, { ReactElement, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 
 const styles = {
   base: {
@@ -27,7 +27,7 @@ const styles = {
   }
 };
 
-const useStyles = createUseStyles(styles, {
+const useStyles = createComponentStyles(styles, {
   name: 'CollapsedAvatar'
 });
 

--- a/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
+++ b/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
@@ -1,6 +1,6 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   objectPage: {
     width: '100%',
     height: '100%',
@@ -9,8 +9,8 @@ const styles = ({ parameters }: JSSTheme) => ({
     flexDirection: 'column',
     isolation: 'isolate',
     whiteSpace: 'normal',
-    fontFamily: parameters.sapUiFontFamily,
-    backgroundColor: parameters.sapUiBaseBG
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    backgroundColor: ThemingParameters.sapUiBaseBG
   },
   contentContainer: {
     overflowX: 'hidden',
@@ -28,8 +28,8 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   anchorBar: {
     paddingLeft: '2rem',
-    backgroundColor: parameters.sapUiObjectHeaderBackground,
-    boxShadow: `inset 0 -0.0625rem ${parameters.sapUiObjectHeaderBorderColor}, inset 0 0.0625rem ${parameters.sapUiObjectHeaderBorderColor}`,
+    backgroundColor: ThemingParameters.sapUiObjectHeaderBackground,
+    boxShadow: `inset 0 -0.0625rem ${ThemingParameters.sapUiObjectHeaderBorderColor}, inset 0 0.0625rem ${ThemingParameters.sapUiObjectHeaderBorderColor}`,
     display: 'flex',
     height: '2.75rem',
     minHeight: '2.75rem',
@@ -48,7 +48,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     // overflowX: 'hidden',
     // overflowY: 'auto',
     overflow: 'hidden',
-    backgroundColor: parameters.sapUiBaseBG,
+    backgroundColor: ThemingParameters.sapUiBaseBG,
     '&:after': {
       clear: 'both',
       display: 'table',
@@ -56,13 +56,13 @@ const styles = ({ parameters }: JSSTheme) => ({
     }
   },
   fillerDiv: {
-    backgroundColor: parameters.sapUiBaseBG
+    backgroundColor: ThemingParameters.sapUiBaseBG
   },
   // header
   header: {
     flexShrink: 0,
     position: 'relative',
-    backgroundColor: parameters.sapUiObjectHeaderBackground,
+    backgroundColor: ThemingParameters.sapUiObjectHeaderBackground,
     '&$stickied': {
       '& $image': {
         opacity: '1',
@@ -73,7 +73,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     }
   },
   contentHeader: {
-    backgroundColor: parameters.sapUiObjectHeaderBackground,
+    backgroundColor: ThemingParameters.sapUiObjectHeaderBackground,
     position: 'relative'
   },
   titleBar: {
@@ -97,7 +97,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     display: 'inline-block',
     margin: '0',
     fontWeight: 'normal',
-    color: parameters.sapUiBaseText
+    color: ThemingParameters.sapUiBaseText
   },
   subTitle: {
     display: 'inline-block',
@@ -106,7 +106,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     paddingTop: '0.5rem',
     paddingBottom: '0.5rem',
     fontSize: '0.875rem',
-    color: parameters.sapUiContentLabelColor
+    color: ThemingParameters.sapUiContentLabelColor
   },
   actions: {
     position: 'absolute',
@@ -204,6 +204,6 @@ const styles = ({ parameters }: JSSTheme) => ({
     top: `-0.625rem`,
     left: 'calc(50% - 1rem)'
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/ObjectPage/ObjectPageAnchorButton.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPageAnchorButton.tsx
@@ -1,5 +1,6 @@
 import '@ui5/webcomponents-icons/dist/icons/slim-arrow-down';
 import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { ScrollLink } from '@ui5/webcomponents-react-base/lib/ScrollLink';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import { List } from '@ui5/webcomponents-react/lib/List';
@@ -8,8 +9,7 @@ import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import { Popover } from '@ui5/webcomponents-react/lib/Popover';
 import { StandardListItem } from '@ui5/webcomponents-react/lib/StandardListItem';
 import React, { FC, useCallback, useState } from 'react';
-import { createUseStyles } from 'react-jss';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 
 interface ObjectPageAnchorPropTypes {
   section: any;
@@ -21,7 +21,7 @@ interface ObjectPageAnchorPropTypes {
   mode: ObjectPageMode;
 }
 
-const anchorButtonStyles = ({ parameters }: JSSTheme) => ({
+const anchorButtonStyles = {
   anchorButtonContainer: {
     position: 'relative',
     display: 'inline-flex',
@@ -32,26 +32,26 @@ const anchorButtonStyles = ({ parameters }: JSSTheme) => ({
     }
   },
   button: {
-    color: parameters.sapUiContentLabelColor,
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    color: ThemingParameters.sapUiContentLabelColor,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     cursor: 'pointer'
   },
   selected: {
-    color: parameters.sapUiSelected,
+    color: ThemingParameters.sapUiSelected,
     minWidth: '2rem',
     textAlign: 'center',
     '&:after': {
       content: '""',
-      borderBottom: `0.188rem solid ${parameters.sapUiSelected}`,
+      borderBottom: `0.188rem solid ${ThemingParameters.sapUiSelected}`,
       width: '100%',
       position: 'absolute',
       bottom: 0,
       left: 0
     }
   }
-});
-const useStyles = createUseStyles(anchorButtonStyles, {
+};
+const useStyles = createComponentStyles(anchorButtonStyles, {
   name: 'ObjectPageAnchorButton'
 });
 

--- a/packages/main/src/components/ObjectPage/ObjectPageScrollBar.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPageScrollBar.tsx
@@ -1,6 +1,6 @@
-import { JSSTheme } from '@ui5/webcomponents-react/interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import React, { FC, RefObject, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { ZIndex } from '../../enums/ZIndex';
 
 interface Props {
@@ -9,14 +9,14 @@ interface Props {
   width: number;
 }
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   outerScrollbar: {
     position: 'absolute',
     right: 0,
     overflow: 'hidden',
     height: '100%',
     zIndex: ZIndex.ResponsivePopover,
-    backgroundColor: parameters.sapUiObjectHeaderBackground,
+    backgroundColor: ThemingParameters.sapUiObjectHeaderBackground,
     '& ::-webkit-scrollbar': {
       backgroundColor: '#ffffff'
     },
@@ -36,9 +36,9 @@ const styles = ({ parameters }: JSSTheme) => ({
     overflowX: 'hidden',
     height: '100%'
   }
-});
+};
 
-const useScrollBarStyles = createUseStyles(styles, { name: 'ObjectPageScrollBar' });
+const useScrollBarStyles = createComponentStyles(styles, { name: 'ObjectPageScrollBar' });
 
 export const ObjectPageScrollBar: FC<Props> = (props) => {
   const { scrollBarRef, innerScrollBarRef, width } = props;

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -24,7 +24,7 @@ import React, {
   useRef,
   useState
 } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { ObjectPageSectionPropTypes } from '../ObjectPageSection';
 import { ObjectPageSubSectionPropTypes } from '../ObjectPageSubSection';
@@ -62,7 +62,7 @@ export interface ObjectPagePropTypes extends CommonProps {
   renderKeyInfos?: () => JSX.Element;
 }
 
-const useStyles = createUseStyles(styles, { name: 'ObjectPage' });
+const useStyles = createComponentStyles(styles, { name: 'ObjectPage' });
 const defaultScrollbarWidth = 12;
 
 /**

--- a/packages/main/src/components/ObjectPageSection/ObjectPageSection.jss.ts
+++ b/packages/main/src/components/ObjectPageSection/ObjectPageSection.jss.ts
@@ -1,23 +1,23 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   header: {
     padding: '0 3rem 0 2.5rem',
-    borderBottom: `1px solid ${parameters.sapUiGroupTitleBorderColor}`,
+    borderBottom: `1px solid ${ThemingParameters.sapUiGroupTitleBorderColor}`,
     boxSizing: 'border-box',
     height: '2.75rem'
   },
   title: {
     height: '2.75rem',
-    color: parameters.sapUiBaseText,
-    fontSize: parameters.sapMFontHeader4Size,
-    borderBottom: `1px solid ${parameters.sapUiActive}`,
+    color: ThemingParameters.sapUiBaseText,
+    fontSize: ThemingParameters.sapMFontHeader4Size,
+    borderBottom: `1px solid ${ThemingParameters.sapUiActive}`,
     display: 'inline-block',
     maxWidth: '100%',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
-    fontFamily: parameters.sapUiFontFamily
+    fontFamily: ThemingParameters.sapUiFontFamily
   },
   uppercase: {
     textTransform: 'uppercase'
@@ -27,8 +27,8 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   sectionContentInner: {
     padding: '1rem 2rem 2rem 2.5rem',
-    fontFamily: parameters.sapUiFontFamily
+    fontFamily: ThemingParameters.sapUiFontFamily
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -3,9 +3,8 @@ import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsoli
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { useScrollElement } from '@ui5/webcomponents-react-base/lib/useScrollElement';
 import React, { FC, forwardRef, ReactNode, ReactNodeArray, RefObject } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { EmptyIdPropException } from '../ObjectPage/EmptyIdPropException';
 import styles from './ObjectPageSection.jss';
 
@@ -16,7 +15,7 @@ export interface ObjectPageSectionPropTypes extends CommonProps {
   children: ReactNode | ReactNodeArray;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'ObjectPageSection' });
+const useStyles = createComponentStyles(styles, { name: 'ObjectPageSection' });
 
 /**
  * <code>import { ObjectPageSection } from '@ui5/webcomponents-react/lib/ObjectPageSection';</code>

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -1,11 +1,11 @@
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { useScrollElement } from '@ui5/webcomponents-react-base/lib/useScrollElement';
 import React, { FC, forwardRef, ReactNode, ReactNodeArray, RefObject } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { EmptyIdPropException } from '../ObjectPage/EmptyIdPropException';
 
 export interface ObjectPageSubSectionPropTypes extends CommonProps {
@@ -14,25 +14,25 @@ export interface ObjectPageSubSectionPropTypes extends CommonProps {
   children: ReactNode | ReactNodeArray;
 }
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   objectPageSubSection: {
     padding: '1rem 0',
     '&:focus': {
-      outline: `1px dotted ${parameters.sapUiContentFocusColor}`,
+      outline: `1px dotted ${ThemingParameters.sapUiContentFocusColor}`,
       outlineOffset: '-1px'
     }
   },
   objectPageSubSectionHeaderTitle: {
-    fontSize: parameters.sapMFontHeader5Size,
-    color: parameters.sapUiGroupTitleTextColor,
+    fontSize: ThemingParameters.sapMFontHeader5Size,
+    color: ThemingParameters.sapUiGroupTitleTextColor,
     marginBottom: '0.5rem'
   },
   subSectionContent: {
     padding: '1rem 2rem 3rem 0'
   }
-});
+};
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'ObjectPageSubSection' });
+const useStyles = createComponentStyles(styles, { name: 'ObjectPageSubSection' });
 
 /**
  * <code>import { ObjectPageSubSection } from '@ui5/webcomponents-react/lib/ObjectPageSubSection';</code>

--- a/packages/main/src/components/ObjectStatus/ObjectStatus.jss.ts
+++ b/packages/main/src/components/ObjectStatus/ObjectStatus.jss.ts
@@ -1,35 +1,35 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   objectStatus: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
     position: 'relative',
     display: 'flex'
   },
   iconSuccess: {
     '& ui5-icon': {
-      color: parameters.sapUiPositiveText
+      color: ThemingParameters.sapUiPositiveText
     }
   },
   iconWarning: {
     '& ui5-icon': {
-      color: parameters.sapUiCriticalText
+      color: ThemingParameters.sapUiCriticalText
     }
   },
   iconError: {
     '& ui5-icon': {
-      color: parameters.sapUiNegativeText
+      color: ThemingParameters.sapUiNegativeText
     }
   },
   iconNone: {
     '& ui5-icon': {
-      color: parameters.sapUiNeutralText
+      color: ThemingParameters.sapUiNeutralText
     }
   },
   iconInformation: {
-    color: parameters.sapUiInformativeElement
+    color: ThemingParameters.sapUiInformativeElement
   },
   icon: {
     marginRight: '0.5rem',
@@ -38,20 +38,20 @@ const styles = ({ parameters }: JSSTheme) => ({
     lineHeight: 'inherit'
   },
   textSuccess: {
-    color: parameters.sapUiPositiveText
+    color: ThemingParameters.sapUiPositiveText
   },
   textError: {
-    color: parameters.sapUiNegativeText
+    color: ThemingParameters.sapUiNegativeText
   },
   textWarning: {
-    color: parameters.sapUiCriticalText
+    color: ThemingParameters.sapUiCriticalText
   },
   textInformation: {
-    color: parameters.sapUiInformativeText
+    color: ThemingParameters.sapUiInformativeText
   },
   textNone: {
-    color: parameters.sapUiNeutralText
+    color: ThemingParameters.sapUiNeutralText
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/ObjectStatus/index.tsx
+++ b/packages/main/src/components/ObjectStatus/index.tsx
@@ -8,9 +8,8 @@ import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePa
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import React, { FC, forwardRef, ReactNode, Ref, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './ObjectStatus.jss';
 
 export interface ObjectStatusPropTypes extends CommonProps {
@@ -39,7 +38,7 @@ const getDefaultIcon = (state) => {
   }
 };
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'ObjectStatus' });
+const useStyles = createComponentStyles(styles, { name: 'ObjectStatus' });
 
 /**
  * <code>import { ObjectStatus } from '@ui5/webcomponents-react/lib/ObjectStatus';</code>

--- a/packages/main/src/components/Page/Page.jss.ts
+++ b/packages/main/src/components/Page/Page.jss.ts
@@ -1,5 +1,5 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
 /**
  * Style Class Generator Function
@@ -7,7 +7,7 @@ import { JSSTheme } from '../../interfaces/JSSTheme';
  * @param {Object} obj - Current Theme Context by JSS Provider.
  * @param {object} obj.parameters - Theming parameters (e.g. LabelColor)
  */
-const styles = ({ parameters }: JSSTheme) => {
+const styles = {
   // const isS = '@media (max-width: 600px)';
   // const isM = '@media (min-width: 601px) and (max-width: 1024px)';
   // const isL = '@media (min-width: 1025px) and (max-width: 1440px)';
@@ -53,109 +53,107 @@ const styles = ({ parameters }: JSSTheme) => {
   //   };
   // }
 
-  return {
-    pageContainer: {
-      width: '100%',
-      height: '100%',
-      overflow: 'hidden',
-      position: 'relative',
-      '& $pageHeader': {
-        // ...getHeaderAndFooterPaddings()
+  pageContainer: {
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    position: 'relative',
+    '& $pageHeader': {
+      // ...getHeaderAndFooterPaddings()
+    },
+    '& $pageFooter': {
+      // ...getHeaderAndFooterPaddings()
+    },
+    '& $contentSection': {
+      // [isS]: {
+      //   padding: '1rem 1rem 0 1rem'
+      // },
+      // [isM]: {
+      //   padding: '1rem 2rem 0 2rem'
+      // },
+      // [isL]: {
+      //   padding: '1rem 2rem 0 2rem'
+      // },
+      // [isXL]: {
+      //   padding: '1rem 3rem 0 3rem'
+      // },
+      // [isXXL]: {
+      //   padding: '1rem 3rem 0 3rem'
+      // }
+    }
+  },
+  backgroundStandard: {
+    background: ThemingParameters.sapUiBaseBG
+  },
+  backgroundSolid: {
+    background: ThemingParameters.sapUiShellBackground
+  },
+  backgroundList: {
+    background: ThemingParameters.sapUiGroupContentBackground
+  },
+  backgroundTransparent: {
+    background: 'transparent'
+  },
+  baseBar: {
+    '& >*': {
+      paddingLeft: '0rem',
+      paddingRight: '0rem',
+      '& [data-bar-part="Left"]': {
+        paddingLeft: '0rem'
       },
-      '& $pageFooter': {
-        // ...getHeaderAndFooterPaddings()
-      },
-      '& $contentSection': {
-        // [isS]: {
-        //   padding: '1rem 1rem 0 1rem'
-        // },
-        // [isM]: {
-        //   padding: '1rem 2rem 0 2rem'
-        // },
-        // [isL]: {
-        //   padding: '1rem 2rem 0 2rem'
-        // },
-        // [isXL]: {
-        //   padding: '1rem 3rem 0 3rem'
-        // },
-        // [isXXL]: {
-        //   padding: '1rem 3rem 0 3rem'
-        // }
-      }
-    },
-    backgroundStandard: {
-      background: parameters.sapUiBaseBG
-    },
-    backgroundSolid: {
-      background: parameters.sapUiShellBackground
-    },
-    backgroundList: {
-      background: parameters.sapUiGroupContentBackground
-    },
-    backgroundTransparent: {
-      background: 'transparent'
-    },
-    baseBar: {
-      '& >*': {
-        paddingLeft: '0rem',
-        paddingRight: '0rem',
-        '& [data-bar-part="Left"]': {
-          paddingLeft: '0rem'
-        },
-        '& [data-bar-part="Right"]': {
-          paddingRight: '0rem'
-        }
-      }
-    },
-    pageHeader: {
-      top: 0,
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      textAlign: 'center',
-      background: parameters.sapUiPageHeaderBackground,
-      '& >*': {
-        background: parameters.sapUiPageHeaderBackground,
-        boxShadow: `inset 0 -0.0625rem ${parameters.sapUiPageHeaderBorderColor}`
-      }
-    },
-    contentSection: {
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      right: '0',
-      bottom: '0',
-      overflowY: 'auto',
-      overflowX: 'hidden',
-      // marginTop: '1px',
-      // marginBottom: '1px',
-      boxSizing: 'border-box'
-      // backgroundColor: parameters.sapUiBaseBG
-    },
-    pageWithHeader: {
-      '& $contentSection': {
-        top: CssSizeVariables.sapWcrBarHeight
-      }
-    },
-    pageWithFooter: {
-      '& $contentSection': {
-        bottom: CssSizeVariables.sapWcrBarHeight
-      }
-    },
-    pageFooter: {
-      position: 'absolute',
-      bottom: '0',
-      left: '0',
-      width: '100%',
-      borderTop: `1px solid ${parameters.sapUiPageFooterBorderColor}`,
-      '& >*': {
-        height: CssSizeVariables.sapWcrBarHeight,
-        background: parameters.sapUiPageFooterBackground,
-        borderTop: `0.0625rem solid ${parameters.sapUiPageFooterBorderColor}`
+      '& [data-bar-part="Right"]': {
+        paddingRight: '0rem'
       }
     }
-  };
+  },
+  pageHeader: {
+    top: 0,
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    textAlign: 'center',
+    background: ThemingParameters.sapUiPageHeaderBackground,
+    '& >*': {
+      background: ThemingParameters.sapUiPageHeaderBackground,
+      boxShadow: `inset 0 -0.0625rem ${ThemingParameters.sapUiPageHeaderBorderColor}`
+    }
+  },
+  contentSection: {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    right: '0',
+    bottom: '0',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    // marginTop: '1px',
+    // marginBottom: '1px',
+    boxSizing: 'border-box'
+    // backgroundColor: ThemingParameters.sapUiBaseBG
+  },
+  pageWithHeader: {
+    '& $contentSection': {
+      top: CssSizeVariables.sapWcrBarHeight
+    }
+  },
+  pageWithFooter: {
+    '& $contentSection': {
+      bottom: CssSizeVariables.sapWcrBarHeight
+    }
+  },
+  pageFooter: {
+    position: 'absolute',
+    bottom: '0',
+    left: '0',
+    width: '100%',
+    borderTop: `1px solid ${ThemingParameters.sapUiPageFooterBorderColor}`,
+    '& >*': {
+      height: CssSizeVariables.sapWcrBarHeight,
+      background: ThemingParameters.sapUiPageFooterBackground,
+      borderTop: `0.0625rem solid ${ThemingParameters.sapUiPageFooterBorderColor}`
+    }
+  }
 };
 
 export default styles;

--- a/packages/main/src/components/Page/index.tsx
+++ b/packages/main/src/components/Page/index.tsx
@@ -9,9 +9,8 @@ import { PageBackgroundDesign } from '@ui5/webcomponents-react/lib/PageBackgroun
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/lib/TitleLevel';
 import React, { FC, forwardRef, ReactElement, ReactNode, Ref, useCallback, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { BarPropTypes } from '../Bar';
 import styles from './Page.jss';
 
@@ -27,7 +26,7 @@ export interface PagePropTypes extends CommonProps {
   children: ReactElement<any> | Array<ReactElement<any>> | ReactNode;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, {
+const useStyles = createComponentStyles(styles, {
   name: 'Page'
 });
 

--- a/packages/main/src/components/ProgressIndicator/ProgressIndicator.jss.ts
+++ b/packages/main/src/components/ProgressIndicator/ProgressIndicator.jss.ts
@@ -1,74 +1,72 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => {
-  return {
-    progressBarRemaining: {
-      height: '100%',
-      flexGrow: '1',
-      minWidth: '0',
-      display: 'flex',
-      alignItems: 'center'
-    },
-    progressBarTextRight: {
-      marginLeft: '0.375rem'
-    },
-    progressBarTextLeft: {
-      marginRight: '0.375rem'
-    },
-    wrapper: {
-      display: 'flex',
-      flexDirection: 'row',
-      WebkitFlexDirection: 'row',
-      boxSizing: 'border-box',
-      outline: 'none',
-      background: parameters.sapUiFieldBackground,
-      width: '100%',
-      height: CssSizeVariables.sapWcrProgressIndicatorHeight,
-      minWidth: '4rem',
-      minHeight: '1rem',
-      padding: '0',
-      margin: CssSizeVariables.sapWcrProgressIndicatorMargin,
-      border: `1px solid ${parameters.sapUiFieldBorderColor}`,
-      borderRadius: '0.5rem',
-      overflow: 'hidden'
-    },
-    progressbar: {
-      transition: 'flex-basis 1s',
-      justifyContent: 'flex-end',
-      display: 'flex',
-      alignItems: 'center'
-    },
-    progressBarText: {
-      textOverflow: 'ellipsis',
-      overflow: 'hidden',
-      whiteSpace: 'nowrap',
-      fontFamily: parameters.sapUiFontFamily,
-      fontSize: parameters.sapMFontSmallSize,
-      fontWeight: 'normal'
-    },
-    progressBarTextColorLow: {
-      color: parameters.sapUiBaseText
-    },
-    progressBarTextColorHigh: {
-      color: parameters.sapUiContentContrastTextColor
-    },
-    stateNone: {
-      backgroundColor: parameters.sapUiNeutralElement
-    },
-    stateSuccess: {
-      backgroundColor: parameters.sapUiPositiveElement
-    },
-    stateWarning: {
-      backgroundColor: parameters.sapUiCriticalElement
-    },
-    stateError: {
-      backgroundColor: parameters.sapUiNegativeElement
-    },
-    stateInformation: {
-      backgroundColor: parameters.sapUiInformativeElement
-    }
-  };
+const styles = {
+  progressBarRemaining: {
+    height: '100%',
+    flexGrow: '1',
+    minWidth: '0',
+    display: 'flex',
+    alignItems: 'center'
+  },
+  progressBarTextRight: {
+    marginLeft: '0.375rem'
+  },
+  progressBarTextLeft: {
+    marginRight: '0.375rem'
+  },
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'row',
+    WebkitFlexDirection: 'row',
+    boxSizing: 'border-box',
+    outline: 'none',
+    background: ThemingParameters.sapUiFieldBackground,
+    width: '100%',
+    height: CssSizeVariables.sapWcrProgressIndicatorHeight,
+    minWidth: '4rem',
+    minHeight: '1rem',
+    padding: '0',
+    margin: CssSizeVariables.sapWcrProgressIndicatorMargin,
+    border: `1px solid ${ThemingParameters.sapUiFieldBorderColor}`,
+    borderRadius: '0.5rem',
+    overflow: 'hidden'
+  },
+  progressbar: {
+    transition: 'flex-basis 1s',
+    justifyContent: 'flex-end',
+    display: 'flex',
+    alignItems: 'center'
+  },
+  progressBarText: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontSmallSize,
+    fontWeight: 'normal'
+  },
+  progressBarTextColorLow: {
+    color: ThemingParameters.sapUiBaseText
+  },
+  progressBarTextColorHigh: {
+    color: ThemingParameters.sapUiContentContrastTextColor
+  },
+  stateNone: {
+    backgroundColor: ThemingParameters.sapUiNeutralElement
+  },
+  stateSuccess: {
+    backgroundColor: ThemingParameters.sapUiPositiveElement
+  },
+  stateWarning: {
+    backgroundColor: ThemingParameters.sapUiCriticalElement
+  },
+  stateError: {
+    backgroundColor: ThemingParameters.sapUiNegativeElement
+  },
+  stateInformation: {
+    backgroundColor: ThemingParameters.sapUiInformativeElement
+  }
 };
 
 export default styles;

--- a/packages/main/src/components/ProgressIndicator/index.tsx
+++ b/packages/main/src/components/ProgressIndicator/index.tsx
@@ -2,9 +2,8 @@ import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHe
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import React, { FC, forwardRef, Ref, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './ProgressIndicator.jss';
 
 export interface ProgressIndicatorPropTypes extends CommonProps {
@@ -33,7 +32,7 @@ export interface ProgressIndicatorPropTypes extends CommonProps {
   state?: ValueState;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'ProgressIndicator' });
+const useStyles = createComponentStyles(styles, { name: 'ProgressIndicator' });
 
 /**
  * <code>import { ProgressIndicator } from '@ui5/webcomponents-react/lib/ProgressIndicator';</code>

--- a/packages/main/src/components/SegmentedButton/index.tsx
+++ b/packages/main/src/components/SegmentedButton/index.tsx
@@ -15,7 +15,7 @@ import React, {
   useEffect,
   useState
 } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 
 export type SelectedKey = string | number;
@@ -45,7 +45,7 @@ const styles = {
   }
 };
 
-const useStyles = createUseStyles(styles, { name: 'SegmentedButton' });
+const useStyles = createComponentStyles(styles, { name: 'SegmentedButton' });
 
 /**
  * <code>import { SegmentedButton } from '@ui5/webcomponents-react/lib/SegmentedButton';</code>

--- a/packages/main/src/components/SegmentedButtonItem/SegmentedButtonItem.jss.ts
+++ b/packages/main/src/components/SegmentedButtonItem/SegmentedButtonItem.jss.ts
@@ -1,9 +1,9 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   segmentedButtonItem: {
-    fontFamily: parameters.sapUiFontFamily,
+    fontFamily: ThemingParameters.sapUiFontFamily,
     listStyle: 'none',
     overflow: 'hidden',
     WebkitTapHighlightColor: 'rgba(255, 255, 255, 0)',
@@ -16,7 +16,7 @@ const styles = ({ parameters }: JSSTheme) => ({
     display: 'inline-block',
     fontSize: '0.875rem',
     '&:focus': {
-      outline: `1px dotted ${parameters.sapUiContentFocusColor}`
+      outline: `1px dotted ${ThemingParameters.sapUiContentFocusColor}`
     },
     height: CssSizeVariables.sapWcrSegmentedButtonItemHeight,
     lineHeight: CssSizeVariables.sapWcrSegmentedButtonItemLineHeight,
@@ -29,26 +29,26 @@ const styles = ({ parameters }: JSSTheme) => ({
     '&:last-child': {
       borderTopRightRadius: '0.25rem',
       borderBottomRightRadius: '0.25rem',
-      borderRightColor: parameters.sapUiSegmentedButtonBorderColor
+      borderRightColor: ThemingParameters.sapUiSegmentedButtonBorderColor
     },
-    color: parameters.sapUiSegmentedButtonTextColor,
-    border: `1px solid ${parameters.sapUiSegmentedButtonBorderColor}`,
+    color: ThemingParameters.sapUiSegmentedButtonTextColor,
+    border: `1px solid ${ThemingParameters.sapUiSegmentedButtonBorderColor}`,
     borderRightColor: 'transparent',
-    backgroundColor: parameters.sapUiSegmentedButtonBackground
+    backgroundColor: ThemingParameters.sapUiSegmentedButtonBackground
   },
   selected: {
-    background: parameters.sapUiSegmentedButtonSelectedBackground,
-    color: parameters.sapUiSegmentedButtonSelectedTextColor,
-    borderColor: parameters.sapUiSegmentedButtonSelectedHoverBorderColor,
-    '--sapUiContentNonInteractiveIconColor': parameters.sapUiContentContrastIconColor,
+    background: ThemingParameters.sapUiSegmentedButtonSelectedBackground,
+    color: ThemingParameters.sapUiSegmentedButtonSelectedTextColor,
+    borderColor: ThemingParameters.sapUiSegmentedButtonSelectedHoverBorderColor,
+    '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiContentContrastIconColor,
     '$:active': {
-      background: parameters.sapUiButtonActiveBackground,
-      color: parameters.sapUiButtonActiveTextColor
+      background: ThemingParameters.sapUiButtonActiveBackground,
+      color: ThemingParameters.sapUiButtonActiveTextColor
     }
   },
   focusableItem: {
     '&:not($selected):hover': {
-      background: parameters.sapUiSegmentedButtonHoverBackground
+      background: ThemingParameters.sapUiSegmentedButtonHoverBackground
     }
   },
   disabled: { textShadow: 'none', cursor: 'default', opacity: '0.4' },
@@ -68,6 +68,6 @@ const styles = ({ parameters }: JSSTheme) => ({
   withText: {
     marginRight: '0.5rem'
   }
-});
+};
 
 export default styles;

--- a/packages/main/src/components/SegmentedButtonItem/index.tsx
+++ b/packages/main/src/components/SegmentedButtonItem/index.tsx
@@ -2,9 +2,8 @@ import { Event } from '@ui5/webcomponents-react-base/lib/Event';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './SegmentedButtonItem.jss';
 
 export interface SegmentedButtonItemPropTypes extends CommonProps {
@@ -16,7 +15,7 @@ export interface SegmentedButtonItemPropTypes extends CommonProps {
   onClick?: (e: Event) => void;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'SegmentedButtonItem' });
+const useStyles = createComponentStyles(styles, { name: 'SegmentedButtonItem' });
 
 /**
  * <code>import { SegmentedButtonItem } from '@ui5/webcomponents-react/lib/SegmentedButtonItem';</code>

--- a/packages/main/src/components/SideNavigation/SideNavigation.jss.ts
+++ b/packages/main/src/components/SideNavigation/SideNavigation.jss.ts
@@ -1,10 +1,10 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-export const sideNavigationStyles = ({ parameters }: JSSTheme) => ({
+export const sideNavigationStyles = {
   sideNavigation: {
     height: '100%',
-    borderRight: `0.0625rem solid ${parameters.sapUiGroupContentBorderColor}`,
-    backgroundColor: parameters.sapUiListBackground,
+    borderRight: `0.0625rem solid ${ThemingParameters.sapUiGroupContentBorderColor}`,
+    backgroundColor: ThemingParameters.sapUiListBackground,
     display: 'flex',
     flexDirection: 'column',
     transition: 'width 500ms'
@@ -30,6 +30,6 @@ export const sideNavigationStyles = ({ parameters }: JSSTheme) => ({
   footerItemsSeparator: {
     margin: '0.25rem 0.875rem',
     height: '0.125rem',
-    backgroundColor: parameters.sapUiListBorderColor
+    backgroundColor: ThemingParameters.sapUiListBorderColor
   }
-});
+};

--- a/packages/main/src/components/SideNavigation/index.tsx
+++ b/packages/main/src/components/SideNavigation/index.tsx
@@ -4,9 +4,8 @@ import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePa
 import { List } from '@ui5/webcomponents-react/lib/List';
 import { SideNavigationOpenState } from '@ui5/webcomponents-react/lib/SideNavigationOpenState';
 import React, { Children, cloneElement, FC, forwardRef, ReactNode, Ref, useCallback, useEffect, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { sideNavigationStyles } from './SideNavigation.jss';
 
 export interface SideNavigationProps extends CommonProps {
@@ -24,7 +23,7 @@ export interface SideNavigationProps extends CommonProps {
 
 let lastFiredSelection = '';
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof sideNavigationStyles>>(sideNavigationStyles, {
+const useStyles = createComponentStyles(sideNavigationStyles, {
   name: 'SideNavigation'
 });
 

--- a/packages/main/src/components/SideNavigationListItem/SideNavigationListItem.jss.ts
+++ b/packages/main/src/components/SideNavigationListItem/SideNavigationListItem.jss.ts
@@ -1,12 +1,12 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-export const sideNavigationListItemStyles = ({ parameters }: JSSTheme) => ({
+export const sideNavigationListItemStyles = {
   listItem: {
     '&:active': {
-      '--sapUiBaseText': parameters.sapUiListActiveTextColor,
+      '--sapUiBaseText': ThemingParameters.sapUiListActiveTextColor,
       '& $icon, & $expandArrow': {
-        '--sapUiContentNonInteractiveIconColor': parameters.sapUiListActiveTextColor
+        '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiListActiveTextColor
       }
     }
   },
@@ -22,7 +22,7 @@ export const sideNavigationListItemStyles = ({ parameters }: JSSTheme) => ({
   },
 
   icon: {
-    '--sapUiContentNonInteractiveIconColor': parameters.sapUiContentIconColor,
+    '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiContentIconColor,
     width: CssSizeVariables.sapWcrSideNavigationItemIconSize,
     height: CssSizeVariables.sapWcrSideNavigationItemIconSize,
     padding: CssSizeVariables.sapWcrSideNavigationItemIconPadding,
@@ -32,7 +32,7 @@ export const sideNavigationListItemStyles = ({ parameters }: JSSTheme) => ({
   text: {},
 
   expandArrow: {
-    '--sapUiContentNonInteractiveIconColor': parameters.sapUiContentIconColor,
+    '--sapUiContentNonInteractiveIconColor': ThemingParameters.sapUiContentIconColor,
     width: '0.875rem',
     height: '0.875rem',
     padding: CssSizeVariables.sapWcrSideNavigationItemExpandedArrowPadding,
@@ -48,9 +48,9 @@ export const sideNavigationListItemStyles = ({ parameters }: JSSTheme) => ({
     height: '0',
     borderStyle: 'solid',
     borderWidth: '0 0 6px 6px',
-    borderColor: `transparent transparent ${parameters.sapUiContentIconColor} transparent`,
+    borderColor: `transparent transparent ${ThemingParameters.sapUiContentIconColor} transparent`,
     position: 'absolute',
     right: '0.125rem',
     bottom: '0.1875rem'
   }
-});
+};

--- a/packages/main/src/components/SideNavigationListItem/index.tsx
+++ b/packages/main/src/components/SideNavigationListItem/index.tsx
@@ -25,9 +25,8 @@ import React, {
   useState
 } from 'react';
 import { createPortal } from 'react-dom';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { sideNavigationListItemStyles } from './SideNavigationListItem.jss';
 
 export interface SideNavigationListItemProps extends CommonProps {
@@ -37,12 +36,9 @@ export interface SideNavigationListItemProps extends CommonProps {
   children?: ReactNode | ReactNodeArray;
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof sideNavigationListItemStyles>>(
-  sideNavigationListItemStyles,
-  {
-    name: 'SideNavigationListItem'
-  }
-);
+const useStyles = createComponentStyles(sideNavigationListItemStyles, {
+  name: 'SideNavigationListItem'
+});
 /**
  * <code>import { SideNavigationListItem } from '@ui5/webcomponents-react/lib/SideNavigationListItem';</code>
  */

--- a/packages/main/src/components/Spinner/index.tsx
+++ b/packages/main/src/components/Spinner/index.tsx
@@ -2,7 +2,7 @@ import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHe
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Size } from '@ui5/webcomponents-react/lib/Size';
 import React, { FC, forwardRef, RefObject, useEffect, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { styles } from './Spinner.jss';
 
@@ -14,7 +14,7 @@ export interface SpinnerProps extends CommonProps {
   size?: Size;
 }
 
-const useStyles = createUseStyles(styles, { name: 'Spinner' });
+const useStyles = createComponentStyles(styles, { name: 'Spinner' });
 
 /**
  * <code>import { Spinner } from '@ui5/webcomponents-react/lib/Spinner';</code>

--- a/packages/main/src/components/Text/Text.jss.ts
+++ b/packages/main/src/components/Text/Text.jss.ts
@@ -1,12 +1,12 @@
-import { JSSTheme } from '../../interfaces/JSSTheme';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 
-export const TextStyles = ({ parameters }: JSSTheme) => ({
+export const TextStyles = {
   // Text Style
   text: {
-    fontFamily: parameters.sapUiFontFamily,
-    fontSize: parameters.sapMFontMediumSize,
+    fontFamily: ThemingParameters.sapUiFontFamily,
+    fontSize: ThemingParameters.sapMFontMediumSize,
     fontWeight: 'normal',
-    color: parameters.sapUiBaseText,
+    color: ThemingParameters.sapUiBaseText,
     display: 'inline-block',
     boxSizing: 'border-box',
     whiteSpace: 'pre-line',
@@ -25,4 +25,4 @@ export const TextStyles = ({ parameters }: JSSTheme) => ({
       whiteSpace: 'pre'
     }
   }
-});
+};

--- a/packages/main/src/components/Text/index.tsx
+++ b/packages/main/src/components/Text/index.tsx
@@ -1,9 +1,8 @@
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import React, { CSSProperties, FC, forwardRef, ReactNode, Ref } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import { ThemeOptions } from '../../interfaces/ThemeOptions';
 import { TextStyles } from './Text.jss';
 
@@ -24,7 +23,7 @@ export interface TextProps extends CommonProps {
   width?: CSSProperties['width'];
 }
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof TextStyles>>(TextStyles, { name: 'Text' });
+const useStyles = createComponentStyles(TextStyles, { name: 'Text' });
 
 /**
  * <code>import { Text } from '@ui5/webcomponents-react/lib/Text';</code>

--- a/packages/main/src/components/ThemeProvider/index.tsx
+++ b/packages/main/src/components/ThemeProvider/index.tsx
@@ -71,7 +71,9 @@ const ThemeProvider: FC<ThemeProviderProps> = (props) => {
     if (cssVarsPonyfillNeeded()) {
       window.CSSVarsPonyfill.cssVars({
         rootElement: document.head,
-        include: 'style[data-ui5-webcomponents-react-sizes],style[data-jss]'
+        include: 'style[data-ui5-webcomponents-react-sizes],style[data-jss]',
+        watch: true,
+        silent: true
       });
     }
   }, []);

--- a/packages/main/src/components/ThemeProvider/index.tsx
+++ b/packages/main/src/components/ThemeProvider/index.tsx
@@ -9,6 +9,16 @@ import { Jss } from 'jss';
 import React, { FC, Fragment, ReactNode, useEffect, useMemo } from 'react';
 import { JssProvider, ThemeProvider as ReactJssThemeProvider } from 'react-jss';
 
+declare global {
+  interface Window {
+    CSSVarsPonyfill: {
+      cssVars: (options: any) => void;
+    };
+  }
+}
+
+const cssVarsPonyfillNeeded = () => !!window.CSSVarsPonyfill;
+
 export interface ThemeProviderProps {
   /*
    * If true, the Theme Provider will also inject the root node for message toasts.
@@ -56,6 +66,15 @@ const ThemeProvider: FC<ThemeProviderProps> = (props) => {
       document.body.classList.remove('ui5-content-density-compact');
     }
   }, [isCompactSize]);
+
+  useEffect(() => {
+    if (cssVarsPonyfillNeeded()) {
+      window.CSSVarsPonyfill.cssVars({
+        rootElement: document.head,
+        include: 'style[data-ui5-webcomponents-react-sizes],style[data-jss]'
+      });
+    }
+  }, []);
 
   return (
     <JssProvider generateId={generateClassName} jss={jss}>

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -1,5 +1,6 @@
 import '@ui5/webcomponents-icons/dist/icons/navigation-down-arrow';
 import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import * as ThemingParameters from '@ui5/webcomponents-react-base/lib/sap_fiori_3';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
@@ -12,9 +13,8 @@ import { StandardListItem } from '@ui5/webcomponents-react/lib/StandardListItem'
 import { Title } from '@ui5/webcomponents-react/lib/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/lib/TitleLevel';
 import React, { FC, forwardRef, Ref, useCallback, useEffect, useMemo, useState } from 'react';
-import { createUseStyles } from 'react-jss';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 
 export interface VariantItem {
   key: string;
@@ -32,7 +32,7 @@ export interface VariantManagementPropTypes extends CommonProps {
   disabled?: boolean;
 }
 
-const styles = ({ parameters }: JSSTheme) => ({
+const styles = {
   VariantManagement: {
     display: 'flex',
     alignItems: 'center',
@@ -41,30 +41,30 @@ const styles = ({ parameters }: JSSTheme) => ({
   },
   VariantManagementText: {
     cursor: 'pointer',
-    color: parameters.sapUiButtonTextColor,
+    color: ThemingParameters.sapUiButtonTextColor,
     '&:hover': {
-      color: parameters.sapUiHighlight
+      color: ThemingParameters.sapUiHighlight
     },
     '&:active': {
-      color: parameters.sapUiHighlight
+      color: ThemingParameters.sapUiHighlight
     }
   },
   disabled: {
-    color: parameters.sapUiGroupTitleTextColor,
+    color: ThemingParameters.sapUiGroupTitleTextColor,
     cursor: 'default',
     '&:hover': {
-      color: parameters.sapUiGroupTitleTextColor
+      color: ThemingParameters.sapUiGroupTitleTextColor
     },
     '&:active': {
-      color: parameters.sapUiGroupTitleTextColor
+      color: ThemingParameters.sapUiGroupTitleTextColor
     }
   },
   footer: {
     margin: '0.4375rem 1rem 0.4325rem auto'
   }
-});
+};
 
-const useStyles = createUseStyles<JSSTheme, keyof ReturnType<typeof styles>>(styles, { name: 'VariantManagement' });
+const useStyles = createComponentStyles(styles, { name: 'VariantManagement' });
 
 /**
  * <code>import { VariantManagement } from '@ui5/webcomponents-react/lib/VariantManagement';</code>

--- a/packages/main/src/enums/BarDesign.ts
+++ b/packages/main/src/enums/BarDesign.ts
@@ -1,7 +1,7 @@
 export enum BarDesign {
-    Auto = 'Auto',
-    Footer = 'Footer',
-    Header = 'Header',
-    SubHeader = 'SubHeader',
-    FloatingFooter = 'FloatingFooter'
+  Auto = 'Auto',
+  Footer = 'Footer',
+  Header = 'Header',
+  SubHeader = 'SubHeader',
+  FloatingFooter = 'FloatingFooter'
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,43 +4,43 @@
       "filename": "charts.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "charts",
-      "size": 18704,
-      "gzip": 5298
+      "size": 19134,
+      "gzip": 5323
     },
     {
       "filename": "charts.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "charts",
-      "size": 18704,
-      "gzip": 5298
+      "size": 19134,
+      "gzip": 5323
     },
     {
       "filename": "base.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "base",
-      "size": 60160,
-      "gzip": 13027
+      "size": 60955,
+      "gzip": 13241
     },
     {
       "filename": "base.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "base",
-      "size": 60160,
-      "gzip": 13027
+      "size": 60955,
+      "gzip": 13241
     },
     {
       "filename": "main.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "main",
-      "size": 141690,
-      "gzip": 37158
+      "size": 143074,
+      "gzip": 37672
     },
     {
       "filename": "main.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "main",
-      "size": 141690,
-      "gzip": 37158
+      "size": 143074,
+      "gzip": 37672
     }
   ]
 }


### PR DESCRIPTION
This PR introduces static styling objects using CSSVariables instead of parameterized function. This helps us creating more stable styles for IE.
In addition, I wrapped the `createUseStyles` function in a custom function in order to enable further tweaks if necessary.
