### PR TITLE
fix(AnalyticalTable): remove z-index from Table Header

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
+++ b/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
@@ -16,7 +16,6 @@ const styles = {
   tableHeaderRow: {
     boxShadow: 'none !important',
     height: CssSizeVariables.sapWcrAnalyticalTableRowHeight,
-    zIndex: 1,
     position: 'relative'
   },
   th: {


### PR DESCRIPTION
z-index on Table Header caused issues when using table in an ObjectPage