### PR TITLE
fix(AnalyticalTable): update react-table

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -36,7 +36,7 @@
     "lodash.debounce": "^4.0.8",
     "react-content-loader": "5.1.0",
     "react-jss": "10.1.1",
-    "react-table": "7.2.2",
+    "react-table": "7.3.2",
     "react-virtual": "2.2.1"
   },
   "peerDependencies": {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -227,8 +227,8 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
       ...reactTableOptions
     },
     useFilters,
-    useGroupBy,
     useColumnOrder,
+    useGroupBy,
     useSortBy,
     useExpanded,
     useRowSelect,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,7 +4481,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.34", "@types/react@^16.9.34":
+"@types/react@*", "@types/react@^16.9.34":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
@@ -16870,10 +16870,10 @@ react-syntax-highlighter@^12.2.1:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react-table@7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.2.2.tgz#2978a903f0e367e1ceab25d60a6a40ae23498f77"
-  integrity sha512-JBE3QUyRQJkHRU72NKo7HRGtSGcrzIcVLDbsoZI+KhWkFEZ2t9UfpqeHBdbc3R5RRJZ6qC7+NzZZxJPSYWKPBQ==
+react-table@7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.3.2.tgz#def43b9777e0ef5839608104a557c3f1c365b2ff"
+  integrity sha512-n8ZvC8tzuDa3qK9PFlcXmo58JCRfxg/3LlvG8YJywvsQKiCnTfK6lDSp8a3WsAOBcZvBtGgyeoke7pBfAdB8jA==
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
Update to 7.3.2 which includes:
- feat: Add reset column resizing
- fix: bug in subRows sortData
- fix: enforce `useColumnOrder` before `useGroupBy`