### PR TITLE
fix(useI18nBundle): prevent state transition if the component has been unmounted

### DIFF
--- a/packages/base/src/hooks/useI18nBundle.ts
+++ b/packages/base/src/hooks/useI18nBundle.ts
@@ -23,17 +23,23 @@ export const useI18nText = (bundleName: string, ...texts: (TextWithDefault | Tex
   const [translations, setTranslations] = useState(resolveTranslations(i18nBundle, texts));
 
   useEffect(() => {
+    let didCancel = false;
     const fetchAndLoadBundle = async () => {
       await fetchI18nBundle(bundleName);
-      setTranslations((prev) => {
-        const next = resolveTranslations(i18nBundle, texts);
-        if (prev.length === next.length && prev.every((translation, index) => next[index] === translation)) {
-          return prev;
-        }
-        return next;
-      });
+      if (!didCancel) {
+        setTranslations((prev) => {
+          const next = resolveTranslations(i18nBundle, texts);
+          if (prev.length === next.length && prev.every((translation, index) => next[index] === translation)) {
+            return prev;
+          }
+          return next;
+        });
+      }
     };
     fetchAndLoadBundle();
+    return () => {
+      didCancel = true;
+    };
   }, [fetchI18nBundle, bundleName, texts]);
 
   return translations;


### PR DESCRIPTION
This fixes the `Can't perform a React state update on an unmounted component.` warning of some components. (E.g.: VariantManagement, Toolbar)
