### PR TITLE
fix: remove useMemo from usePassThroughHtmlProps

### DIFF
--- a/packages/base/src/hooks/usePassThroughHtmlProps.ts
+++ b/packages/base/src/hooks/usePassThroughHtmlProps.ts
@@ -1,23 +1,14 @@
-import { useMemo } from 'react';
-
 const PROP_WHITELIST = /^(aria-|data-|id$|on[A-Z])/;
 
 export const usePassThroughHtmlProps = (props, propBlackList: string[] = []) => {
   const componentPropBlacklist = new Set(propBlackList);
-  const passThroughPropNames = Object.keys(props).filter(
-    (name) => PROP_WHITELIST.test(name) && !componentPropBlacklist.has(name)
-  );
 
-  return useMemo(
-    () => {
-      return passThroughPropNames.reduce(
-        (acc, val) => ({
-          ...acc,
-          [val]: props[val]
-        }),
-        {}
-      );
-    },
-    passThroughPropNames.map((name) => props[name])
-  );
+  const returnVal = {};
+  for (const name in props) {
+    if (PROP_WHITELIST.test(name) && !componentPropBlacklist.has(name)) {
+      returnVal[name] = props[name];
+    }
+  }
+
+  return returnVal;
 };


### PR DESCRIPTION
Remove `useMemo` here as it had no effect because the returned object is always spreaded.