### PR TITLE
fix(PieChart): added the option to style the tooltip label and items …

### DIFF
--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -81,6 +81,8 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
       paddingAngle: 0,
       outerRadius: '80%',
       resizeDebounce: 250,
+      tooltipItemStyle: { color: 'var (--sapTextColor)' },
+      tooltipLabelStyle: {},
       ...props.chartConfig
     };
   }, [props.chartConfig]);
@@ -182,7 +184,13 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
               />
             ))}
         </Pie>
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          contentStyle={tooltipContentStyle}
+          itemStyle={chartConfig.tooltipItemStyle}
+          labelStyle={chartConfig.tooltipLabelStyle}
+        />
         {!noLegend && (
           <Legend
             verticalAlign={chartConfig.legendPosition}

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -55,6 +55,8 @@ export interface PieChartProps extends IChartBaseProps<IPolarChartConfig> {
   measure: MeasureConfig;
 }
 
+const tooltipItemDefaultStyle = { color: 'var (--sapTextColor)' };
+
 /**
  * <code>import { PieChart } from '@ui5/webcomponents-react-charts/lib/PieChart';</code>
  */
@@ -81,8 +83,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
       paddingAngle: 0,
       outerRadius: '80%',
       resizeDebounce: 250,
-      tooltipItemStyle: { color: 'var (--sapTextColor)' },
-      tooltipLabelStyle: {},
+      tooltipItemStyle: tooltipItemDefaultStyle,
       ...props.chartConfig
     };
   }, [props.chartConfig]);


### PR DESCRIPTION
…via the chartConfig, also added as item style default color sapTextColor, now the items are readable while using the dark theme

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/master/docs/Guidelines.md#commit-message-style)
