### PR TITLE
fix(Charts - New): layouting fixes

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -20,28 +20,21 @@ import {
   YAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
+import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
-const formatYAxisTicks = (tick = '') => {
-  const splitTick = tick.split(' ');
-  return splitTick.length > 3
-    ? `${splitTick.slice(0, 3).join(' ')}...`
-    : tick.length > 11
-    ? `${tick.slice(0, 12)}...`
-    : tick;
-};
-
 const dimensionDefaults = {
-  formatter: formatYAxisTicks
+  formatter: defaultFormatter
 };
 
 const measureDefaults = {
-  formatter: (d) => d,
+  formatter: defaultFormatter,
   opacity: 1
 };
 
@@ -120,7 +113,8 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
       gridStroke: ThemingParameters.sapList_BorderColor,
       gridHorizontal: true,
       gridVertical: false,
-      legendPosition: 'top',
+      legendPosition: 'bottom',
+      legendHorizontalAlign: 'left',
       barGap: 3,
       zoomingTool: false,
       ...props.chartConfig
@@ -164,14 +158,9 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
   const isBigDataSet = dataset?.length > 30;
   const primaryDimensionAccessor = primaryDimension?.accessor;
 
-  const marginChart = useChartMargin(
-    dataset,
-    dimensions,
-    chartConfig.margin,
-    true,
-    dimensions.length > 1,
-    chartConfig.zoomingTool
-  );
+  const [width, legendPosition] = useLongestYAxisLabel(dataset, dimensions);
+
+  const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
 
   return (
     <ChartContainer
@@ -194,13 +183,13 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
           <XAxis
             interval={0}
             type="number"
-            tick={<XAxisTicks config={primaryMeasure} chartRef={chartRef} />}
+            tick={<XAxisTicks config={primaryMeasure} />}
             axisLine={chartConfig.xAxisVisible}
             tickLine={tickLineConfig}
             tickFormatter={primaryMeasure?.formatter}
           />
         )}
-        {(chartConfig.yAxisVisible) &&
+        {chartConfig.yAxisVisible &&
           dimensions.map((dimension, index) => {
             return (
               <YAxis
@@ -213,6 +202,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
                 tickLine={index < 1}
                 axisLine={index < 1}
                 yAxisId={index}
+                width={width}
               />
             );
           })}
@@ -234,7 +224,14 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
             />
           );
         })}
-        {!noLegend && <Legend verticalAlign={chartConfig.legendPosition} onClick={onItemLegendClick} />}
+        {!noLegend && (
+          <Legend
+            verticalAlign={chartConfig.legendPosition}
+            align={chartConfig.legendHorizontalAlign}
+            onClick={onItemLegendClick}
+            wrapperStyle={legendPosition}
+          />
+        )}
         {chartConfig.referenceLine && (
           <ReferenceLine
             stroke={chartConfig.referenceLine.color}

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -21,6 +21,7 @@ import {
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
+import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
@@ -162,6 +163,8 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
 
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
 
+  const [xAxisHeight] = useObserveXAxisHeights(chartRef, 1);
+
   return (
     <ChartContainer
       dataset={dataset}
@@ -187,6 +190,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<a
             axisLine={chartConfig.xAxisVisible}
             tickLine={tickLineConfig}
             tickFormatter={primaryMeasure?.formatter}
+            height={xAxisHeight}
           />
         )}
         {chartConfig.yAxisVisible &&

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -21,6 +21,7 @@ import {
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
+import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
@@ -165,6 +166,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
   const primaryDimensionAccessor = primaryDimension?.accessor;
 
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
+  const xAxisHeights = useObserveXAxisHeights(chartRef, props.dimensions.length);
 
   return (
     <ChartContainer
@@ -194,6 +196,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
                 tick={<XAxisTicks config={dimension} level={index} />}
                 tickLine={index < 1}
                 axisLine={index < 1}
+                height={xAxisHeights[index]}
               />
             );
           })}

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -24,6 +24,7 @@ import {
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
+import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
@@ -129,8 +130,6 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     dataset.some(({ type }) => type === 'bar') ? BAR_DEFAULT_PADDING : 0
   );
 
-  const [xAxisHeights, setXAxisHeights] = useState(props.dimensions.map(() => 20));
-
   const chartConfig = useMemo(() => {
     return {
       yAxisVisible: false,
@@ -207,6 +206,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
   const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset, layout === 'vertical' ? dimensions : measures);
 
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
+  const xAxisHeights = useObserveXAxisHeights(chartRef, layout === 'vertical' ? 1 : props.dimensions.length);
 
   const measureAxisProps = {
     axisLine: chartConfig.yAxisVisible,
@@ -233,12 +233,6 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
           });
           setCurrentBarWidth(totalBarWidth);
         }
-        const calculatedXAxisHeights = props.dimensions.map(() => 20);
-        chartRef.current?.querySelectorAll('.xAxis').forEach((xAxis, index) => {
-          calculatedXAxisHeights[index] = xAxis?.getBBox()?.height;
-        });
-        console.log(calculatedXAxisHeights);
-        setXAxisHeights(calculatedXAxisHeights);
       }
     }, 50),
     [chartRef, setCurrentBarWidth, layout, props.dimensions]

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -7,7 +7,8 @@ import { XAxisTicks } from '@ui5/webcomponents-react-charts/lib/components/XAxis
 import { YAxisTicks } from '@ui5/webcomponents-react-charts/lib/components/YAxisTicks';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/lib/next/ChartContainer';
 import { useLegendItemClick } from '@ui5/webcomponents-react-charts/lib/useLegendItemClick';
-import React, { FC, forwardRef, Ref, useCallback, useState, useMemo } from 'react';
+import debounce from 'lodash.debounce';
+import React, { FC, forwardRef, Ref, useCallback, useMemo, useState } from 'react';
 import {
   Area,
   Bar,
@@ -21,21 +22,22 @@ import {
   XAxis,
   YAxis
 } from 'recharts';
-import debounce from 'lodash.debounce';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
+import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
 const dimensionDefaults = {
-  formatter: (d) => d
+  formatter: defaultFormatter
 };
 
 const measureDefaults = {
-  formatter: (d) => d,
+  formatter: defaultFormatter,
   opacity: 1
 };
 
@@ -127,6 +129,8 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     dataset.some(({ type }) => type === 'bar') ? BAR_DEFAULT_PADDING : 0
   );
 
+  const [xAxisHeights, setXAxisHeights] = useState(props.dimensions.map(() => 20));
+
   const chartConfig = useMemo(() => {
     return {
       yAxisVisible: false,
@@ -134,7 +138,8 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
       gridStroke: ThemingParameters.sapList_BorderColor,
       gridHorizontal: true,
       gridVertical: false,
-      legendPosition: 'top',
+      legendPosition: 'bottom',
+      legendHorizontalAlign: 'left',
       zoomingTool: false,
       ...props.chartConfig
     };
@@ -160,33 +165,35 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
   const onDataPointClickInternal = useCallback(
     (payload, eventOrIndex, event) => {
       if (payload.name) {
-        typeof onDataPointClick === 'function' && onDataPointClick(
-          enrichEventWithDetails(event ?? eventOrIndex, {
-            value: payload.value.length ? payload.value[1] - payload.value[0] : payload.value,
-            dataIndex: payload.index ?? eventOrIndex,
-            dataKey: payload.value.length
-              ? Object.keys(payload).filter((key) =>
-                  payload.value.length
-                    ? payload[key] === payload.value[1] - payload.value[0]
-                    : payload[key] === payload.value && key !== 'value'
-                )[0]
-              : payload.dataKey ??
-                Object.keys(payload).find((key) => payload[key] === payload.value && key !== 'value'),
-            payload: payload.payload
-          })
-        );
+        typeof onDataPointClick === 'function' &&
+          onDataPointClick(
+            enrichEventWithDetails(event ?? eventOrIndex, {
+              value: payload.value.length ? payload.value[1] - payload.value[0] : payload.value,
+              dataIndex: payload.index ?? eventOrIndex,
+              dataKey: payload.value.length
+                ? Object.keys(payload).filter((key) =>
+                    payload.value.length
+                      ? payload[key] === payload.value[1] - payload.value[0]
+                      : payload[key] === payload.value && key !== 'value'
+                  )[0]
+                : payload.dataKey ??
+                  Object.keys(payload).find((key) => payload[key] === payload.value && key !== 'value'),
+              payload: payload.payload
+            })
+          );
       } else {
-        typeof onDataPointClick === 'function' && onDataPointClick(
-          enrichEventWithDetails(
-            {},
-            {
-              value: eventOrIndex.value,
-              dataKey: eventOrIndex.dataKey,
-              dataIndex: eventOrIndex.index,
-              payload: eventOrIndex.payload
-            }
-          )
-        );
+        typeof onDataPointClick === 'function' &&
+          onDataPointClick(
+            enrichEventWithDetails(
+              {},
+              {
+                value: eventOrIndex.value,
+                dataKey: eventOrIndex.dataKey,
+                dataIndex: eventOrIndex.index,
+                payload: eventOrIndex.payload
+              }
+            )
+          );
       }
     },
     [onDataPointClick]
@@ -197,14 +204,9 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
   const isBigDataSet = dataset?.length > 30 ?? false;
   const primaryDimensionAccessor = primaryDimension?.accessor;
 
-  const marginChart = useChartMargin(
-    dataset,
-    layout === 'vertical' ? dimensions : measures,
-    chartConfig.margin,
-    false,
-    dimensions.length > 1,
-    chartConfig.zoomingTool
-  );
+  const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset, layout === 'vertical' ? dimensions : measures);
+
+  const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
 
   const measureAxisProps = {
     axisLine: chartConfig.yAxisVisible,
@@ -231,9 +233,15 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
           });
           setCurrentBarWidth(totalBarWidth);
         }
+        const calculatedXAxisHeights = props.dimensions.map(() => 20);
+        chartRef.current?.querySelectorAll('.xAxis').forEach((xAxis, index) => {
+          calculatedXAxisHeights[index] = xAxis?.getBBox()?.height;
+        });
+        console.log(calculatedXAxisHeights);
+        setXAxisHeights(calculatedXAxisHeights);
       }
     }, 50),
-    [chartRef, setCurrentBarWidth, layout]
+    [chartRef, setCurrentBarWidth, layout, props.dimensions]
   );
 
   return (
@@ -269,27 +277,30 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
               axisProps.tick = <YAxisTicks config={dimension} level={index} />;
               axisProps.yAxisId = index;
               axisProps.padding = { top: currentBarWidth, bottom: currentBarWidth };
+              axisProps.width = yAxisWidth;
               AxisComponent = YAxis;
             } else {
               axisProps.dataKey = dimension.accessor;
-              axisProps.tick = <XAxisTicks config={dimension} chartRef={chartRef} level={index} />;
+              axisProps.tick = <XAxisTicks config={dimension} level={index} />;
               axisProps.xAxisId = index;
               axisProps.padding = { left: currentBarWidth, right: currentBarWidth };
+              axisProps.height = xAxisHeights[index];
+              // axisProps.height = 100
               AxisComponent = XAxis;
             }
 
             return <AxisComponent {...axisProps} />;
           })}
         {layout === 'horizontal' && (
-          <YAxis {...measureAxisProps} yAxisId="primary" tick={<YAxisTicks config={primaryMeasure} />} />
+          <YAxis
+            {...measureAxisProps}
+            yAxisId="primary"
+            width={yAxisWidth}
+            tick={<YAxisTicks config={primaryMeasure} />}
+          />
         )}
         {layout === 'vertical' && (
-          <XAxis
-            {...measureAxisProps}
-            xAxisId="primary"
-            type="number"
-            tick={<XAxisTicks config={primaryMeasure} chartRef={chartRef} />}
-          />
+          <XAxis {...measureAxisProps} xAxisId="primary" type="number" tick={<XAxisTicks config={primaryMeasure} />} />
         )}
 
         {chartConfig.secondYAxis?.dataKey && layout === 'horizontal' && (
@@ -324,11 +335,20 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
           />
         )}
         <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
-        {!noLegend && <Legend verticalAlign={chartConfig.legendPosition} onClick={onItemLegendClick} />}
+        {!noLegend && (
+          <Legend
+            verticalAlign={chartConfig.legendPosition}
+            align={chartConfig.legendHorizontalAlign}
+            onClick={onItemLegendClick}
+            wrapperStyle={legendPosition}
+          />
+        )}
         {measures?.map((element, index) => {
           const ChartElement = (ChartTypes[element.type] as any) as FC<any>;
 
-          const chartElementProps: any = {};
+          const chartElementProps: any = {
+            onAnimationEnd: updateChartPadding
+          };
           let labelPosition = 'top';
 
           switch (element.type) {
@@ -341,7 +361,6 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
               chartElementProps.dot = !isBigDataSet;
               break;
             case 'bar':
-              chartElementProps.onAnimationEnd = updateChartPadding;
               chartElementProps.fillOpacity = element.opacity;
               chartElementProps.strokeOpacity = element.opacity;
               chartElementProps.barSize = element.width;

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -20,11 +20,13 @@ import {
   YAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
+import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
 interface MeasureConfig extends IChartMeasure {
@@ -68,11 +70,11 @@ export interface LineChartProps extends RechartBaseProps {
 }
 
 const dimensionDefaults = {
-  formatter: (d) => d
+  formatter: defaultFormatter
 };
 
 const measureDefaults = {
-  formatter: (d) => d,
+  formatter: defaultFormatter,
   width: 1,
   opacity: 1
 };
@@ -101,7 +103,8 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
       gridStroke: ThemingParameters.sapList_BorderColor,
       gridHorizontal: true,
       gridVertical: false,
-      legendPosition: 'top',
+      legendPosition: 'bottom',
+      legendHorizontalAlign: 'left',
       zoomingTool: false,
       ...props.chartConfig
     };
@@ -150,14 +153,8 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
   const isBigDataSet = dataset?.length > 30 ?? false;
   const primaryDimensionAccessor = primaryDimension?.accessor;
 
-  const marginChart = useChartMargin(
-    dataset,
-    measures,
-    chartConfig.margin,
-    false,
-    dimensions.length > 1,
-    chartConfig.zoomingTool
-  );
+  const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset, measures);
+  const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
 
   return (
     <ChartContainer
@@ -184,7 +181,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
                 dataKey={dimension.accessor}
                 xAxisId={index}
                 interval={dimension?.interval ?? (isBigDataSet ? 'preserveStart' : 0)}
-                tick={<XAxisTicks config={dimension} chartRef={chartRef} level={index} />}
+                tick={<XAxisTicks config={dimension} level={index} />}
                 tickLine={index < 1}
                 axisLine={index < 1}
               />
@@ -197,6 +194,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
           tickFormatter={primaryMeasure?.formatter}
           interval={0}
           tick={<YAxisTicks config={primaryMeasure} />}
+          width={yAxisWidth}
         />
         {chartConfig.secondYAxis?.dataKey && (
           <YAxis
@@ -225,7 +223,14 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
             />
           );
         })}
-        {!noLegend && <Legend verticalAlign={chartConfig.legendPosition} onClick={onItemLegendClick} />}
+        {!noLegend && (
+          <Legend
+            verticalAlign={chartConfig.legendPosition}
+            align={chartConfig.legendHorizontalAlign}
+            onClick={onItemLegendClick}
+            wrapperStyle={legendPosition}
+          />
+        )}
         {chartConfig.referenceLine && (
           <ReferenceLine
             stroke={chartConfig.referenceLine.color}

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -21,6 +21,7 @@ import {
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
+import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartDimension } from '../../interfaces/IChartDimension';
@@ -155,6 +156,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
 
   const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset, measures);
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
+  const xAxisHeights = useObserveXAxisHeights(chartRef, props.dimensions.length);
 
   return (
     <ChartContainer
@@ -184,6 +186,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
                 tick={<XAxisTicks config={dimension} level={index} />}
                 tickLine={index < 1}
                 axisLine={index < 1}
+                height={xAxisHeights[index]}
               />
             );
           })}

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -4,6 +4,7 @@ import { useConsolidatedRef } from '@ui5/webcomponents-react-base/lib/useConsoli
 import { ChartContainer } from '@ui5/webcomponents-react-charts/lib/next/ChartContainer';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
 import { Bar, BarChart as MicroBarChartLib, Cell, Tooltip, XAxis, YAxis } from 'recharts';
+import { defaultFormatter } from '../../internal/defaults';
 import { BarChartPlaceholder } from '../BarChart/Placeholder';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
@@ -85,14 +86,14 @@ const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartPr
 
   const dimension: DimensionConfig = useMemo(
     () => ({
-      formatter: (d) => d,
+      formatter: defaultFormatter,
       ...props.dimension
     }),
     [props.dimension]
   );
   const measure: MeasureConfig = useMemo(
     () => ({
-      formatter: (d) => d,
+      formatter: defaultFormatter,
       ...props.measure
     }),
     [props.measure]
@@ -142,12 +143,7 @@ const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartPr
       tooltip={tooltip}
       slot={slot}
     >
-      <MicroBarChartLib
-        margin={microBarChartMargin}
-        layout='vertical'
-        data={dataset}
-        label={microBarChartLabel}
-      >
+      <MicroBarChartLib margin={microBarChartMargin} layout="vertical" data={dataset} label={microBarChartLabel}>
         <XAxis hide type="number" />
         <YAxis
           axisLine={false}

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -75,6 +75,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<a
     return {
       margin: { right: 30, left: 30, bottom: 30, top: 30, ...(props.chartConfig?.margin ?? {}) },
       legendPosition: 'bottom',
+      legendHorizontalAlign: 'center',
       paddingAngle: 0,
       ...props.chartConfig
     };
@@ -148,16 +149,22 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<a
         >
           {centerLabel && <Label position={'center'}>{centerLabel}</Label>}
           {dataset &&
-          dataset.map((data, index) => (
-            <Cell
-              key={index}
-              name={dimension.formatter(getValueByDataKey(data, dimension.accessor, ''))}
-              fill={measure.colors?.[index] ?? `var(--sapChart_OrderedColor_${(index % 11) + 1})`}
-            />
-          ))}
+            dataset.map((data, index) => (
+              <Cell
+                key={index}
+                name={dimension.formatter(getValueByDataKey(data, dimension.accessor, ''))}
+                fill={measure.colors?.[index] ?? `var(--sapChart_OrderedColor_${(index % 11) + 1})`}
+              />
+            ))}
         </Pie>
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle}/>
-        {!noLegend && <Legend verticalAlign={chartConfig.legendPosition} onClick={onItemLegendClick}/>}
+        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        {!noLegend && (
+          <Legend
+            verticalAlign={chartConfig.legendPosition}
+            align={chartConfig.legendHorizontalAlign}
+            onClick={onItemLegendClick}
+          />
+        )}
       </PieChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -8,6 +8,7 @@ import { Cell, Label, Legend, Pie, PieChart as PieChartLib, Tooltip } from 'rech
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
+import { defaultFormatter } from '../../internal/defaults';
 import { tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
 interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'color'> {
@@ -83,14 +84,14 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<a
 
   const dimension: DimensionConfig = useMemo(
     () => ({
-      formatter: (d) => d,
+      formatter: defaultFormatter,
       ...props.dimension
     }),
     [props.dimension]
   );
   const measure: MeasureConfig = useMemo(
     () => ({
-      formatter: (d) => d,
+      formatter: defaultFormatter,
       ...props.measure
     }),
     [props.measure]

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -20,6 +20,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { RechartBaseProps } from '../../interfaces/RechartBaseProps';
 import { ChartDataLabel } from '@ui5/webcomponents-react-charts/lib/components/ChartDataLabel';
+import { defaultFormatter } from '../../internal/defaults';
 import { tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
 interface MeasureConfig extends IChartMeasure {
@@ -60,7 +61,7 @@ const dimensionDefaults = {
 };
 
 const measureDefaults = {
-  formatter: (d) => d,
+  formatter: defaultFormatter,
   opacity: 0.5
 };
 

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -84,6 +84,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
   const chartConfig = useMemo(() => {
     return {
       legendPosition: 'bottom',
+      legendHorizontalAlign: 'center',
       dataLabel: true,
       polarGridType: 'circle',
       ...props.chartConfig
@@ -163,7 +164,13 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
           );
         })}
         <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
-        {!noLegend && <Legend verticalAlign={chartConfig.legendPosition} onClick={onItemLegendClick} />}
+        {!noLegend && (
+          <Legend
+            verticalAlign={chartConfig.legendPosition}
+            align={chartConfig.legendHorizontalAlign}
+            onClick={onItemLegendClick}
+          />
+        )}
       </RadarChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/hooks/useChartMargin.ts
+++ b/packages/charts/src/hooks/useChartMargin.ts
@@ -1,27 +1,11 @@
-import { getTextWidth, truncateLongLabel } from '@ui5/webcomponents-react-charts/lib/Utils';
 import { useMemo } from 'react';
-import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 
-export const useChartMargin = (dataset: unknown[], elements, margin, isBar?, hasSecondaryDimension?, hasZoomingTool?) =>
+export const useChartMargin = (margin, hasZoomingTool) =>
   useMemo(() => {
-    let marginLeft = 0;
-    const primaryElement = elements[0];
-    if (dataset instanceof Array && primaryElement) {
-      marginLeft = Math.max(
-        ...dataset
-          .map((item) =>
-            elements.map((elementConfig) =>
-              truncateLongLabel(primaryElement.formatter(getValueByDataKey(item, elementConfig.accessor, '')))
-            )
-          )
-          .flat()
-          .map(getTextWidth)
-      );
-    }
     return {
-      right: margin?.right ?? 60,
-      top: margin?.top ?? hasZoomingTool ? 40 : 10,
-      bottom: margin?.bottom ?? (!isBar && hasSecondaryDimension) ? 100 : 30,
-      left: margin?.left ?? marginLeft / 2
+      right: margin?.right ?? 30,
+      top: margin?.top ?? hasZoomingTool ? 40 : 20,
+      bottom: margin?.bottom ?? 20,
+      left: margin?.left ?? 10
     };
-  }, [dataset, elements, margin, hasSecondaryDimension, hasZoomingTool]);
+  }, [margin, hasZoomingTool]);

--- a/packages/charts/src/hooks/useLongestYAxisLabel.ts
+++ b/packages/charts/src/hooks/useLongestYAxisLabel.ts
@@ -1,0 +1,23 @@
+import { getTextWidth } from '@ui5/webcomponents-react-charts/lib/Utils';
+import { useMemo } from 'react';
+import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
+import { defaultMaxYAxisWidth } from '../internal/defaults';
+
+export const useLongestYAxisLabel = (dataset: unknown[], elements): [number, object] =>
+  useMemo(() => {
+    let labelLength = 0;
+    const primaryElement = elements[0];
+
+    if (dataset instanceof Array && primaryElement) {
+      const resolveAllMeasureLabels = (item): string[] => {
+        return elements.map((elementConfig) =>
+          primaryElement.formatter(getValueByDataKey(item, elementConfig.accessor, ''))
+        );
+      };
+      labelLength = Math.max(...dataset.map(resolveAllMeasureLabels).flat().map(getTextWidth));
+      labelLength += 8;
+    }
+
+    labelLength = Math.min(labelLength, defaultMaxYAxisWidth);
+    return [labelLength, { marginLeft: labelLength, maxWidth: `calc(100% - ${labelLength + 10}px)` }];
+  }, [dataset, elements]);

--- a/packages/charts/src/hooks/useObserveXAxisHeights.ts
+++ b/packages/charts/src/hooks/useObserveXAxisHeights.ts
@@ -1,0 +1,12 @@
+import { RefObject } from 'react';
+
+export const useObserveXAxisHeights = (chartRef: RefObject<SVGElement>, axisCount) => {
+  const defaultHeights = Array(axisCount).fill(30);
+  if (chartRef.current) {
+    chartRef.current?.querySelectorAll<SVGElement>('.xAxis').forEach((xAxis, index) => {
+      defaultHeights[index] = xAxis?.getBBox()?.height;
+    });
+  }
+
+  return defaultHeights;
+};

--- a/packages/charts/src/internal/SecondaryDimensionXAxisTick.tsx
+++ b/packages/charts/src/internal/SecondaryDimensionXAxisTick.tsx
@@ -4,17 +4,16 @@ import React from 'react';
 
 let lastRenderedTickValue = '';
 export const SecondaryDimensionTicksXAxis = (props) => {
-  const { x, y, payload, config, rotate } = props;
+  const { x, y, payload, config } = props;
 
   const tickValue = config.formatter(payload.value);
   if (lastRenderedTickValue === tickValue && payload.index !== 0) {
     return null;
   }
   lastRenderedTickValue = tickValue;
-  const dy = rotate ? 40 : 0;
 
   return (
-    <g transform={`translate(${x},${y + dy})`}>
+    <g transform={`translate(${x},${y})`}>
       <text fill={ThemingParameters.sapTextColor}>|</text>
       <text fill={ThemingParameters.sapTextColor} textAnchor="middle" y={15}>
         {`${truncateLongLabel(tickValue, 25)}`}

--- a/packages/charts/src/internal/XAxisTicks.tsx
+++ b/packages/charts/src/internal/XAxisTicks.tsx
@@ -1,35 +1,44 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
-import { truncateLongLabel } from '@ui5/webcomponents-react-charts/lib/Utils';
-import React, { FC, RefObject } from 'react';
+import { getTextWidth, truncateLongLabel } from '@ui5/webcomponents-react-charts/lib/Utils';
+import React, { FC } from 'react';
 import { IChartMeasure } from '../interfaces/IChartMeasure';
 import { SecondaryDimensionTicksXAxis } from './SecondaryDimensionXAxisTick';
 
 interface XAxisTicksProps {
+  visibleTicksCount?: number;
+  width?: number;
   x?: number;
   y?: number;
   payload?: any;
   config: IChartMeasure;
   level?: number;
-  chartRef: RefObject<HTMLDivElement>;
 }
 
 export const XAxisTicks: FC<XAxisTicksProps> = (props: XAxisTicksProps) => {
-  const { chartRef, x, y, payload, config, level = 0 } = props;
-  let shouldRotate = false;
-  if (chartRef.current) {
-    const [firstLine, secondLine] = chartRef.current.querySelectorAll('.xAxis .recharts-cartesian-axis-ticks line');
-    if (firstLine && secondLine) {
-      const firstLineX = firstLine.getBoundingClientRect().x;
-      const secondLineX = secondLine.getBoundingClientRect().x;
-      shouldRotate = secondLineX - firstLineX <= 100;
-    }
-  }
+  const { x, y, payload, config, level = 0, visibleTicksCount, width } = props;
+
+  const bandWidth = width / visibleTicksCount;
+  const shouldRotate = bandWidth <= 100;
 
   if (level > 0) {
     return <SecondaryDimensionTicksXAxis {...props} rotate={shouldRotate} />;
   }
 
   const formattedValue = config.formatter(payload.value);
+  let textToDisplay;
+  if (shouldRotate) {
+    textToDisplay = truncateLongLabel(formattedValue, 11);
+  } else if (getTextWidth(formattedValue) <= bandWidth) {
+    textToDisplay = formattedValue;
+  } else {
+    for (let i = `${formattedValue}`.length; i > 0; i--) {
+      textToDisplay = truncateLongLabel(formattedValue, i);
+      if (getTextWidth(textToDisplay) <= bandWidth) {
+        break;
+      }
+    }
+  }
+
   return (
     <g transform={`translate(${x},${y + 10})`}>
       <text
@@ -37,7 +46,7 @@ export const XAxisTicks: FC<XAxisTicksProps> = (props: XAxisTicksProps) => {
         transform={shouldRotate ? 'rotate(-35)' : undefined}
         textAnchor={shouldRotate ? 'end' : 'middle'}
       >
-        {truncateLongLabel(formattedValue, 11)}
+        {textToDisplay}
       </text>
     </g>
   );

--- a/packages/charts/src/internal/XAxisTicks.tsx
+++ b/packages/charts/src/internal/XAxisTicks.tsx
@@ -21,16 +21,14 @@ export const XAxisTicks: FC<XAxisTicksProps> = (props: XAxisTicksProps) => {
   const shouldRotate = bandWidth <= 100;
 
   if (level > 0) {
-    return <SecondaryDimensionTicksXAxis {...props} rotate={shouldRotate} />;
+    return <SecondaryDimensionTicksXAxis {...props} />;
   }
 
   const formattedValue = config.formatter(payload.value);
-  let textToDisplay;
+  let textToDisplay = formattedValue;
   if (shouldRotate) {
     textToDisplay = truncateLongLabel(formattedValue, 11);
-  } else if (getTextWidth(formattedValue) <= bandWidth) {
-    textToDisplay = formattedValue;
-  } else {
+  } else if (getTextWidth(formattedValue) > bandWidth) {
     for (let i = `${formattedValue}`.length; i > 0; i--) {
       textToDisplay = truncateLongLabel(formattedValue, i);
       if (getTextWidth(textToDisplay) <= bandWidth) {

--- a/packages/charts/src/internal/YAxisTicks.tsx
+++ b/packages/charts/src/internal/YAxisTicks.tsx
@@ -1,7 +1,8 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingParameters';
-import { truncateLongLabel } from '@ui5/webcomponents-react-charts/lib/Utils';
+import { getTextWidth, truncateLongLabel } from '@ui5/webcomponents-react-charts/lib/Utils';
 import React, { FC } from 'react';
 import { IChartMeasure } from '../interfaces/IChartMeasure';
+import { defaultMaxYAxisWidth } from './defaults';
 import { SecondaryDimensionTicksYAxis } from './SecondaryDimensionYAxisTick';
 
 interface YAxisTicksProps {
@@ -19,10 +20,20 @@ export const YAxisTicks: FC<YAxisTicksProps> = (props: YAxisTicksProps) => {
     return <SecondaryDimensionTicksYAxis {...props} />;
   }
   const formattedValue = config.formatter(payload.value);
+  let textToDisplay = formattedValue;
+  if (getTextWidth(formattedValue) > defaultMaxYAxisWidth) {
+    for (let i = `${formattedValue}`.length; i > 0; i--) {
+      textToDisplay = truncateLongLabel(formattedValue, i);
+      if (getTextWidth(textToDisplay) <= defaultMaxYAxisWidth) {
+        break;
+      }
+    }
+  }
+
   return (
     <g transform={`translate(${x},${y + 3})`}>
       <text fill={ThemingParameters.sapContent_LabelColor} textAnchor="end">
-        {truncateLongLabel(formattedValue)}
+        {textToDisplay}
       </text>
     </g>
   );

--- a/packages/charts/src/internal/defaults.ts
+++ b/packages/charts/src/internal/defaults.ts
@@ -1,0 +1,3 @@
+export const defaultFormatter = (d) => d;
+
+export const defaultMaxYAxisWidth = 200;

--- a/packages/charts/src/internal/staticProps.ts
+++ b/packages/charts/src/internal/staticProps.ts
@@ -2,4 +2,4 @@ import { ThemingParameters } from '@ui5/webcomponents-react-base/lib/ThemingPara
 
 export const tickLineConfig = { stroke: 'transparent' };
 export const tooltipContentStyle = { backgroundColor: ThemingParameters.sapBackgroundColor };
-export const tooltipFillOpacity = { fillOpacity: 0.3 } ;
+export const tooltipFillOpacity = { fillOpacity: 0.3 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
       "es6",
       "es7",
       "es2017",
+      "es2018",
+      "es2019",
       "dom"
     ],
     "sourceMap": true,


### PR DESCRIPTION
- Legend Position is always bottom, modifiable via `chartConfig.legendPosition`
- Legend Horizontal Align is always Start (Center for Polar Charts), modifiable with `chartConfig.legendHorizontalAlign`
- Calculation of longest y-axis-label, limited to 200px
- adjust legend position based on needed axis size