### PR TITLE
refactor(Event-System): Call all event handlers with a CustomEvent instance

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -17,7 +17,8 @@
     "core-js/**/*",
     "./src/polyfill/*.ts",
     "./polyfill/*.js",
-    "intersection-observer"
+    "intersection-observer",
+    "proxy-polyfill/*"
   ],
   "scripts": {
     "clean": "rimraf cjs Device hooks lib polyfill styling types utils index.esm.js index.d.ts",
@@ -28,6 +29,7 @@
   "dependencies": {
     "core-js": "3.6.4",
     "intersection-observer": "^0.7.0",
+    "proxy-polyfill": "^0.3.1",
     "resize-observer-polyfill": "^1.5.1",
     "smoothscroll-polyfill": "^0.4.4"
   },

--- a/packages/base/src/hooks/usePassThroughHtmlProps.ts
+++ b/packages/base/src/hooks/usePassThroughHtmlProps.ts
@@ -2,8 +2,11 @@ import { useMemo } from 'react';
 
 const PROP_WHITELIST = /^(aria-|data-|id$|on[A-Z])/;
 
-export const usePassThroughHtmlProps = (props) => {
-  const passThroughPropNames = Object.keys(props).filter((name) => PROP_WHITELIST.test(name));
+export const usePassThroughHtmlProps = (props, propBlackList: string[] = []) => {
+  const componentPropBlacklist = new Set(propBlackList);
+  const passThroughPropNames = Object.keys(props).filter(
+    (name) => PROP_WHITELIST.test(name) && !componentPropBlacklist.has(name)
+  );
 
   return useMemo(
     () => {

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -15,7 +15,7 @@ import * as spacing from './lib/spacing';
 import { StyleClassHelper } from './lib/StyleClassHelper';
 import { useConsolidatedRef } from './lib/useConsolidatedRef';
 import { usePassThroughHtmlProps } from './lib/usePassThroughHtmlProps';
-import { deprecationNotice, getScrollBarWidth } from './lib/Utils';
+import { deprecationNotice, getScrollBarWidth, enrichEventWithDetails } from './lib/Utils';
 
 export {
   createComponentStyles,
@@ -36,5 +36,6 @@ export {
   CssSizeVariablesNames,
   CssSizeVariables,
   cssVariablesStyles,
-  ThemingParameters
+  ThemingParameters,
+  enrichEventWithDetails
 };

--- a/packages/base/src/interfaces/IScroller.ts
+++ b/packages/base/src/interfaces/IScroller.ts
@@ -1,7 +1,7 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 
 export interface IScroller {
-  scroll: (e: Event) => void;
+  scroll: (e: CustomEvent) => void;
   scrollToElementById: (id: string, scrollOffset?: number) => void;
   scrollToTop: () => void;
 }

--- a/packages/base/src/interfaces/IScroller.ts
+++ b/packages/base/src/interfaces/IScroller.ts
@@ -1,5 +1,3 @@
-import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
-
 export interface IScroller {
   scroll: (e: CustomEvent) => void;
   scrollToElementById: (id: string, scrollOffset?: number) => void;

--- a/packages/base/src/lib/Utils.ts
+++ b/packages/base/src/lib/Utils.ts
@@ -1,3 +1,3 @@
-import { deprecationNotice, getScrollBarWidth } from '../utils';
+import { deprecationNotice, getScrollBarWidth, enrichEventWithDetails, polyfillDeprecatedEventAPI } from '../utils';
 
-export { deprecationNotice, getScrollBarWidth };
+export { deprecationNotice, getScrollBarWidth, enrichEventWithDetails, polyfillDeprecatedEventAPI };

--- a/packages/base/src/polyfill/IE11.ts
+++ b/packages/base/src/polyfill/IE11.ts
@@ -5,6 +5,7 @@ import 'core-js/modules/es.array.from';
 import ResizeObserver from 'resize-observer-polyfill';
 import 'intersection-observer';
 import { polyfill as scrollToPolyfill } from 'smoothscroll-polyfill';
+import 'proxy-polyfill/proxy.min.js';
 
 // @ts-ignore
 window.ResizeObserver = ResizeObserver;

--- a/packages/base/src/utils/Event.ts
+++ b/packages/base/src/utils/Event.ts
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, UIEvent } from 'react';
 import { HTMLEvent } from '../interfaces/HTMLEvent';
+import { deprecationNotice } from '@ui5/webcomponents-react-base/lib/Utils';
 
 export interface Parameters {
   [key: string]: number | string | object | boolean | Parameters;

--- a/packages/base/src/utils/Event.ts
+++ b/packages/base/src/utils/Event.ts
@@ -1,4 +1,4 @@
-import { ReactNode, UIEvent } from 'react';
+import { ReactNode } from 'react';
 import { HTMLEvent } from '../interfaces/HTMLEvent';
 import { deprecationNotice } from '@ui5/webcomponents-react-base/lib/Utils';
 
@@ -23,6 +23,10 @@ export class Event {
     this.originalEvent = originalEvent;
     this.parameters = parameters;
     this.htmlSource = originalEvent.target;
+    deprecationNotice(
+      '@ui5/webcomponents-react-base/lib/Event',
+      'This class is deprecated and will be removed in future releases. We recommend working with CustomEvents from now on.'
+    );
   }
 
   /**

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -1,9 +1,11 @@
 import { UIEvent } from 'react';
 
 export const deprecationNotice = (component: string, message: string) => {
-  const value = `*** ui5-webcomponents-react Deprecation Notice - ${component} ***\n`;
-  // eslint-disable-next-line no-console
-  console.warn(`${value}${message}`);
+  if (process.env.NODE_ENV === 'development') {
+    const value = `*** ui5-webcomponents-react Deprecation Notice - ${component} ***\n`;
+    // eslint-disable-next-line no-console
+    console.warn(`${value}${message}`);
+  }
 };
 
 export const getScrollBarWidth = () => {

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { UIEvent } from 'react';
+
 export const deprecationNotice = (component: string, message: string) => {
   const value = `*** ui5-webcomponents-react Deprecation Notice - ${component} ***\n`;
   // eslint-disable-next-line no-console
@@ -30,4 +32,64 @@ export const getScrollBarWidth = () => {
 
   document.body.removeChild(outer);
   return w1 - w2;
+};
+
+export const polyfillDeprecatedEventAPI = (event: any) => {
+  event.getOriginalEvent = () => {
+    deprecationNotice(
+      'Event',
+      "'event.getOriginalEvent' is deprecated and will be removed in the next major release. Please use the event object itself instead."
+    );
+    return event;
+  };
+  event.getParameters = () => {
+    deprecationNotice(
+      'Event',
+      "'event.getParameters' is deprecated and will be removed in the next major release. Please use 'event.detail' instead."
+    );
+    return event.detail;
+  };
+  event.getParameter = (parameter: keyof typeof event.detail) => {
+    deprecationNotice(
+      'Event',
+      "'event.getParameter' is deprecated and will be removed in the next major release. Please use 'event.detail[parameter]' instead."
+    );
+    return event.detail[parameter];
+  };
+  event.getHtmlSourceElement = () => {
+    deprecationNotice(
+      'Event',
+      "'event.getHtmlSourceElement' is deprecated and will be removed in the next major release. Please use 'event.target' instead."
+    );
+    return event.target;
+  };
+
+  event.parameters = new Proxy(
+    {},
+    {
+      get: (obj, prop) => {
+        deprecationNotice(
+          'Event',
+          "'event.parameters' is deprecated and will be removed in the next major release. Please use 'event.detail' instead."
+        );
+        return event.detail[prop];
+      }
+    }
+  );
+
+  return event;
+};
+
+export const enrichEventWithDetails = <T = {}>(event: UIEvent, payload: T = {} as any) => {
+  if (event.hasOwnProperty('persist')) {
+    // if there is a persist method, it's an SyntheticEvent so we need to persist it
+    event.persist();
+  }
+  if (!event.hasOwnProperty('detail')) {
+    Object.defineProperty(event, 'detail', { value: {}, writable: true });
+  }
+  Object.assign(event.detail, payload);
+  // "polyfill" old features
+  polyfillDeprecatedEventAPI(event);
+  return (event as unknown) as CustomEvent<T>;
 };

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -92,9 +92,11 @@ export const enrichEventWithDetails = <T = {}>(event: UIEvent, payload: T = {} a
     // if there is a persist method, it's an SyntheticEvent so we need to persist it
     event.persist();
   }
-  if (!event.hasOwnProperty('detail')) {
-    Object.defineProperty(event, 'detail', { value: {}, writable: true });
-  }
+  Object.defineProperty(event, 'detail', {
+    value: typeof event.detail === 'object' ? event.detail : {},
+    writable: true,
+    configurable: true
+  });
   Object.assign(event.detail, payload);
   // "polyfill" old features
   polyfillDeprecatedEventAPI(event);

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -92,8 +92,11 @@ export const enrichEventWithDetails = <T = {}>(event: UIEvent, payload: T = {} a
     // if there is a persist method, it's an SyntheticEvent so we need to persist it
     event.persist();
   }
+
+  const shouldCreateNewDetails =
+    event.detail === null || event.detail === undefined || typeof event.detail !== 'object';
   Object.defineProperty(event, 'detail', {
-    value: typeof event.detail === 'object' ? event.detail : {},
+    value: shouldCreateNewDetails ? {} : event.detail,
     writable: true,
     configurable: true
   });

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -40,6 +40,7 @@ export const polyfillDeprecatedEventAPI = (event: any) => {
   event.getOriginalEvent = () => {
     deprecationNotice(
       'Event',
+      // eslint-disable-next-line max-len
       "'event.getOriginalEvent' is deprecated and will be removed in the next major release. Please use the event object itself instead."
     );
     return event;
@@ -47,6 +48,7 @@ export const polyfillDeprecatedEventAPI = (event: any) => {
   event.getParameters = () => {
     deprecationNotice(
       'Event',
+      // eslint-disable-next-line max-len
       "'event.getParameters' is deprecated and will be removed in the next major release. Please use 'event.detail' instead."
     );
     return event.detail;
@@ -54,6 +56,7 @@ export const polyfillDeprecatedEventAPI = (event: any) => {
   event.getParameter = (parameter: keyof typeof event.detail) => {
     deprecationNotice(
       'Event',
+      // eslint-disable-next-line max-len
       "'event.getParameter' is deprecated and will be removed in the next major release. Please use 'event.detail[parameter]' instead."
     );
     return event.detail[parameter];
@@ -61,6 +64,7 @@ export const polyfillDeprecatedEventAPI = (event: any) => {
   event.getHtmlSourceElement = () => {
     deprecationNotice(
       'Event',
+      // eslint-disable-next-line max-len
       "'event.getHtmlSourceElement' is deprecated and will be removed in the next major release. Please use 'event.target' instead."
     );
     return event.target;
@@ -72,6 +76,7 @@ export const polyfillDeprecatedEventAPI = (event: any) => {
       get: (obj, prop) => {
         deprecationNotice(
           'Event',
+          // eslint-disable-next-line max-len
           "'event.parameters' is deprecated and will be removed in the next major release. Please use 'event.detail' instead."
         );
         return event.detail[prop];

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -16,7 +16,7 @@
     "@ui5/webcomponents/dist/Label"
   ],
   "scripts": {
-    "clean": "rimraf cjs components interfaces internal lib themes util index.esm.js index.d.ts config.d.ts",
+    "clean": "rimraf cjs components interfaces internal lib themes util index.esm.js index.d.ts config.d.ts hooks indexNew.d.ts",
     "postbuild": "rollup -c rollup.config.js"
   },
   "dependencies": {

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { BarChartPlaceholder } from '@ui5/webcomponents-react-charts/lib/BarChartPlaceholder';
@@ -83,7 +83,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
       if (payload && onDataPointClick) {
         const value = payload.value.length ? payload.value[1] - payload.value[0] : payload.value;
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             dataKey: Object.keys(payload)
               .filter((key) => key !== 'value')
               .find((key) => payload[key] === value),

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { ColumnChartPlaceholder } from '@ui5/webcomponents-react-charts/lib/ColumnChartPlaceholder';
@@ -94,7 +94,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
     (payload, eventOrIndex, event) => {
       if (payload && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             dataKey: Object.keys(payload).filter((key) =>
               payload.value.length
                 ? payload[key] === payload.value[1] - payload.value[0]

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
@@ -117,7 +117,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     (payload, eventOrIndex, event) => {
       if (payload.name && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, event ?? eventOrIndex, {
+          enrichEventWithDetails(event ?? eventOrIndex, {
             value: payload.value.length ? payload.value[1] - payload.value[0] : payload.value,
             xIndex: payload.index ?? eventOrIndex,
             dataKey: payload.value.length
@@ -133,7 +133,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
         );
       } else {
         onDataPointClick(
-          Event.of(null, event ?? eventOrIndex, {
+          enrichEventWithDetails(event ?? eventOrIndex, {
             value: eventOrIndex.value,
             xIndex: eventOrIndex.index ?? eventOrIndex,
             dataKey:

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
@@ -90,7 +90,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
     (payload, eventOrIndex) => {
       if (eventOrIndex.dataKey && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             value: eventOrIndex.value,
             dataKey: eventOrIndex.dataKey,
             xIndex: eventOrIndex.index,

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
@@ -49,7 +49,7 @@ const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartPr
     (e, i) => {
       if (e && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, e, {
+          enrichEventWithDetails(e, {
             dataKey: Object.keys(e).filter((key) =>
               e.value.length ? e[key] === e.value[1] - e.value[0] : e[key] === e.value && key !== 'value'
             )[0],

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/lib/next/ChartContainer';
@@ -63,7 +63,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<a
     (payload, index, event) => {
       if (payload && onDataPointClick && payload.value) {
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             value: payload.value,
             dataKey: currentDataKeys[0],
             name: payload.name,

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
@@ -64,7 +64,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
     (payload, eventOrIndex) => {
       if (eventOrIndex.value && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             value: eventOrIndex.value,
             dataKey: eventOrIndex.dataKey,
             name: eventOrIndex.payload.label,

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { useInitialize } from '@ui5/webcomponents-react-charts/lib/initialize';
@@ -13,7 +13,7 @@ interface RadialChartProps extends CommonProps {
   maxValue?: number;
   displayValue?: number | string;
   color?: CSSProperties['color'];
-  onDataPointClick?: (event: Event) => void;
+  onDataPointClick?: (event: CustomEvent) => void;
   height?: number | string;
   width?: number | string;
 }
@@ -51,7 +51,7 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     (payload, i, event) => {
       if (payload && onDataPointClick) {
         onDataPointClick(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             value: payload.value,
             payload: payload.payload,
             xIndex: i

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -13,7 +13,7 @@ interface RadialChartProps extends CommonProps {
   maxValue?: number;
   displayValue?: number | string;
   color?: CSSProperties['color'];
-  onDataPointClick?: (event: CustomEvent) => void;
+  onDataPointClick?: (event: CustomEvent<{value: unknown; payload: unknown; xIndex: number}>) => void;
   height?: number | string;
   width?: number | string;
 }
@@ -99,7 +99,7 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
           textAnchor="middle"
           dominantBaseline="middle"
           className="progress-label"
-          style={{ fontSize: ThemingParameters.sapMFontHeader3Size, fill: ThemingParameters.sapTextColor }}
+          style={{ fontSize: ThemingParameters.sapFontHeader3Size, fill: ThemingParameters.sapTextColor }}
         >
           {displayValue}
         </text>

--- a/packages/charts/src/hooks/useLegendItemClick.ts
+++ b/packages/charts/src/hooks/useLegendItemClick.ts
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { useCallback } from 'react';
 
 export const useLegendItemClick = (handler, dataKeyExtractor = (e?) => e.dataKey) => {
@@ -6,7 +6,7 @@ export const useLegendItemClick = (handler, dataKeyExtractor = (e?) => e.dataKey
     (payload, index, event) => {
       if (typeof handler === 'function') {
         handler(
-          Event.of(null, event, {
+          enrichEventWithDetails(event, {
             dataKey: dataKeyExtractor(payload),
             value: payload.value,
             chartType: payload.type,

--- a/packages/charts/src/interfaces/ChartBaseProps.ts
+++ b/packages/charts/src/interfaces/ChartBaseProps.ts
@@ -13,8 +13,8 @@ export interface ChartBaseProps extends CommonProps {
   options?: ChartOptions;
   categoryAxisFormatter?: (value: any, currentDataset?: object, currentContext?: object) => string | number;
   valueAxisFormatter?: (value: any, currentDataset?: object, currentContext?: object) => string | number;
-  getDatasetAtEvent?: (dataset: ChartDataSets[], event?: Event) => void;
-  getElementAtEvent?: (dataset: ChartDataSets[], event?: Event) => void;
+  getDatasetAtEvent?: (dataset: ChartDataSets[], event?: CustomEvent) => void;
+  getElementAtEvent?: (dataset: ChartDataSets[], event?: CustomEvent) => void;
   loading?: boolean;
   noLegend?: boolean;
 }

--- a/packages/charts/src/interfaces/RechartBaseProps.ts
+++ b/packages/charts/src/interfaces/RechartBaseProps.ts
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CSSProperties } from 'react';
 import { ChartContainerProps } from './ChartContainerProps';
 
@@ -6,8 +6,8 @@ export interface RechartBaseProps extends ChartContainerProps {
   labelKey?: string;
   dataKeys?: string[];
   noLegend?: boolean;
-  onDataPointClick?: (event: Event) => void;
-  onLegendClick?: (event: Event) => void;
+  onDataPointClick?: (event: CustomEvent) => void;
+  onLegendClick?: (event: CustomEvent) => void;
   color?: string;
   colors?: CSSProperties['color'][];
 

--- a/packages/main/scripts/wrapperGeneration/generateTypingsWeb.js
+++ b/packages/main/scripts/wrapperGeneration/generateTypingsWeb.js
@@ -213,8 +213,8 @@ export function generateTypings(meta) {
     .filter(([key]) => !key.startsWith('_'))
     .forEach(([key]) => {
       typings[mapEventName(key)] = {
-        tsType: '(event : Event) => void',
-        importStatement: "import { Event } from '@ui5/webcomponents-react-base/lib/Event';"
+        tsType: '(event : CustomEvent) => void',
+        importStatement: "import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';"
       };
     });
 

--- a/packages/main/scripts/wrapperGeneration/steps/createDemo.js
+++ b/packages/main/scripts/wrapperGeneration/steps/createDemo.js
@@ -84,7 +84,7 @@ function createDemoForComponent(dto) {
     } else if (meta.isEnum) {
       storyBookImports['select'] = true;
       return `select('${key}', ${meta.tsType}, ${checkForDefaultProp(meta, 'null')})`;
-    } else if (meta.tsType === '(event : Event) => void') {
+    } else if (meta.tsType === '(event : CustomEvent) => void') {
       importStorybookActions = true;
       return `action('${key}')`;
     } else {

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -25,7 +25,7 @@ export interface AnalyticalCardHeaderPropTypes extends CommonProps {
   valueState?: ValueState;
   target?: string;
   deviation?: string;
-  onHeaderPress?: (event: CustomEvent) => void;
+  onHeaderPress?: (event: CustomEvent<{}>) => void;
   description?: string;
   counter?: string;
   counterState?: ValueState;

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -123,7 +123,7 @@ export const AnalyticalCardHeader: FC<AnalyticalCardHeaderPropTypes> = forwardRe
     }
     const shouldRenderContent = [value, unit, deviation, target].some((v) => v !== null);
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['onHeaderPress']);
 
     return (
       <div

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { DeviationIndicator } from '@ui5/webcomponents-react/lib/DeviationIndicator';
@@ -25,7 +25,7 @@ export interface AnalyticalCardHeaderPropTypes extends CommonProps {
   valueState?: ValueState;
   target?: string;
   deviation?: string;
-  onHeaderPress?: (event: Event) => void;
+  onHeaderPress?: (event: CustomEvent) => void;
   description?: string;
   counter?: string;
   counterState?: ValueState;
@@ -65,7 +65,7 @@ export const AnalyticalCardHeader: FC<AnalyticalCardHeaderPropTypes> = forwardRe
     const onClick = useCallback(
       (e) => {
         if (onHeaderPress) {
-          onHeaderPress(Event.of(null, e));
+          onHeaderPress(enrichEventWithDetails(e));
         }
       },
       [onHeaderPress]

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CustomListItem } from '@ui5/webcomponents-react/lib/CustomListItem';
 import { FlexBox } from '@ui5/webcomponents-react/lib/FlexBox';
 import { FlexBoxAlignItems } from '@ui5/webcomponents-react/lib/FlexBoxAlignItems';
@@ -20,8 +20,8 @@ export interface ColumnHeaderModalProperties {
   showGroup?: boolean;
   column: ColumnType;
   style: CSSProperties;
-  onSort?: (e: Event) => void;
-  onGroupBy?: (e: Event) => void;
+  onSort?: (e: CustomEvent) => void;
+  onGroupBy?: (e: CustomEvent) => void;
 }
 
 const staticStyle = { fontWeight: 'normal' };
@@ -35,14 +35,14 @@ export const ColumnHeaderModal: FC<ColumnHeaderModalProperties> = (props) => {
 
   const handleSort = useCallback(
     (e) => {
-      const sortType = e.getParameter('item').getAttribute('data-sort');
+      const sortType = e.detail.item.getAttribute('data-sort');
 
       switch (sortType) {
         case 'asc':
           column.toggleSortBy(false);
           if (typeof onSort === 'function') {
             onSort(
-              Event.of(null, e, {
+              enrichEventWithDetails(e, {
                 column,
                 sortDirection: sortType
               })
@@ -53,7 +53,7 @@ export const ColumnHeaderModal: FC<ColumnHeaderModalProperties> = (props) => {
           column.toggleSortBy(true);
           if (typeof onSort === 'function') {
             onSort(
-              Event.of(null, e, {
+              enrichEventWithDetails(e, {
                 column,
                 sortDirection: sortType
               })
@@ -65,7 +65,7 @@ export const ColumnHeaderModal: FC<ColumnHeaderModalProperties> = (props) => {
           column.toggleGroupBy(willGroup);
           if (typeof onGroupBy === 'function') {
             onGroupBy(
-              Event.of(null, e, {
+              enrichEventWithDetails(e, {
                 column,
                 isGrouped: willGroup
               })

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
@@ -20,8 +20,8 @@ export interface ColumnHeaderModalProperties {
   showGroup?: boolean;
   column: ColumnType;
   style: CSSProperties;
-  onSort?: (e: CustomEvent) => void;
-  onGroupBy?: (e: CustomEvent) => void;
+  onSort?: (e: CustomEvent<{column: unknown; sortDirection: string}>) => void;
+  onGroupBy?: (e: CustomEvent<{column: unknown; isGrouped: boolean}>) => void;
 }
 
 const staticStyle = { fontWeight: 'normal' };

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -3,19 +3,16 @@ import '@ui5/webcomponents-icons/dist/icons/group-2';
 import '@ui5/webcomponents-icons/dist/icons/sort-ascending';
 import '@ui5/webcomponents-icons/dist/icons/sort-descending';
 import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
-import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import React, { CSSProperties, DragEventHandler, FC, ReactNode, ReactNodeArray, useMemo } from 'react';
-import { JSSTheme } from '../../../interfaces/JSSTheme';
 import { ColumnType } from '../types/ColumnType';
 import { ColumnHeaderModal } from './ColumnHeaderModal';
 
 export interface ColumnHeaderProps {
   id: string;
   defaultSortDesc: boolean;
-  onFilteredChange: (event: CustomEvent) => void;
   children: ReactNode | ReactNodeArray;
   grouping: string;
   className: string;
@@ -25,8 +22,8 @@ export interface ColumnHeaderProps {
   sortable: boolean;
   filterable: boolean;
   isLastColumn?: boolean;
-  onSort?: (e: CustomEvent) => void;
-  onGroupBy?: (e: CustomEvent) => void;
+  onSort?: (e: CustomEvent<{column: unknown; sortDirection: string}>) => void;
+  onGroupBy?: (e: CustomEvent<{column: unknown; isGrouped: boolean}>) => void;
   onDragStart: DragEventHandler<HTMLDivElement>;
   onDragOver: DragEventHandler<HTMLDivElement>;
   onDrop: DragEventHandler<HTMLDivElement>;

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -3,7 +3,7 @@ import '@ui5/webcomponents-icons/dist/icons/group-2';
 import '@ui5/webcomponents-icons/dist/icons/sort-ascending';
 import '@ui5/webcomponents-icons/dist/icons/sort-descending';
 import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
@@ -15,7 +15,7 @@ import { ColumnHeaderModal } from './ColumnHeaderModal';
 export interface ColumnHeaderProps {
   id: string;
   defaultSortDesc: boolean;
-  onFilteredChange: (event: Event) => void;
+  onFilteredChange: (event: CustomEvent) => void;
   children: ReactNode | ReactNodeArray;
   grouping: string;
   className: string;
@@ -25,8 +25,8 @@ export interface ColumnHeaderProps {
   sortable: boolean;
   filterable: boolean;
   isLastColumn?: boolean;
-  onSort?: (e: Event) => void;
-  onGroupBy?: (e: Event) => void;
+  onSort?: (e: CustomEvent) => void;
+  onGroupBy?: (e: CustomEvent) => void;
   onDragStart: DragEventHandler<HTMLDivElement>;
   onDragOver: DragEventHandler<HTMLDivElement>;
   onDrop: DragEventHandler<HTMLDivElement>;

--- a/packages/main/src/components/AnalyticalTable/defaults/FilterComponent/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/FilterComponent/index.tsx
@@ -7,7 +7,7 @@ export /**
 const DefaultFilterComponent: FC<any> = ({ column }) => {
   const handleChange = useCallback(
     (e) => {
-      column.setFilter(e.getParameter('value'));
+      column.setFilter(e.detail.value);
     },
     [column.setFilter]
   );

--- a/packages/main/src/components/AnalyticalTable/hooks/useDragAndDrop.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useDragAndDrop.ts
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { useCallback, useState } from 'react';
 
 const getColumnId = (column) => {
@@ -47,7 +47,7 @@ export const useDragAndDrop = (props, setColumnOrder, columnOrder, resizeInfo, c
 
       const columnsNewOrder = tempCols.map((tempColId) => columns.find((col) => getColumnId(col) === tempColId));
       onColumnsReordered(
-        Event.of(null, e, {
+        enrichEventWithDetails(e, {
           columnsNewOrder,
           column: columns[draggedColIdx]
         })

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CheckBox } from '@ui5/webcomponents-react/lib/CheckBox';
 import { TableSelectionMode } from '@ui5/webcomponents-react/lib/TableSelectionMode';
 import React from 'react';
@@ -23,10 +23,10 @@ export const useRowSelectionColumn: PluginHook<{}> = (hooks) => {
     }
 
     const toggleAllRowsSelected = (e) => {
-      const allRowsSelected = e.getParameter('checked');
+      const allRowsSelected = e.detail.checked;
       instance.toggleAllRowsSelected(allRowsSelected);
       if (typeof onRowSelected === 'function') {
-        onRowSelected(Event.of(null, e, { allRowsSelected }));
+        onRowSelected(enrichEventWithDetails(e, { allRowsSelected }));
       }
     };
 

--- a/packages/main/src/components/AnalyticalTable/hooks/useTableRowStyling.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useTableRowStyling.ts
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { TableSelectionMode } from '@ui5/webcomponents-react/lib/TableSelectionMode';
 
 const ROW_SELECTION_ATTRIBUTE = 'data-is-selected';
@@ -30,7 +30,7 @@ export const useTableRowStyling = (hooks) => {
         row.toggleRowSelected();
 
         if (typeof onRowSelected === 'function') {
-          onRowSelected(Event.of(null, e, { row, isSelected: !row.isSelected }));
+          onRowSelected(enrichEventWithDetails(e, { row, isSelected: !row.isSelected }));
         }
 
         if (selectionMode === TableSelectionMode.SINGLE_SELECT) {

--- a/packages/main/src/components/AnalyticalTable/hooks/useToggleRowExpand.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useToggleRowExpand.ts
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { PluginHook } from 'react-table';
 
 export const useToggleRowExpand: PluginHook<any> = (hooks) => {
@@ -15,7 +15,7 @@ export const useToggleRowExpand: PluginHook<any> = (hooks) => {
           column = row.cells.find((cell) => cell.column.id === row.groupByID).column;
         }
 
-        onRowExpandChange(Event.of(null, e, { row, column }));
+        onRowExpandChange(enrichEventWithDetails(e, { row, column }));
       }
     };
   });

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -1,5 +1,5 @@
 import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { TableSelectionMode } from '@ui5/webcomponents-react/lib/TableSelectionMode';
@@ -108,11 +108,11 @@ export interface TableProps extends CommonProps {
 
   // events
 
-  onSort?: (e?: Event) => void;
-  onGroup?: (e?: Event) => void;
-  onRowSelected?: (e?: Event) => any;
-  onRowExpandChange?: (e?: Event) => any;
-  onColumnsReordered?: (e?: Event) => void;
+  onSort?: (e?: CustomEvent) => void;
+  onGroup?: (e?: CustomEvent) => void;
+  onRowSelected?: (e?: CustomEvent) => any;
+  onRowExpandChange?: (e?: CustomEvent) => any;
+  onColumnsReordered?: (e?: CustomEvent) => void;
   /**
    * additional options which will be passed to [react-table´s useTable hook](https://github.com/tannerlinsley/react-table/blob/master/docs/api/useTable.md#table-options)
    */
@@ -287,7 +287,7 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
 
   const onGroupByChanged = useCallback(
     (e) => {
-      const { column, isGrouped } = e.getParameters();
+      const { column, isGrouped } = e.detail;
       let groupedColumns = [];
       if (isGrouped) {
         groupedColumns = [...tableState.groupBy, column.id];
@@ -296,7 +296,7 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
       }
       dispatch({ type: 'SET_GROUP_BY', payload: groupedColumns });
       onGroup(
-        Event.of(null, e.getOriginalEvent(), {
+        enrichEventWithDetails(e, {
           column,
           groupedColumns
         })

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -108,11 +108,11 @@ export interface TableProps extends CommonProps {
 
   // events
 
-  onSort?: (e: CustomEvent<{column: unknown; sortDirection: string}>) => void;
-  onGroup?: (e: CustomEvent<{column: unknown; groupedColumns: string[]}>) => void;
-  onRowSelected?: (e?: CustomEvent<{allRowsSelected?: boolean; row?: unknown; isSelected?: boolean}>) => any;
-  onRowExpandChange?: (e?: CustomEvent<{row: unknown; column: unknown}>) => any;
-  onColumnsReordered?: (e?: CustomEvent<{columnsNewOrder: string[]; column: unknown}>) => void;
+  onSort?: (e: CustomEvent<{ column: unknown; sortDirection: string }>) => void;
+  onGroup?: (e: CustomEvent<{ column: unknown; groupedColumns: string[] }>) => void;
+  onRowSelected?: (e?: CustomEvent<{ allRowsSelected?: boolean; row?: unknown; isSelected?: boolean }>) => any;
+  onRowExpandChange?: (e?: CustomEvent<{ row: unknown; column: unknown }>) => any;
+  onColumnsReordered?: (e?: CustomEvent<{ columnsNewOrder: string[]; column: unknown }>) => void;
   /**
    * additional options which will be passed to [react-table´s useTable hook](https://github.com/tannerlinsley/react-table/blob/master/docs/api/useTable.md#table-options)
    */
@@ -313,7 +313,13 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
     tableInternalColumns
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, [
+    'onSort',
+    'onGroup',
+    'onRowSelected',
+    'onRowExpandChange',
+    'onColumnsReordered'
+  ]);
 
   return (
     <div className={className} style={style} title={tooltip} ref={analyticalTableRef} {...passThroughProps}>

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -109,7 +109,7 @@ export interface TableProps extends CommonProps {
   // events
 
   onSort?: (e: CustomEvent<{column: unknown; sortDirection: string}>) => void;
-  onGroupBy?: (e: CustomEvent<{column: unknown; isGrouped: boolean}>) => void;
+  onGroup?: (e: CustomEvent<{column: unknown; groupedColumns: string[]}>) => void;
   onRowSelected?: (e?: CustomEvent<{allRowsSelected?: boolean; row?: unknown; isSelected?: boolean}>) => any;
   onRowExpandChange?: (e?: CustomEvent<{row: unknown; column: unknown}>) => any;
   onColumnsReordered?: (e?: CustomEvent<{columnsNewOrder: string[]; column: unknown}>) => void;

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -108,11 +108,11 @@ export interface TableProps extends CommonProps {
 
   // events
 
-  onSort?: (e?: CustomEvent) => void;
-  onGroup?: (e?: CustomEvent) => void;
-  onRowSelected?: (e?: CustomEvent) => any;
-  onRowExpandChange?: (e?: CustomEvent) => any;
-  onColumnsReordered?: (e?: CustomEvent) => void;
+  onSort?: (e: CustomEvent<{column: unknown; sortDirection: string}>) => void;
+  onGroupBy?: (e: CustomEvent<{column: unknown; isGrouped: boolean}>) => void;
+  onRowSelected?: (e?: CustomEvent<{allRowsSelected?: boolean; row?: unknown; isSelected?: boolean}>) => any;
+  onRowExpandChange?: (e?: CustomEvent<{row: unknown; column: unknown}>) => any;
+  onColumnsReordered?: (e?: CustomEvent<{columnsNewOrder: string[]; column: unknown}>) => void;
   /**
    * additional options which will be passed to [react-table´s useTable hook](https://github.com/tannerlinsley/react-table/blob/master/docs/api/useTable.md#table-options)
    */

--- a/packages/main/src/components/AutoCloseOnOutsideClick/index.tsx
+++ b/packages/main/src/components/AutoCloseOnOutsideClick/index.tsx
@@ -2,7 +2,7 @@ import { polyfillDeprecatedEventAPI } from '@ui5/webcomponents-react-base/lib/Ut
 import React, { PureComponent, ReactNode, RefObject } from 'react';
 
 export interface AutoCloseOnOutsideClickPropTypes {
-  onOutsideClick?: (e: CustomEvent) => void;
+  onOutsideClick?: (e: CustomEvent<{}>) => void;
   children?: ReactNode[] | ReactNode;
 }
 

--- a/packages/main/src/components/AutoCloseOnOutsideClick/index.tsx
+++ b/packages/main/src/components/AutoCloseOnOutsideClick/index.tsx
@@ -1,8 +1,8 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { polyfillDeprecatedEventAPI } from '@ui5/webcomponents-react-base/lib/Utils';
 import React, { PureComponent, ReactNode, RefObject } from 'react';
 
 export interface AutoCloseOnOutsideClickPropTypes {
-  onOutsideClick?: (e: Event) => void;
+  onOutsideClick?: (e: CustomEvent) => void;
   children?: ReactNode[] | ReactNode;
 }
 
@@ -36,7 +36,7 @@ export class AutoCloseOnOutsideClick extends PureComponent<
           isContentAreaOpen: !this.state.isContentAreaOpen
         });
         document.removeEventListener('mousedown', this.checkFocus);
-        this.props.onOutsideClick(Event.of(this, oEvent));
+        this.props.onOutsideClick(polyfillDeprecatedEventAPI(oEvent));
       }
     }
   };

--- a/packages/main/src/components/Avatar/index.tsx
+++ b/packages/main/src/components/Avatar/index.tsx
@@ -1,11 +1,10 @@
 import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { AvatarShape } from '@ui5/webcomponents-react/lib/AvatarShape';
 import { AvatarSize } from '@ui5/webcomponents-react/lib/AvatarSize';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './Avatar.jss';
 
 export interface AvatarPropTypes extends CommonProps {
@@ -13,7 +12,7 @@ export interface AvatarPropTypes extends CommonProps {
   shape?: AvatarShape;
   initials?: string;
   image?: string;
-  onClick?: (event: Event) => void;
+  onClick?: (event: CustomEvent<{}>) => void;
   children?: JSX.Element;
   customDisplaySize?: CSSProperties['width'];
   customFontSize?: CSSProperties['width'];
@@ -71,7 +70,7 @@ const Avatar: FC<AvatarPropTypes> = forwardRef((props: AvatarPropTypes, ref: Ref
   const handleKeyDown = useCallback(
     (e) => {
       if (e.key === 'Enter') {
-        onClick?.(Event.of(null, e));
+        onClick?.(enrichEventWithDetails(e));
       }
     },
     [onClick]
@@ -79,7 +78,7 @@ const Avatar: FC<AvatarPropTypes> = forwardRef((props: AvatarPropTypes, ref: Ref
 
   const handleOnClick = useCallback(
     (e) => {
-      onClick?.(Event.of(null, e));
+      onClick?.(enrichEventWithDetails(e));
     },
     [onClick]
   );

--- a/packages/main/src/components/Avatar/index.tsx
+++ b/packages/main/src/components/Avatar/index.tsx
@@ -83,7 +83,7 @@ const Avatar: FC<AvatarPropTypes> = forwardRef((props: AvatarPropTypes, ref: Ref
     [onClick]
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onClick']);
 
   return (
     <span

--- a/packages/main/src/components/Carousel/Carousel.test.tsx
+++ b/packages/main/src/components/Carousel/Carousel.test.tsx
@@ -86,7 +86,7 @@ describe('Carousel', () => {
       .find(Icon)
       .last()
       .simulate('click');
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(1);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(1);
   });
 
   test('Navigation to previous page', () => {
@@ -96,7 +96,7 @@ describe('Carousel', () => {
       .find(Icon)
       .first()
       .simulate('click');
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(0);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(0);
   });
 
   test('Navigation to previous page - w/o Loop', () => {
@@ -116,7 +116,7 @@ describe('Carousel', () => {
       .find(Icon)
       .first()
       .simulate('click');
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(6);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(6);
   });
 
   test('Navigation to next page - w/o Loop', () => {
@@ -136,7 +136,7 @@ describe('Carousel', () => {
       .find(Icon)
       .last()
       .simulate('click');
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(0);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(0);
   });
 
   test('Carousel with 1 child', () => {
@@ -155,7 +155,7 @@ describe('Carousel', () => {
       .find('div[role="list"]')
       .last()
       .simulate('keydown', { key: 'ArrowRight' });
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(1);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(1);
   });
 
   test('Navigation to previous page with Keyboard', () => {
@@ -165,7 +165,7 @@ describe('Carousel', () => {
       .find('div[role="list"]')
       .first()
       .simulate('keydown', { key: 'ArrowLeft' });
-    expect(getEventFromCallback(callback).getParameter('selectedIndex')).toEqual(0);
+    expect(getEventFromCallback(callback).detail.selectedIndex).toEqual(0);
   });
 
   createPassThroughPropsTest(Carousel);

--- a/packages/main/src/components/Carousel/index.tsx
+++ b/packages/main/src/components/Carousel/index.tsx
@@ -159,7 +159,7 @@ const Carousel: FC<CarouselPropTypes> = forwardRef((props: CarouselPropTypes, re
 
   const translateXPrefix = document.dir === 'rtl' ? '' : '-';
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onPageChanged']);
 
   return (
     <div

--- a/packages/main/src/components/Carousel/index.tsx
+++ b/packages/main/src/components/Carousel/index.tsx
@@ -1,6 +1,7 @@
-import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
+import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CarouselArrowsPlacement } from '@ui5/webcomponents-react/lib/CarouselArrowsPlacement';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import React, {
@@ -15,7 +16,6 @@ import React, {
   useEffect,
   useState
 } from 'react';
-import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
 import { CommonProps } from '../../interfaces/CommonProps';
 import styles from './Carousel.jss';
 import { CarouselPagination, CarouselPaginationPropTypes } from './CarouselPagination';
@@ -30,7 +30,7 @@ export interface CarouselPropTypes
   /**
    * This event is fired after a carousel swipe has been completed
    */
-  onPageChanged?: (event: CustomEvent) => void;
+  onPageChanged?: (event: CustomEvent<{ selectedIndex: number }>) => void;
   /**
    * The height of the carousel. Note that when a percentage value is used, the height of the surrounding container
    * must be defined.

--- a/packages/main/src/components/Carousel/index.tsx
+++ b/packages/main/src/components/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { CarouselArrowsPlacement } from '@ui5/webcomponents-react/lib/CarouselArrowsPlacement';
@@ -30,7 +30,7 @@ export interface CarouselPropTypes
   /**
    * This event is fired after a carousel swipe has been completed
    */
-  onPageChanged?: (event: Event) => void;
+  onPageChanged?: (event: CustomEvent) => void;
   /**
    * The height of the carousel. Note that when a percentage value is used, the height of the surrounding container
    * must be defined.
@@ -93,7 +93,7 @@ const Carousel: FC<CarouselPropTypes> = forwardRef((props: CarouselPropTypes, re
   const selectPageAtIndex = useCallback(
     (index, event) => {
       setCurrentlyActivePage(index);
-      onPageChanged(Event.of(null, event, { selectedIndex: index }));
+      onPageChanged(enrichEventWithDetails(event, { selectedIndex: index }));
     },
     [onPageChanged, setCurrentlyActivePage]
   );

--- a/packages/main/src/components/FilterBar/demo.stories.tsx
+++ b/packages/main/src/components/FilterBar/demo.stories.tsx
@@ -26,9 +26,6 @@ const renderVariants = () => {
       closeOnItemSelect={boolean('closeOnItemSelect', true)}
       initialSelectedKey={'2'}
       variantItems={variantItems}
-      onSelect={(e) => {
-        console.log(e.getParameter('selectedItem').key);
-      }}
       placement={select('Placement', PlacementType, PlacementType.Bottom)}
       level={select('level', TitleLevel, TitleLevel.H6)}
     />
@@ -43,7 +40,6 @@ export const renderStory = () => {
   return (
     <FilterBar renderSearch={renderSearch} renderVariants={renderVariants}>
       <FilterItem
-        onChange={(e) => alert(e.getParameter('selectedItem').key)}
         filterItems={filterItems}
         label="Classification"
         key="classification"

--- a/packages/main/src/components/FilterItem/index.tsx
+++ b/packages/main/src/components/FilterItem/index.tsx
@@ -129,7 +129,7 @@ const FilterItem: FC<FilterItemPropTypes> = forwardRef((props: FilterItemPropTyp
 
   const filterItemClasses = StyleClassHelper.of(classes.filterItem);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onChange']);
 
   return (
     <div ref={ref} className={filterItemClasses.toString()} style={style} title={tooltip} {...passThroughProps}>

--- a/packages/main/src/components/FilterItem/index.tsx
+++ b/packages/main/src/components/FilterItem/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { BusyIndicator } from '@ui5/webcomponents-react/lib/BusyIndicator';
@@ -21,7 +21,7 @@ export interface FilterItemPropTypes extends CommonProps {
   type?: FilterType;
   label?: string;
   filterItems?: any[];
-  onChange?: (event: Event) => void;
+  onChange?: (event: CustomEvent) => void;
   loading?: boolean;
   children?: ReactNode;
   valueParamName?: string;
@@ -54,15 +54,15 @@ const FilterItem: FC<FilterItemPropTypes> = forwardRef((props: FilterItemPropTyp
   }
 
   function onSelect(e) {
-    const selectedKey = e.getParameter('selectedOption').getAttribute('data-key');
+    const selectedKey = e.detail.selectedOption.getAttribute('data-key');
     const item = getItemByKey(selectedKey) || filterItems[0];
-    onChange(Event.of(null, e.getOriginalEvent(), { selectedItem: item }));
+    onChange(enrichEventWithDetails(e, { selectedItem: item }));
   }
 
   function onMultiCbChange(e) {
-    const selectedItems = e.getParameter('items');
+    const selectedItems = e.detail.items;
     onChange(
-      Event.of(null, e.getOriginalEvent(), {
+      enrichEventWithDetails(e, {
         selectedItems: selectedItems.map((item) => {
           return getItemByKey(item.getAttribute('data-key'));
         })

--- a/packages/main/src/components/FilterItem/index.tsx
+++ b/packages/main/src/components/FilterItem/index.tsx
@@ -21,7 +21,7 @@ export interface FilterItemPropTypes extends CommonProps {
   type?: FilterType;
   label?: string;
   filterItems?: any[];
-  onChange?: (event: CustomEvent) => void;
+  onChange?: (event: CustomEvent<{selectedItem?: unknown; selectedItems?: unknown}>) => void;
   loading?: boolean;
   children?: ReactNode;
   valueParamName?: string;

--- a/packages/main/src/components/Grid/Grid.stories.tsx
+++ b/packages/main/src/components/Grid/Grid.stories.tsx
@@ -1,10 +1,9 @@
-import { action } from '@storybook/addon-actions';
 import { Grid } from '@ui5/webcomponents-react/lib/Grid';
 import React from 'react';
 
 export const defaultStory = () => {
   return (
-    <Grid onRateChanged={action('rate changed')}>
+    <Grid>
       <div style={{ backgroundColor: 'lightgreen' }}>Div 1</div>
       <div style={{ backgroundColor: 'yellow' }}>Div 2</div>
       <div style={{ backgroundColor: 'cyan' }}>Div 3</div>

--- a/packages/main/src/components/MessageBox/MessageBox.test.tsx
+++ b/packages/main/src/components/MessageBox/MessageBox.test.tsx
@@ -22,7 +22,7 @@ describe('MessageBox', () => {
       .instance() as any;
 
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.OK);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.OK);
   });
 
   test('Confirm - Cancel', () => {
@@ -39,7 +39,7 @@ describe('MessageBox', () => {
       .last()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.CANCEL);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.CANCEL);
   });
 
   test('Success', () => {
@@ -56,7 +56,7 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.OK);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.OK);
   });
 
   test('Warning', () => {
@@ -73,7 +73,7 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.OK);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.OK);
   });
 
   test('Error', () => {
@@ -90,7 +90,7 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.CLOSE);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.CLOSE);
   });
 
   test('Information', () => {
@@ -107,7 +107,7 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.OK);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.OK);
   });
 
   test('Show', () => {
@@ -124,14 +124,14 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.YES);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.YES);
 
     component = wrapper
       .find('ui5-button')
       .last()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback, 1).getParameter('action')).toEqual(MessageBoxActions.NO);
+    expect(getEventFromCallback(callback, 1).detail.action).toEqual(MessageBoxActions.NO);
   });
 
   test('Success w/ custom title', () => {
@@ -148,7 +148,7 @@ describe('MessageBox', () => {
       .first()
       .instance() as any;
     component.fireEvent('click');
-    expect(getEventFromCallback(callback).getParameter('action')).toEqual(MessageBoxActions.OK);
+    expect(getEventFromCallback(callback).detail.action).toEqual(MessageBoxActions.OK);
   });
 
   test('Not open', () => {

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -28,7 +28,7 @@ export interface MessageBoxPropTypes extends CommonProps {
   actions?: MessageBoxActions[];
   icon?: ReactNode;
   type?: MessageBoxTypes;
-  onClose: (event: CustomEvent) => void;
+  onClose: (event: CustomEvent<{action: MessageBoxActions}>) => void;
 }
 
 const useStyles = createComponentStyles(styles, { name: 'MessageBox' });

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -4,7 +4,7 @@ import '@ui5/webcomponents-icons/dist/icons/message-information';
 import '@ui5/webcomponents-icons/dist/icons/message-success';
 import '@ui5/webcomponents-icons/dist/icons/message-warning';
 import '@ui5/webcomponents-icons/dist/icons/question-mark';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
@@ -28,7 +28,7 @@ export interface MessageBoxPropTypes extends CommonProps {
   actions?: MessageBoxActions[];
   icon?: ReactNode;
   type?: MessageBoxTypes;
-  onClose: (event: Event) => void;
+  onClose: (event: CustomEvent) => void;
 }
 
 const useStyles = createComponentStyles(styles, { name: 'MessageBox' });
@@ -97,8 +97,8 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
 
   const handleOnClose = useCallback(
     (e) => {
-      const action = e.getHtmlSourceElement().dataset.action;
-      onClose(Event.of(null, e, { action }));
+      const { action } = e.target.dataset;
+      onClose(enrichEventWithDetails(e, { action }));
     },
     [onClose]
   );

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -103,7 +103,7 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
     [onClose]
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onClose']);
 
   return (
     <Dialog

--- a/packages/main/src/components/Notification/index.tsx
+++ b/packages/main/src/components/Notification/index.tsx
@@ -236,7 +236,7 @@ const Notification: FC<NotificationProptypes> = forwardRef(
       return { borderRadius: borderRadius() };
     }, [isChild, isLastChild, children, showChildren]);
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['onClick', 'onClose']);
 
     if (!visibleState) return null;
     return (

--- a/packages/main/src/components/Notification/index.tsx
+++ b/packages/main/src/components/Notification/index.tsx
@@ -31,7 +31,7 @@ export interface NotificationProptypes extends CommonProps {
   onClick?: (e: any) => any;
   noShowMoreButton?: boolean;
   truncate?: boolean;
-  onClose?: (event: CustomEvent) => void;
+  onClose?: (event: CustomEvent<{}>) => void;
 
   children?: React.ReactElement<NotificationProptypes> | React.ReactElement<NotificationProptypes>[];
   collapsed?: boolean;

--- a/packages/main/src/components/Notification/index.tsx
+++ b/packages/main/src/components/Notification/index.tsx
@@ -2,7 +2,7 @@ import '@ui5/webcomponents-icons/dist/icons/decline';
 import '@ui5/webcomponents-icons/dist/icons/message-error';
 import '@ui5/webcomponents-icons/dist/icons/message-success';
 import '@ui5/webcomponents-icons/dist/icons/message-warning';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Avatar } from '@ui5/webcomponents-react/lib/Avatar';
 import { AvatarShape } from '@ui5/webcomponents-react/lib/AvatarShape';
@@ -31,7 +31,7 @@ export interface NotificationProptypes extends CommonProps {
   onClick?: (e: any) => any;
   noShowMoreButton?: boolean;
   truncate?: boolean;
-  onClose?: (event: Event) => void;
+  onClose?: (event: CustomEvent) => void;
 
   children?: React.ReactElement<NotificationProptypes> | React.ReactElement<NotificationProptypes>[];
   collapsed?: boolean;
@@ -99,7 +99,7 @@ const Notification: FC<NotificationProptypes> = forwardRef(
     const handleClose = useCallback(
       (e) => {
         toggleVisible(false);
-        onClose(Event.of(null, e));
+        onClose(enrichEventWithDetails(e));
       },
       [toggleVisible, onClose]
     );
@@ -107,7 +107,7 @@ const Notification: FC<NotificationProptypes> = forwardRef(
     const handleNotificationClick = useCallback(
       (e) => {
         if (e.target.nodeName !== 'UI5-BUTTON' && e.target.nodeName !== 'UI5-ICON' && typeof onClick === 'function') {
-          onClick(Event.of(null, e));
+          onClick(enrichEventWithDetails(e));
         }
       },
       [onClick]

--- a/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
@@ -156,7 +156,7 @@ describe('ObjectPage', () => {
       .find('section[role="navigation"] ui5-button')
       .first()
       .simulate('click');
-    expect(getEventFromCallback(callback).getParameter('selectedSectionId')).toEqual('1');
+    expect(getEventFromCallback(callback).detail.selectedSectionId).toEqual('1');
   });
 
   test('No Header', () => {

--- a/packages/main/src/components/ObjectPage/ObjectPageAnchorBar.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPageAnchorBar.tsx
@@ -3,7 +3,7 @@ import '@ui5/webcomponents-icons/dist/icons/pushpin-off';
 import '@ui5/webcomponents-icons/dist/icons/slim-arrow-down';
 import '@ui5/webcomponents-icons/dist/icons/slim-arrow-up';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
 import { List } from '@ui5/webcomponents-react/lib/List';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
@@ -115,17 +115,17 @@ const ObjectPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElement
 
   const onPinHeader = useCallback(
     (e) => {
-      setHeaderPinned(e.getParameter('pressed'));
+      setHeaderPinned(e.detail.pressed);
     },
     [setHeaderPinned]
   );
 
   const onTabItemSelect = useCallback((event) => {
-    const { sectionId, index } = event.getParameter('item').dataset;
+    const { sectionId, index } = event.detail.item.dataset;
     // eslint-disable-next-line eqeqeq
     const section = safeGetChildrenArray(sections).find((el) => el.props.id == sectionId);
     handleOnSectionSelected(
-      Event.of(null, {} as any, {
+      enrichEventWithDetails({} as any, {
         ...section,
         index
       })
@@ -142,12 +142,12 @@ const ObjectPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElement
 
   const onSubSectionClick = useCallback(
     (e) => {
-      const selectedId = e.getParameter('item').dataset.key;
+      const selectedId = e.detail.item.dataset.key;
       const subSection = popoverContent.props.children
         .filter((item) => item.props && item.props.isSubSection)
         .find((item) => item.props.id === selectedId);
       if (subSection) {
-        handleOnSubSectionSelected(Event.of(null, e.getOriginalEvent(), { section: popoverContent, subSection }));
+        handleOnSubSectionSelected(enrichEventWithDetails(e, { section: popoverContent, subSection }));
       }
       popoverRef.current.close();
     },

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -18,7 +18,8 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-  useState
+  useState,
+  ComponentType
 } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { ObjectPageSectionPropTypes } from '../ObjectPageSection';
@@ -44,7 +45,9 @@ export interface ObjectPagePropTypes extends CommonProps {
 
   selectedSectionId?: string;
   selectedSubSectionId?: string;
-  onSelectedSectionChanged?: (event: CustomEvent) => void;
+  onSelectedSectionChanged?: (
+    event: CustomEvent<{ selectedSectionIndex: number; selectedSectionId: string; section: ComponentType }>
+  ) => void;
 
   renderBreadcrumbs?: () => JSX.Element;
   renderKeyInfos?: () => JSX.Element;

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -368,7 +368,7 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
     };
   }, [scrollbarWidth]);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onSelectedSectionChanged']);
 
   useEffect(() => {
     const objectPageHeight = objectPageRef.current?.clientHeight ?? 1000;

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -1,5 +1,5 @@
 import { createComponentStyles } from '@ui5/webcomponents-react-base/lib/createComponentStyles';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
@@ -44,7 +44,7 @@ export interface ObjectPagePropTypes extends CommonProps {
 
   selectedSectionId?: string;
   selectedSubSectionId?: string;
-  onSelectedSectionChanged?: (event: Event) => void;
+  onSelectedSectionChanged?: (event: CustomEvent) => void;
 
   renderBreadcrumbs?: () => JSX.Element;
   renderKeyInfos?: () => JSX.Element;
@@ -151,7 +151,7 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
   const handleOnSectionSelected = useCallback(
     (e) => {
       isProgrammaticallyScrolled.current = true;
-      const newSelectionSection = e.getParameter('props')?.id;
+      const newSelectionSection = e.detail.props?.id;
       setInternalSelectedSectionId((oldSelectedSection) => {
         if (oldSelectedSection === newSelectionSection) {
           scrollToSection(newSelectionSection);
@@ -273,10 +273,10 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
 
   const fireOnSelectedChangedEvent = debounce((e) => {
     onSelectedSectionChanged(
-      Event.of(null, e.getOriginalEvent(), {
-        selectedSectionIndex: e.getParameter('index'),
-        selectedSectionId: e.getParameter('props').id,
-        section: e.getParameters()
+      enrichEventWithDetails(e, {
+        selectedSectionIndex: e.detail.index,
+        selectedSectionId: e.props.id,
+        section: e.detail
       })
     );
   }, 500);
@@ -285,10 +285,10 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
     (e) => {
       isProgrammaticallyScrolled.current = true;
       if (mode === ObjectPageMode.IconTabBar) {
-        const sectionId = e.getParameter('section').props?.id;
+        const sectionId = e.detail.section.props?.id;
         setInternalSelectedSectionId(sectionId);
       }
-      const subSection = e.getParameter('subSection');
+      const subSection = e.detail.subSection;
       setSelectedSubSectionId(subSection.props.id);
     },
     [mode, setInternalSelectedSectionId, setSelectedSubSectionId, isProgrammaticallyScrolled]
@@ -296,7 +296,7 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
 
   const onToggleHeaderContentVisibility = useCallback(
     (e) => {
-      const srcElement = e.getHtmlSourceElement();
+      const srcElement = e.target;
       const shouldHideHeader = srcElement.icon === 'slim-arrow-up';
       if (shouldHideHeader) {
         objectPageRef.current.classList.add(classes.headerCollapsed);

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -41,7 +41,7 @@ const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
       titleClasses.put(classes.uppercase);
     }
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['id']);
 
     return (
       <section

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -58,7 +58,7 @@ const ObjectPageSubSection: FC<ObjectPageSubSectionPropTypes> = forwardRef(
       subSectionClassName.put(className);
     }
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['id']);
 
     return (
       <div

--- a/packages/main/src/components/Page/index.tsx
+++ b/packages/main/src/components/Page/index.tsx
@@ -1,5 +1,5 @@
 import '@ui5/webcomponents-icons/dist/icons/navigation-left-arrow';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Bar } from '@ui5/webcomponents-react/lib/Bar';
@@ -22,7 +22,7 @@ export interface PagePropTypes extends CommonProps {
   showBackButton?: boolean;
   showFooter?: boolean;
   showHeader?: boolean;
-  onNavButtonPress?: (e: Event) => void;
+  onNavButtonPress?: (e: CustomEvent) => void;
   children: ReactElement<any> | Array<ReactElement<any>> | ReactNode;
 }
 
@@ -55,7 +55,7 @@ const Page: FC<PagePropTypes> = forwardRef((props: PagePropTypes, ref: Ref<HTMLD
   const handleNavBackButtonPress = useCallback(
     (e) => {
       if (typeof onNavButtonPress === 'function') {
-        onNavButtonPress(Event.of(null, e.getOriginalEvent()));
+        onNavButtonPress(enrichEventWithDetails(e));
       }
     },
     [onNavButtonPress]

--- a/packages/main/src/components/Page/index.tsx
+++ b/packages/main/src/components/Page/index.tsx
@@ -22,8 +22,8 @@ export interface PagePropTypes extends CommonProps {
   showBackButton?: boolean;
   showFooter?: boolean;
   showHeader?: boolean;
-  onNavButtonPress?: (e: CustomEvent) => void;
-  children: ReactElement<any> | Array<ReactElement<any>> | ReactNode;
+  onNavButtonPress?: (e: CustomEvent<{}>) => void;
+  children: ReactElement<any> | ReactElement<any>[] | ReactNode;
 }
 
 const useStyles = createComponentStyles(styles, {

--- a/packages/main/src/components/Page/index.tsx
+++ b/packages/main/src/components/Page/index.tsx
@@ -98,7 +98,7 @@ const Page: FC<PagePropTypes> = forwardRef((props: PagePropTypes, ref: Ref<HTMLD
 
   pageContainer.put(classes[`background${backgroundDesign}`]);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onNavButtonPress']);
 
   return (
     <div ref={ref} className={pageContainer.valueOf()} style={style} title={tooltip} slot={slot} {...passThroughProps}>

--- a/packages/main/src/components/SegmentedButton/SegmentedButton.test.tsx
+++ b/packages/main/src/components/SegmentedButton/SegmentedButton.test.tsx
@@ -20,7 +20,7 @@ describe('SegmentedButton', () => {
       .last()
       .simulate('click');
     wrapper.update();
-    expect(getEventFromCallback(callback).getParameter('selectedKey')).toEqual('btn-2');
+    expect(getEventFromCallback(callback).detail.selectedKey).toEqual('btn-2');
   });
 
   test('Update Selection via API', () => {

--- a/packages/main/src/components/SegmentedButton/index.tsx
+++ b/packages/main/src/components/SegmentedButton/index.tsx
@@ -24,7 +24,7 @@ export interface SegmentedButtonPropTypes extends CommonProps {
   disabled?: boolean;
   selectedKey?: SelectedKey;
   children: ReactNode | ReactNode[];
-  onItemSelected?: (event: CustomEvent) => void;
+  onItemSelected?: (event: CustomEvent<{ selectedKey: string | number }>) => void;
 }
 
 const styles = {

--- a/packages/main/src/components/SegmentedButton/index.tsx
+++ b/packages/main/src/components/SegmentedButton/index.tsx
@@ -115,7 +115,7 @@ const SegmentedButton: FC<SegmentedButtonPropTypes> = forwardRef(
       });
     }, [children, listRef]);
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['onItemSelected']);
 
     return (
       <ul

--- a/packages/main/src/components/SegmentedButton/index.tsx
+++ b/packages/main/src/components/SegmentedButton/index.tsx
@@ -1,5 +1,5 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
@@ -24,7 +24,7 @@ export interface SegmentedButtonPropTypes extends CommonProps {
   disabled?: boolean;
   selectedKey?: SelectedKey;
   children: ReactNode | ReactNode[];
-  onItemSelected?: (event: Event) => void;
+  onItemSelected?: (event: CustomEvent) => void;
 }
 
 const styles = {
@@ -80,11 +80,11 @@ const SegmentedButton: FC<SegmentedButtonPropTypes> = forwardRef(
 
     const handleSegmentedButtonItemSelected = useCallback(
       (originalOnclick) => (e) => {
-        const newSelectedKey = e.getParameter('selectedKey');
+        const newSelectedKey = e.detail.selectedKey;
         if (newSelectedKey !== internalSelectedKey) {
           setSelectedKey(newSelectedKey);
           if (typeof onItemSelected === 'function') {
-            onItemSelected(Event.of(null, e.getOriginalEvent(), e.getParameters()));
+            onItemSelected(enrichEventWithDetails(e, e.detail));
           }
         }
         if (typeof originalOnclick === 'function') {

--- a/packages/main/src/components/SegmentedButton/index.tsx
+++ b/packages/main/src/components/SegmentedButton/index.tsx
@@ -59,10 +59,7 @@ const SegmentedButton: FC<SegmentedButtonPropTypes> = forwardRef(
     const [internalSelectedKey, setSelectedKey] = useState(() => {
       if (selectedKey) return selectedKey;
       const firstChild: any = Children.toArray(children)[0];
-      if (firstChild && firstChild.props) {
-        return firstChild.props.id;
-      }
-      return null;
+      return firstChild?.props?.id ?? null;
     });
 
     useEffect(() => {

--- a/packages/main/src/components/SegmentedButtonItem/SegmentedButtonItem.test.tsx
+++ b/packages/main/src/components/SegmentedButtonItem/SegmentedButtonItem.test.tsx
@@ -43,7 +43,7 @@ describe('SegmentedButtonItem', () => {
     const wrapper = mount(<SegmentedButtonItem id={1} icon={<Icon name="add" />} onClick={callback} />);
     wrapper.simulate('click');
     expect(wrapper.render()).toMatchSnapshot();
-    expect(getEventFromCallback(callback).getParameter('selectedKey')).toEqual(1);
+    expect(getEventFromCallback(callback).detail.selectedKey).toEqual(1);
   });
 
   createPassThroughPropsTest(SegmentedButtonItem);

--- a/packages/main/src/components/SegmentedButtonItem/index.tsx
+++ b/packages/main/src/components/SegmentedButtonItem/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
@@ -12,7 +12,7 @@ export interface SegmentedButtonItemPropTypes extends CommonProps {
   disabled?: boolean;
   children?: string;
   width?: CSSProperties['width'];
-  onClick?: (e: Event) => void;
+  onClick?: (e: CustomEvent) => void;
 }
 
 const useStyles = createComponentStyles(styles, { name: 'SegmentedButtonItem' });
@@ -52,7 +52,7 @@ const SegmentedButtonItem: FC<SegmentedButtonItemPropTypes> = forwardRef(
     const handleOnClick = useCallback(
       (e) => {
         if (!disabled && typeof onClick === 'function') {
-          onClick(Event.of(null, e, { selectedKey: id }));
+          onClick(enrichEventWithDetails(e, { selectedKey: id }));
         }
       },
       [onClick, disabled, id]

--- a/packages/main/src/components/SegmentedButtonItem/index.tsx
+++ b/packages/main/src/components/SegmentedButtonItem/index.tsx
@@ -12,7 +12,7 @@ export interface SegmentedButtonItemPropTypes extends CommonProps {
   disabled?: boolean;
   children?: string;
   width?: CSSProperties['width'];
-  onClick?: (e: CustomEvent) => void;
+  onClick?: (e: CustomEvent<{ selectedKey: string | number }>) => void;
 }
 
 const useStyles = createComponentStyles(styles, { name: 'SegmentedButtonItem' });

--- a/packages/main/src/components/SegmentedButtonItem/index.tsx
+++ b/packages/main/src/components/SegmentedButtonItem/index.tsx
@@ -69,7 +69,7 @@ const SegmentedButtonItem: FC<SegmentedButtonItemPropTypes> = forwardRef(
       };
     }, [style, width]);
 
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['onClick']);
 
     return (
       <li

--- a/packages/main/src/components/SideNavigation/SideNavigation.test.tsx
+++ b/packages/main/src/components/SideNavigation/SideNavigation.test.tsx
@@ -9,7 +9,7 @@ describe('SideNavigation', () => {
   test('Expanded', () => {
     const wrapper = mount(
       <SideNavigation
-        openState={SideNavigationOpenState.Expandend}
+        openState={SideNavigationOpenState.Expanded}
         selectedId={'sales-leads'}
         footerItems={[
           <SideNavigationListItem id="1" text="Legal Information" icon="compare" />,
@@ -33,7 +33,7 @@ describe('SideNavigation', () => {
   test('Expanded without Icons', () => {
     const wrapper = mount(
       <SideNavigation
-        openState={SideNavigationOpenState.Expandend}
+        openState={SideNavigationOpenState.Expanded}
         selectedId={'sales-leads'}
         noIcons
         footerItems={[

--- a/packages/main/src/components/SideNavigation/index.tsx
+++ b/packages/main/src/components/SideNavigation/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/lib/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { List } from '@ui5/webcomponents-react/lib/List';
@@ -13,8 +13,8 @@ export interface SideNavigationProps extends CommonProps {
   children?: ReactNode;
   footerItems?: ReactNode[];
   selectedId?: string | number;
-  onItemSelect?: (event: Event) => void;
-  onItemClick?: (event: Event) => void;
+  onItemSelect?: (event: CustomEvent<{ selectedItem: HTMLElement; selectedId: string | number }>) => void;
+  onItemClick?: (event: CustomEvent<{ selectedItem: HTMLElement; selectedId: string | number }>) => void;
   /*
    * Flag whether to show icons or not. Will only take effect in <code>openState: Expanded</code>
    */
@@ -75,13 +75,8 @@ const SideNavigation: FC<SideNavigationProps> = forwardRef((props: SideNavigatio
 
   const onListItemSelected = useCallback(
     (e) => {
-      const listItem = e.getParameter('item');
-      onItemClick(
-        Event.of(null, e, {
-          selectedItem: listItem,
-          selectedId: listItem.dataset.id
-        })
-      );
+      const listItem = e.detail.item;
+      onItemClick(enrichEventWithDetails(e, { selectedItem: listItem, selectedId: listItem.dataset.id }));
 
       if (lastFiredSelection === listItem.dataset.id) {
         return;
@@ -89,7 +84,7 @@ const SideNavigation: FC<SideNavigationProps> = forwardRef((props: SideNavigatio
       setInternalSelectedId(listItem.dataset.id);
 
       onItemSelect(
-        Event.of(null, e, {
+        enrichEventWithDetails(e, {
           selectedItem: listItem,
           selectedId: listItem.dataset.id
         })

--- a/packages/main/src/components/SideNavigation/index.tsx
+++ b/packages/main/src/components/SideNavigation/index.tsx
@@ -94,7 +94,7 @@ const SideNavigation: FC<SideNavigationProps> = forwardRef((props: SideNavigatio
     [onItemSelect, onItemClick, setInternalSelectedId]
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const passThroughProps = usePassThroughHtmlProps(props, ['onItemSelect', 'onItemClick']);
 
   return (
     <div ref={ref} className={sideNavigationClasses.valueOf()} style={style} title={tooltip} {...passThroughProps}>

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -1,5 +1,5 @@
 import '@ui5/webcomponents-icons/dist/icons/navigation-down-arrow';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from "@ui5/webcomponents-react-base/lib/Utils";
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/lib/usePassThroughHtmlProps';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
@@ -27,7 +27,7 @@ export interface VariantManagementPropTypes extends CommonProps {
   initialSelectedKey?: string;
   closeOnItemSelect?: boolean;
   variantItems: VariantItem[];
-  onSelect?: (event: Event) => void;
+  onSelect?: (event: CustomEvent<{item: HTMLElement; selectedItem: VariantItem}>) => void;
   level?: TitleLevel;
   disabled?: boolean;
 }
@@ -140,10 +140,10 @@ const VariantManagement: FC<VariantManagementPropTypes> = forwardRef(
 
     const handleVariantItemSelect = useCallback(
       (event) => {
-        const newSelectedKey = event.getParameter('item').dataset.key;
+        const newSelectedKey = event.detail.item.dataset.key;
         const selectedItem = getItemByKey(newSelectedKey) || variantItems[0];
         setSelectedKey(newSelectedKey);
-        onSelect(Event.of(null, event.getOriginalEvent(), { selectedItem }));
+        onSelect(enrichEventWithDetails(event, { ...event.details, selectedItem}));
         if (closeOnItemSelect) {
           handleCancelButtonClick();
         }

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -150,7 +150,7 @@ const VariantManagement: FC<VariantManagementPropTypes> = forwardRef(
       },
       [handleCancelButtonClick, closeOnItemSelect, selectedKey, variantItems, setSelectedKey]
     );
-    const passThroughProps = usePassThroughHtmlProps(props);
+    const passThroughProps = usePassThroughHtmlProps(props, ['onSelect']);
 
     return (
       <Popover

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -1,5 +1,5 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
+import { polyfillDeprecatedEventAPI } from "@ui5/webcomponents-react-base/lib/Utils";
 import React, {
   Children,
   cloneElement,
@@ -62,29 +62,9 @@ export const withWebComponent = <T extends any>(
       );
   };
 
-  const createEventWrapperFor = (eventIdentifier, eventHandler) => (e) => {
-    let payload = Object.keys(getWebComponentMetadata().getProperties()).reduce((acc, val) => {
-      if (val.startsWith('_')) {
-        return acc;
-      }
-      acc[val] = e.target[toKebabCase(val)];
-      return acc;
-    }, {});
-
-    const eventMeta = getWebComponentMetadata().getEvents()[eventIdentifier] || {};
-
-    payload = Object.keys(eventMeta).reduce((acc, val) => {
-      if (val === 'detail' && e[val]) {
-        return {
-          ...acc,
-          ...e[val]
-        };
-      }
-      acc[val] = (e.detail && e.detail[val]) || e[val];
-      return acc;
-    }, payload);
-    // TODO: Pass Web Component Ref in here?
-    eventHandler(Event.of(null, e, payload));
+  const createEventWrapperFor = (eventIdentifier, eventHandler) => (event) => {
+    polyfillDeprecatedEventAPI(event);
+    return eventHandler(event);
   };
 
   const WithWebComponent = React.forwardRef((props: T & WithWebComponentPropTypes, wcRef: RefObject<Ui5DomRef>) => {

--- a/packages/main/src/webComponents/Button/index.tsx
+++ b/packages/main/src/webComponents/Button/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Button from '@ui5/webcomponents/dist/Button';
@@ -11,7 +11,7 @@ export interface ButtonPropTypes extends WithWebComponentPropTypes {
   icon?: string; // @generated
   iconEnd?: boolean; // @generated
   submits?: boolean; // @generated
-  onClick?: (event: Event) => void; // @generated
+  onClick?: (event: CustomEvent) => void; // @generated
   children?: string; // @generated
 }
 

--- a/packages/main/src/webComponents/Calendar/index.tsx
+++ b/packages/main/src/webComponents/Calendar/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CalendarType } from '@ui5/webcomponents-react/lib/CalendarType';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Calendar from '@ui5/webcomponents/dist/Calendar';
@@ -10,7 +10,7 @@ export interface CalendarPropTypes extends WithWebComponentPropTypes {
   primaryCalendarType?: CalendarType; // @generated
   selectedDates?: number[]; // @generated
   formatPattern?: string; // @generated
-  onSelectedDatesChange?: (event: Event) => void; // @generated
+  onSelectedDatesChange?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/Card/index.tsx
+++ b/packages/main/src/webComponents/Card/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Card from '@ui5/webcomponents/dist/Card';
 import React, { FC, ReactNode } from 'react';
@@ -10,7 +10,7 @@ export interface CardPropTypes extends WithWebComponentPropTypes {
   status?: string; // @generated
   headerInteractive?: boolean; // @generated
   avatar?: ReactNode; // @generated
-  onHeaderClick?: (event: Event) => void; // @generated
+  onHeaderClick?: (event: CustomEvent) => void; // @generated
   children?: ReactNode | ReactNode[]; // @generated
 }
 

--- a/packages/main/src/webComponents/CheckBox/index.tsx
+++ b/packages/main/src/webComponents/CheckBox/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5CheckBox from '@ui5/webcomponents/dist/CheckBox';
@@ -13,7 +13,7 @@ export interface CheckBoxPropTypes extends WithWebComponentPropTypes {
   valueState?: ValueState; // @generated
   wrap?: boolean; // @generated
   name?: string; // @generated
-  onChange?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/DatePicker/index.tsx
+++ b/packages/main/src/webComponents/DatePicker/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { CalendarType } from '@ui5/webcomponents-react/lib/CalendarType';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
@@ -15,8 +15,8 @@ export interface DatePickerPropTypes extends WithWebComponentPropTypes {
   readonly?: boolean; // @generated
   placeholder?: string; // @generated
   name?: string; // @generated
-  onChange?: (event: Event) => void; // @generated
-  onInput?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
+  onInput?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/Dialog/index.tsx
+++ b/packages/main/src/webComponents/Dialog/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Dialog from '@ui5/webcomponents/dist/Dialog';
@@ -12,10 +12,10 @@ export interface DialogPropTypes extends WithWebComponentPropTypes {
   hideHeader?: boolean; // @generated
   headerText?: string; // @generated
   stretch?: boolean; // @generated
-  onBeforeOpen?: (event: Event) => void; // @generated
-  onAfterOpen?: (event: Event) => void; // @generated
-  onBeforeClose?: (event: Event) => void; // @generated
-  onAfterClose?: (event: Event) => void; // @generated
+  onBeforeOpen?: (event: CustomEvent) => void; // @generated
+  onAfterOpen?: (event: CustomEvent) => void; // @generated
+  onBeforeClose?: (event: CustomEvent) => void; // @generated
+  onAfterClose?: (event: CustomEvent) => void; // @generated
   header?: ReactNode; // @generated
   footer?: ReactNode; // @generated
   content?: ReactNode | ReactNode[];

--- a/packages/main/src/webComponents/Input/index.tsx
+++ b/packages/main/src/webComponents/Input/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { InputType } from '@ui5/webcomponents-react/lib/InputType';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
@@ -15,10 +15,10 @@ export interface InputPropTypes extends WithWebComponentPropTypes {
   valueState?: ValueState; // @generated
   name?: string; // @generated
   showSuggestions?: boolean; // @generated
-  onChange?: (event: Event) => void; // @generated
-  onInput?: (event: Event) => void; // @generated
-  onSubmit?: (event: Event) => void; // @generated
-  onSuggestionItemSelect?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
+  onInput?: (event: CustomEvent) => void; // @generated
+  onSubmit?: (event: CustomEvent) => void; // @generated
+  onSuggestionItemSelect?: (event: CustomEvent) => void; // @generated
   icon?: ReactNode; // @generated
   children?: string;
 }

--- a/packages/main/src/webComponents/Link/index.tsx
+++ b/packages/main/src/webComponents/Link/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { LinkDesign } from '@ui5/webcomponents-react/lib/LinkDesign';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Link from '@ui5/webcomponents/dist/Link';
@@ -11,7 +11,7 @@ export interface LinkPropTypes extends WithWebComponentPropTypes {
   target?: string; // @generated
   design?: LinkDesign; // @generated
   wrap?: boolean; // @generated
-  onClick?: (event: Event) => void; // @generated
+  onClick?: (event: CustomEvent) => void; // @generated
   children?: string; // @generated
 }
 

--- a/packages/main/src/webComponents/List/index.tsx
+++ b/packages/main/src/webComponents/List/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ListMode } from '@ui5/webcomponents-react/lib/ListMode';
 import { ListSeparators } from '@ui5/webcomponents-react/lib/ListSeparators';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
@@ -13,9 +13,9 @@ export interface ListPropTypes extends WithWebComponentPropTypes {
   mode?: ListMode;
   noDataText?: string;
   separators?: ListSeparators;
-  onItemClick?: (event: Event) => void;
-  onItemDelete?: (event: Event) => void;
-  onSelectionChange?: (event: Event) => void;
+  onItemClick?: (event: CustomEvent) => void;
+  onItemDelete?: (event: CustomEvent) => void;
+  onSelectionChange?: (event: CustomEvent) => void;
   header?: ReactNode;
   children?: ReactNode | ReactNode[];
 }

--- a/packages/main/src/webComponents/MessageStrip/index.tsx
+++ b/packages/main/src/webComponents/MessageStrip/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { MessageStripType } from '@ui5/webcomponents-react/lib/MessageStripType';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5MessageStrip from '@ui5/webcomponents/dist/MessageStrip';
@@ -10,7 +10,7 @@ export interface MessageStripPropTypes extends WithWebComponentPropTypes {
   icon?: string; // @generated
   noIcon?: boolean; // @generated
   noCloseButton?: boolean; // @generated
-  onClose?: (event: Event) => void; // @generated
+  onClose?: (event: CustomEvent) => void; // @generated
   children?: string; // @generated
 }
 

--- a/packages/main/src/webComponents/MultiComboBox/index.tsx
+++ b/packages/main/src/webComponents/MultiComboBox/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import '@ui5/webcomponents/dist/features/InputSuggestions';
@@ -13,9 +13,9 @@ export interface MultiComboBoxPropTypes extends WithWebComponentPropTypes {
   disabled?: boolean; // @generated
   valueState?: ValueState; // @generated
   readonly?: boolean; // @generated
-  onChange?: (event: Event) => void; // @generated
-  onInput?: (event: Event) => void; // @generated
-  onSelectionChange?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
+  onInput?: (event: CustomEvent) => void; // @generated
+  onSelectionChange?: (event: CustomEvent) => void; // @generated
   children?: ReactNode[]; // @generated
 }
 

--- a/packages/main/src/webComponents/Panel/index.tsx
+++ b/packages/main/src/webComponents/Panel/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { PanelAccessibleRoles } from '@ui5/webcomponents-react/lib/PanelAccessibleRoles';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Panel from '@ui5/webcomponents/dist/Panel';
@@ -10,7 +10,7 @@ export interface PanelPropTypes extends WithWebComponentPropTypes {
   fixed?: boolean; // @generated
   collapsed?: boolean; // @generated
   accessibleRole?: PanelAccessibleRoles; // @generated
-  onToggle?: (event: Event) => void; // @generated
+  onToggle?: (event: CustomEvent) => void; // @generated
   header?: ReactNode; // @generated
   children?: ReactNode | ReactNode[];
 }

--- a/packages/main/src/webComponents/Popover/demo.stories.tsx
+++ b/packages/main/src/webComponents/Popover/demo.stories.tsx
@@ -1,4 +1,5 @@
 import { boolean, select, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { Button } from '@ui5/webcomponents-react/lib/Button';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import { Popover } from '@ui5/webcomponents-react/lib/Popover';
@@ -15,16 +16,16 @@ export const defaultStory = () => (
   <Popover
     initialFocus={'generatedString'}
     headerText={text('headerText', 'Test Popover')}
-    placementType={select('placementType', PlacementType)}
-    horizontalAlign={select('horizontalAlign', PopoverHorizontalAlign, null)}
-    verticalAlign={select('verticalAlign', PopoverVerticalAlign, null)}
+    placementType={select('placementType', PlacementType, PlacementType.Bottom)}
+    horizontalAlign={select('horizontalAlign', PopoverHorizontalAlign, PopoverHorizontalAlign.Center)}
+    verticalAlign={select('verticalAlign', PopoverVerticalAlign, PopoverVerticalAlign.Center)}
     modal={boolean('modal', false)}
     noArrow={boolean('noArrow', false)}
     open={boolean('open', false)}
-    onBeforeOpen={null}
-    onAfterOpen={null}
-    onBeforeClose={null}
-    onAfterClose={null}
+    onBeforeOpen={action('onBeforeOpen')}
+    onAfterOpen={action('onAfterOpen')}
+    onBeforeClose={action('onBeforeClose')}
+    onAfterClose={action('onAfterClose')}
     content={<div>Test</div>}
     footer={
       <div

--- a/packages/main/src/webComponents/Popover/index.tsx
+++ b/packages/main/src/webComponents/Popover/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsolidatedRef';
 import { PlacementType } from '@ui5/webcomponents-react/lib/PlacementType';
 import { PopoverHorizontalAlign } from '@ui5/webcomponents-react/lib/PopoverHorizontalAlign';
@@ -18,10 +18,10 @@ export interface PopoverPropTypes extends WithWebComponentPropTypes {
   modal?: boolean; // @generated
   noArrow?: boolean; // @generated
   allowTargetOverlap?: boolean; // @generated
-  onBeforeOpen?: (event: Event) => void; // @generated
-  onAfterOpen?: (event: Event) => void; // @generated
-  onBeforeClose?: (event: Event) => void; // @generated
-  onAfterClose?: (event: Event) => void; // @generated
+  onBeforeOpen?: (event: CustomEvent) => void; // @generated
+  onAfterOpen?: (event: CustomEvent) => void; // @generated
+  onBeforeClose?: (event: CustomEvent) => void; // @generated
+  onAfterClose?: (event: CustomEvent) => void; // @generated
   header?: ReactNode; // @generated
   footer?: ReactNode; // @generated
   content?: ReactNode | ReactNode[];

--- a/packages/main/src/webComponents/ProductSwitchItem/index.tsx
+++ b/packages/main/src/webComponents/ProductSwitchItem/index.tsx
@@ -1,5 +1,5 @@
 import UI5ProductSwitchItem from '@ui5/webcomponents-fiori/dist/ProductSwitchItem';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import React, { FC } from 'react';
 import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
@@ -10,7 +10,7 @@ export interface ProductSwitchItemPropTypes extends WithWebComponentPropTypes {
   icon?: string; // @generated
   target?: string; // @generated
   targetSrc?: string; // @generated
-  onClick?: (event: Event) => void; // @generated
+  onClick?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/RadioButton/index.tsx
+++ b/packages/main/src/webComponents/RadioButton/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5RadioButton from '@ui5/webcomponents/dist/RadioButton';
@@ -13,7 +13,7 @@ export interface RadioButtonPropTypes extends WithWebComponentPropTypes {
   valueState?: ValueState; // @generated
   name?: string; // @generated
   value?: string; // @generated
-  onSelect?: (event: Event) => void; // @generated
+  onSelect?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/Select/index.tsx
+++ b/packages/main/src/webComponents/Select/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ValueState } from '@ui5/webcomponents-react/lib/ValueState';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Select from '@ui5/webcomponents/dist/Select';
@@ -8,7 +8,7 @@ import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
 export interface SelectPropTypes extends WithWebComponentPropTypes {
   disabled?: boolean; // @generated
   valueState?: ValueState; // @generated
-  onChange?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
   children?: ReactNode[]; // @generated
 }
 

--- a/packages/main/src/webComponents/ShellBar/demo.stories.tsx
+++ b/packages/main/src/webComponents/ShellBar/demo.stories.tsx
@@ -34,7 +34,7 @@ export const generatedDefaultStory = () => (
       onProfileClick={action('onProfileClick')}
       onProductSwitchClick={(e) => {
         // @ts-ignore
-        document.getElementById('product-switch-popover').openBy(e.getParameter('targetRef'));
+        document.getElementById('product-switch-popover').openBy(e.detail.targetRef);
       }}
       searchField={null}
       startButton={null}

--- a/packages/main/src/webComponents/ShellBar/index.tsx
+++ b/packages/main/src/webComponents/ShellBar/index.tsx
@@ -1,5 +1,5 @@
 import UI5ShellBar from '@ui5/webcomponents-fiori/dist/ShellBar';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import React, { FC, ReactNode } from 'react';
 import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
@@ -13,12 +13,12 @@ export interface ShellBarPropTypes extends WithWebComponentPropTypes {
   showNotifications?: boolean; // @generated
   showProductSwitch?: boolean; // @generated
   showCoPilot?: boolean; // @generated
-  onNotificationsClick?: (event: Event) => void; // @generated
-  onProfileClick?: (event: Event) => void; // @generated
-  onProductSwitchClick?: (event: Event) => void; // @generated
-  onLogoClick?: (event: Event) => void; // @generated
-  onCoPilotClick?: (event: Event) => void; // @generated
-  onMenuItemClick?: (event: Event) => void; // @generated
+  onNotificationsClick?: (event: CustomEvent) => void; // @generated
+  onProfileClick?: (event: CustomEvent) => void; // @generated
+  onProductSwitchClick?: (event: CustomEvent) => void; // @generated
+  onLogoClick?: (event: CustomEvent) => void; // @generated
+  onCoPilotClick?: (event: CustomEvent) => void; // @generated
+  onMenuItemClick?: (event: CustomEvent) => void; // @generated
   children?: ReactNode; // @generated
   menuItems?: ReactNode; // @generated
   searchField?: ReactNode; // @generated

--- a/packages/main/src/webComponents/ShellBarItem/index.tsx
+++ b/packages/main/src/webComponents/ShellBarItem/index.tsx
@@ -1,5 +1,5 @@
 import UI5ShellBarItem from '@ui5/webcomponents-fiori/dist/ShellBarItem';
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import React, { FC } from 'react';
 import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
@@ -7,7 +7,7 @@ import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
 export interface ShellBarItemPropTypes extends WithWebComponentPropTypes {
   icon?: string; // @generated
   text?: string; // @generated
-  onItemClick?: (event: Event) => void; // @generated
+  onItemClick?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/Switch/index.tsx
+++ b/packages/main/src/webComponents/Switch/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Switch from '@ui5/webcomponents/dist/Switch';
 import React, { FC } from 'react';
@@ -10,7 +10,7 @@ export interface SwitchPropTypes extends WithWebComponentPropTypes {
   textOn?: string; // @generated
   textOff?: string; // @generated
   graphical?: boolean; // @generated
-  onChange?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/TabContainer/index.tsx
+++ b/packages/main/src/webComponents/TabContainer/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5TabContainer from '@ui5/webcomponents/dist/TabContainer';
 import React, { FC, ReactNode } from 'react';
@@ -8,7 +8,7 @@ export interface TabContainerPropTypes extends WithWebComponentPropTypes {
   fixed?: boolean;
   collapsed?: boolean;
   showOverflow?: boolean;
-  onItemSelect?: (event: Event) => any;
+  onItemSelect?: (event: CustomEvent) => any;
   children?: ReactNode | ReactNode[];
 }
 

--- a/packages/main/src/webComponents/TextArea/index.tsx
+++ b/packages/main/src/webComponents/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5TextArea from '@ui5/webcomponents/dist/TextArea';
 import React, { FC } from 'react';
@@ -15,7 +15,7 @@ export interface TextAreaPropTypes extends WithWebComponentPropTypes {
   growing?: boolean; // @generated
   growingMaxLines?: number; // @generated
   name?: string; // @generated
-  onChange?: (event: Event) => void; // @generated
+  onChange?: (event: CustomEvent) => void; // @generated
 }
 
 /**

--- a/packages/main/src/webComponents/TimelineItem/index.tsx
+++ b/packages/main/src/webComponents/TimelineItem/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5TimelineItem from '@ui5/webcomponents/dist/TimelineItem';
 import React, { FC, ReactNode } from 'react';
@@ -10,7 +10,7 @@ export interface TimelineItemPropTypes extends WithWebComponentPropTypes {
   itemNameClickable?: boolean; // @generated
   titleText?: string; // @generated
   subtitleText?: string; // @generated
-  onItemNameClick?: (event: Event) => void; // @generated
+  onItemNameClick?: (event: CustomEvent) => void; // @generated
   children?: ReactNode; // @generated
 }
 

--- a/packages/main/src/webComponents/ToggleButton/index.tsx
+++ b/packages/main/src/webComponents/ToggleButton/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ButtonDesign } from '@ui5/webcomponents-react/lib/ButtonDesign';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5ToggleButton from '@ui5/webcomponents/dist/ToggleButton';
@@ -12,7 +12,7 @@ export interface ToggleButtonPropTypes extends WithWebComponentPropTypes {
   iconEnd?: boolean; // @generated
   submits?: boolean; // @generated
   pressed?: boolean; // @generated
-  onClick?: (event: Event) => void; // @generated
+  onClick?: (event: CustomEvent) => void; // @generated
   children?: string; // @generated
 }
 

--- a/packages/main/src/webComponents/Token/index.tsx
+++ b/packages/main/src/webComponents/Token/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Token from '@ui5/webcomponents/dist/Token';
 import React, { FC, ReactNode, ReactNodeArray } from 'react';
@@ -7,8 +7,8 @@ import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
 export interface TokenPropTypes extends WithWebComponentPropTypes {
   selected?: boolean; // @generated
   readonly?: boolean; // @generated
-  onDelete?: (event: Event) => void; // @generated
-  onSelect?: (event: Event) => void; // @generated
+  onDelete?: (event: CustomEvent) => void; // @generated
+  onSelect?: (event: CustomEvent) => void; // @generated
   children?: ReactNode | ReactNodeArray; // @generated
 }
 

--- a/packages/main/src/webComponents/Tokenizer/index.tsx
+++ b/packages/main/src/webComponents/Tokenizer/index.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { withWebComponent } from '@ui5/webcomponents-react/lib/withWebComponent';
 import UI5Tokenizer from '@ui5/webcomponents/dist/Tokenizer';
 import React, { FC, ReactNode } from 'react';
@@ -7,8 +7,8 @@ import { WithWebComponentPropTypes } from '../../internal/withWebComponent';
 export interface TokenizerPropTypes extends WithWebComponentPropTypes {
   showMore?: boolean; // @generated
   disabled?: boolean; // @generated
-  onTokenDelete?: (event: Event) => void; // @generated
-  onShowMoreItemsPress?: (event: Event) => void; // @generated
+  onTokenDelete?: (event: CustomEvent) => void; // @generated
+  onShowMoreItemsPress?: (event: CustomEvent) => void; // @generated
   children?: ReactNode[]; // @generated
 }
 

--- a/shared/tests/utils.tsx
+++ b/shared/tests/utils.tsx
@@ -1,4 +1,4 @@
-import { Event } from '@ui5/webcomponents-react-base/lib/Event';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/lib/Utils';
 import { ThemeProvider } from '@ui5/webcomponents-react/lib/ThemeProvider';
 import { mount, shallow } from 'enzyme';
 import React, { ComponentType } from 'react';
@@ -10,7 +10,7 @@ export const modifyObjectProperty = (object: any, attr: string, value: any) => {
     writable: true
   });
 };
-export const getEventFromCallback = (callback, index = 0): Event => {
+export const getEventFromCallback = (callback, index = 0): CustomEvent<Record<string, unknown>> => {
   return callback.args[index][0];
 };
 export const setUserAgentString = (userAgent) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3310,7 +3310,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.2":
+"@types/react@*", "@types/react@16.9.2", "@types/react@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
   integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3310,7 +3310,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.2", "@types/react@^16.9.2":
+"@types/react@*", "@types/react@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
   integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==
@@ -14632,6 +14632,11 @@ proxy-from-env@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-polyfill@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/proxy-polyfill/-/proxy-polyfill-0.3.1.tgz#163d5283cf928dd8ddb5c5e88528e4ccd233496f"
+  integrity sha512-jywE1NIksgIGqZc4uF0QLbXGz2RcHQobsCkAW+8F0nr/6agap+TWksEAKyLnIBafPD88HT9qZR2ec0oomHdjcQ==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR is changing the eventing system of the library. We used to create an instance of a **custom** class called Event and wrapped the event in the following structure:
```ts
export class Event {
  readonly source: ReactNode;
  readonly originalEvent: HTMLEvent;
  readonly parameters: any;
  readonly htmlSource: EventTarget;
}
```
This API is incompatible with the UI5 Web Components API and therefore we decided to remove our custom event wrapper and use the `CustomEvent` API instead.
Now, all event handlers are called with an Object which is compatible with the `CustomEvent` API. Sometimes a UI5 Custom Event is passed, sometimes a React SyntheticEvent is passed and all details are in the `details` object.

For preventing breaking changes, I added all previous methods and a proxy for accessing the parameters object to the CustomEvent and added deprecation notices.

Closes #324 