### PR TITLE
fix(AnalyticalTable): prevent overflow if rows are selectable

### DIFF
--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -33,7 +33,6 @@ import {
 } from 'react-table';
 import { TableScaleWidthMode } from '../../enums/TableScaleWidthMode';
 import { CommonProps } from '../../interfaces/CommonProps';
-import { JSSTheme } from '../../interfaces/JSSTheme';
 import styles from './AnayticalTable.jss';
 import { ColumnHeader } from './ColumnHeader';
 import { DefaultColumn } from './defaults/Column';
@@ -227,11 +226,11 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
     useTableHeaderGroupStyling,
     useTableHeaderStyling,
     useTableRowStyling,
+    useRowSelectionColumn,
     useDynamicColumnWidths,
     useColumnsDependencies,
     useTableCellStyling,
     useToggleRowExpand,
-    useRowSelectionColumn,
     ...tableHooks
   );
 


### PR DESCRIPTION
register useRowSelectionColumn before useDynamicColumnWidths hook

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/master/docs/Guidelines.md#commit-message-style)
