### PR TITLE
fix(Charts): tooltip respects dimension formatter

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -22,6 +22,7 @@ import {
 } from 'recharts';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLabelFormatter } from '../../hooks/useLabelFormatter';
 import { useLongestYAxisLabelBar } from '../../hooks/useLongestYAxisLabelBar';
 import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
@@ -143,6 +144,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
   const chartRef = useConsolidatedRef<any>(ref);
 
   const onItemLegendClick = useLegendItemClick(onLegendClick);
+  const labelFormatter = useLabelFormatter(primaryDimension);
 
   const onDataPointClickInternal = useCallback(
     (payload, i, event) => {
@@ -261,7 +263,12 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
             label={chartConfig.referenceLine.label}
           />
         )}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          contentStyle={tooltipContentStyle}
+          labelFormatter={labelFormatter}
+        />
         {chartConfig.zoomingTool && (
           <Brush
             y={10}

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -22,6 +22,7 @@ import {
 } from 'recharts';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLabelFormatter } from '../../hooks/useLabelFormatter';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
@@ -140,6 +141,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
   const primaryDimension = dimensions[0];
   const primaryMeasure = measures[0];
 
+  const labelFormatter = useLabelFormatter(primaryDimension);
   const chartRef = useConsolidatedRef<any>(ref);
 
   const dataKeys = measures.map(({ accessor }) => accessor);
@@ -272,7 +274,12 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
             yAxisId={'left'}
           />
         )}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          labelFormatter={labelFormatter}
+          contentStyle={tooltipContentStyle}
+        />
         {chartConfig.zoomingTool && (
           <Brush
             y={10}

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -22,6 +22,7 @@ import {
   YAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLabelFormatter } from '../../hooks/useLabelFormatter';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
@@ -150,6 +151,8 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
 
   const primaryDimension = dimensions[0];
   const primaryMeasure = measures[0];
+
+  const labelFormatter = useLabelFormatter(primaryDimension);
 
   const dataKeys = measures.map(({ accessor }) => accessor);
   const colorSecondY = chartConfig.secondYAxis
@@ -307,7 +310,12 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
             xAxisId={layout === 'vertical' ? 'primary' : undefined}
           />
         )}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          labelFormatter={labelFormatter}
+          contentStyle={tooltipContentStyle}
+        />
         {!noLegend && (
           <Legend
             verticalAlign={chartConfig.legendPosition}

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -20,6 +20,7 @@ import {
   YAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
+import { useLabelFormatter } from '../../hooks/useLabelFormatter';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { useObserveXAxisHeights } from '../../hooks/useObserveXAxisHeights';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
@@ -123,6 +124,8 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
 
   const primaryDimension = dimensions[0];
   const primaryMeasure = measures[0];
+
+  const labelFormatter = useLabelFormatter(primaryDimension);
 
   const chartRef = useConsolidatedRef<any>(ref);
 
@@ -252,7 +255,12 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
             yAxisId={'left'}
           />
         )}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          contentStyle={tooltipContentStyle}
+          labelFormatter={labelFormatter}
+        />
         {chartConfig.zoomingTool && (
           <Brush
             y={10}

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -118,7 +118,10 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     [measure]
   );
 
-  const tooltipValueFormatter = useCallback((value) => measure.formatter(value), [measure.formatter]);
+  const tooltipValueFormatter = useCallback((value, name) => [measure.formatter(value), dimension.formatter(name)], [
+    measure.formatter,
+    dimension.formatter
+  ]);
   const chartRef = useConsolidatedRef<any>(ref);
 
   const onItemLegendClick = useLegendItemClick(onLegendClick, () => measure.accessor);

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -15,6 +15,7 @@ import {
   RadarChart as RadarChartLib,
   Tooltip
 } from 'recharts';
+import { useLabelFormatter } from '../../hooks/useLabelFormatter';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { useTooltipFormatter } from '../../hooks/useTooltipFormatter';
 import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
@@ -106,6 +107,8 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
 
   const primaryDimension = dimensions[0];
 
+  const labelFormatter = useLabelFormatter(primaryDimension);
+
   const primaryDimensionAccessor = primaryDimension?.accessor;
 
   const onItemLegendClick = useLegendItemClick(onLegendClick);
@@ -171,7 +174,12 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
             />
           );
         })}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          contentStyle={tooltipContentStyle}
+          labelFormatter={labelFormatter}
+        />
         {!noLegend && (
           <Legend
             verticalAlign={chartConfig.legendPosition}

--- a/packages/charts/src/hooks/useLabelFormatter.ts
+++ b/packages/charts/src/hooks/useLabelFormatter.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+
+export const useLabelFormatter = (primaryDimension) => {
+  return useCallback(
+    (name) => {
+      if (primaryDimension && typeof primaryDimension?.formatter === 'function') {
+        return primaryDimension.formatter(name);
+      }
+    },
+    [primaryDimension]
+  );
+};

--- a/packages/charts/src/hooks/useLabelFormatter.ts
+++ b/packages/charts/src/hooks/useLabelFormatter.ts
@@ -6,6 +6,7 @@ export const useLabelFormatter = (primaryDimension) => {
       if (primaryDimension && typeof primaryDimension?.formatter === 'function') {
         return primaryDimension.formatter(name);
       }
+      return name;
     },
     [primaryDimension]
   );


### PR DESCRIPTION
The dimension formatter was only applied to the Tooltip when the dimension accessor was `name`, this was due to a side effect of the `formatter` function of the `Tooltip` component. 

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/master/docs/Guidelines.md#commit-message-style)
