### PR TITLE
chore(AnalyticalTable): remove busyIndicatorEnabled prop

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -85,7 +85,6 @@ import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/lib/FlexBoxJusti
       }
     ],
     title: 'Table Title',
-    busyIndicatorEnabled: true,
     sortable: true,
     filterable: true,
     visibleRows: 15,
@@ -135,7 +134,6 @@ import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/lib/FlexBoxJusti
           data={args.data}
           columns={args.columns}
           loading={args.loading}
-          busyIndicatorEnabled={args.busyIndicatorEnabled}
           alternateRowColor={args.alternateRowColor}
           sortable={args.sortable}
           filterable={args.filterable}
@@ -283,7 +281,6 @@ This even works if you resize the browser window!
         data={args.dataTree}
         columns={args.columns}
         loading={args.loading}
-        busyIndicatorEnabled={args.busyIndicatorEnabled}
         sortable={args.sortable}
         filterable={args.filterable}
         visibleRows={args.visibleRows}

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
@@ -169,7 +169,6 @@ describe('AnalyticalTable', () => {
         data={dataTree}
         columns={columns}
         loading={false}
-        busyIndicatorEnabled={true}
         sortable={true}
         filterable={true}
         visibleRows={15}

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -72,7 +72,6 @@ export interface TableProps extends CommonProps {
   minRows?: number;
   visibleRows?: number;
   loading?: boolean;
-  busyIndicatorEnabled?: boolean;
   noDataText?: string;
   rowHeight?: number;
   alternateRowColor?: boolean;
@@ -143,7 +142,6 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
     onSort,
     reactTableOptions,
     tableHooks,
-    busyIndicatorEnabled,
     subRowsKey,
     onGroup,
     rowHeight,
@@ -403,9 +401,7 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
             </header>
           );
         })}
-        {loading && busyIndicatorEnabled && props.data?.length > 0 && (
-          <LoadingComponent style={{ width: `${totalColumnsWidth}px` }} />
-        )}
+        {loading && props.data?.length > 0 && <LoadingComponent style={{ width: `${totalColumnsWidth}px` }} />}
         {loading && props.data?.length === 0 && (
           <TablePlaceholder
             columns={tableInternalColumns.filter(
@@ -448,7 +444,6 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
 AnalyticalTable.displayName = 'AnalyticalTable';
 AnalyticalTable.defaultProps = {
   loading: false,
-  busyIndicatorEnabled: true,
   sortable: true,
   filterable: false,
   groupable: false,


### PR DESCRIPTION
BREAKING CHANGE: remove  prop `busyIndicatorEnabled` as it is somehow duplicate to `loading`. The visibility of the busy indicator is now solely controlled by the prop `loading`.
