### PR TITLE
feat(Web Components): allow nested fragments in slots (not available for IE11)

### DIFF
--- a/packages/main/src/components/AnalyticalTable/defaults/Column/Expandable.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/Column/Expandable.tsx
@@ -1,4 +1,4 @@
-import { isIE } from '@ui5/webcomponents-base/dist/Device';
+import { isIE } from '@ui5/webcomponents-react-base/lib/Device';
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/lib/CssSizeVariables';
 import { Icon } from '@ui5/webcomponents-react/lib/Icon';
 import React, { CSSProperties } from 'react';

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -8,41 +8,49 @@ exports[`MessageBox Confirm - Cancel 1`] = `
     style="z-index: 114; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-      <ui5-button
-        data-action="Cancel"
-        design="Transparent"
-        ui5-button=""
-      >
-        Cancel
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Confirm"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+        <ui5-button
+          data-action="Cancel"
+          design="Transparent"
+          ui5-button=""
+        >
+          Cancel
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="question-mark"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Confirm"
       >
-        Confirmation
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="question-mark"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Confirmation
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -60,41 +68,49 @@ exports[`MessageBox Confirm 1`] = `
     style="z-index: 102; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-      <ui5-button
-        data-action="Cancel"
-        design="Transparent"
-        ui5-button=""
-      >
-        Cancel
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Confirm"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+        <ui5-button
+          data-action="Cancel"
+          design="Transparent"
+          ui5-button=""
+        >
+          Cancel
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="question-mark"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Confirm"
       >
-        Confirmation
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="question-mark"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Confirmation
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -110,41 +126,49 @@ exports[`MessageBox Custom Action Text 1`] = `
     class="MessageBox-messageBox"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-      <ui5-button
-        data-action="My Custom Action"
-        design="Transparent"
-        ui5-button=""
-      >
-        My Custom Action
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Confirm"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+        <ui5-button
+          data-action="My Custom Action"
+          design="Transparent"
+          ui5-button=""
+        >
+          My Custom Action
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="question-mark"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Confirm"
       >
-        Confirmation
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="question-mark"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Confirmation
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -162,28 +186,36 @@ exports[`MessageBox Don't crash on unknown type 1`] = `
     style="z-index: 122; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="FOO_BAR"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-title
-        level="H5"
-        ui5-title=""
-      />
-    </header>
+      <header
+        class="MessageBox-header"
+        data-type="FOO_BAR"
+      >
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        />
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -201,34 +233,42 @@ exports[`MessageBox Error 1`] = `
     style="z-index: 108; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="Close"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        Close
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Error"
+        <ui5-button
+          data-action="Close"
+          design="Emphasized"
+          ui5-button=""
+        >
+          Close
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="message-error"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Error"
       >
-        Error
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="message-error"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Error
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -246,34 +286,42 @@ exports[`MessageBox Highlight 1`] = `
     style="z-index: 112; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Highlight"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="hint"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Highlight"
       >
-        Highlight
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="hint"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Highlight
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -291,34 +339,42 @@ exports[`MessageBox Information 1`] = `
     style="z-index: 110; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Information"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="message-information"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Information"
       >
-        Information
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="message-information"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Information
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -336,41 +392,49 @@ exports[`MessageBox No Title 1`] = `
     style="z-index: 120; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-      <ui5-button
-        data-action="Cancel"
-        design="Transparent"
-        ui5-button=""
-      >
-        Cancel
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Confirm"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+        <ui5-button
+          data-action="Cancel"
+          design="Transparent"
+          ui5-button=""
+        >
+          Cancel
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="question-mark"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Confirm"
       >
-        Confirmation
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="question-mark"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Confirmation
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -386,34 +450,42 @@ exports[`MessageBox Not open 1`] = `
     class="MessageBox-messageBox"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Success"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="message-success"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Success"
       >
-        Custom Success
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="message-success"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Custom Success
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -431,41 +503,49 @@ exports[`MessageBox Show 1`] = `
     style="z-index: 116; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="Yes"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        Yes
-      </ui5-button>
-      <ui5-button
-        data-action="No"
-        design="Transparent"
-        ui5-button=""
-      >
-        No
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Confirm"
+        <ui5-button
+          data-action="Yes"
+          design="Emphasized"
+          ui5-button=""
+        >
+          Yes
+        </ui5-button>
+        <ui5-button
+          data-action="No"
+          design="Transparent"
+          ui5-button=""
+        >
+          No
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="question-mark"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Confirm"
       >
-        Custom
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="question-mark"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Custom
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -483,34 +563,42 @@ exports[`MessageBox Success 1`] = `
     style="z-index: 104; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Success"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="message-success"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Success"
       >
-        Success
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="message-success"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Success
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -528,34 +616,42 @@ exports[`MessageBox Success w/ custom title 1`] = `
     style="z-index: 118; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Success"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="add"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Success"
       >
-        Custom Success
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="add"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Custom Success
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >
@@ -573,34 +669,42 @@ exports[`MessageBox Warning 1`] = `
     style="z-index: 106; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
-    <footer
-      class="MessageBox-footer"
+    <div
       slot="footer"
+      style="display: contents;"
     >
-      <ui5-button
-        data-action="OK"
-        design="Emphasized"
-        ui5-button=""
+      <footer
+        class="MessageBox-footer"
       >
-        OK
-      </ui5-button>
-    </footer>
-    <header
-      class="MessageBox-header"
-      data-type="Warning"
+        <ui5-button
+          data-action="OK"
+          design="Emphasized"
+          ui5-button=""
+        >
+          OK
+        </ui5-button>
+      </footer>
+    </div>
+    <div
       slot="header"
+      style="display: contents;"
     >
-      <ui5-icon
-        name="message-warning"
-        ui5-icon=""
-      />
-      <ui5-title
-        level="H5"
-        ui5-title=""
+      <header
+        class="MessageBox-header"
+        data-type="Warning"
       >
-        Warning
-      </ui5-title>
-    </header>
+        <ui5-icon
+          name="message-warning"
+          ui5-icon=""
+        />
+        <ui5-title
+          level="H5"
+          ui5-title=""
+        >
+          Warning
+        </ui5-title>
+      </header>
+    </div>
     <span
       class="Text-text MessageBox-content"
     >

--- a/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/main/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -15,19 +15,27 @@ exports[`Page Basic Page 1`] = `
           design="Header"
           ui5-bar=""
         >
-          <ui5-title
-            level="H5"
+          <div
             slot="middleContent"
-            ui5-title=""
+            style="display: contents;"
           >
-            Page Demo
-          </ui5-title>
-          <ui5-button
-            design="Transparent"
-            icon="navigation-left-arrow"
+            <ui5-title
+              level="H5"
+              ui5-title=""
+            >
+              Page Demo
+            </ui5-title>
+          </div>
+          <div
             slot="startContent"
-            ui5-button=""
-          />
+            style="display: contents;"
+          >
+            <ui5-button
+              design="Transparent"
+              icon="navigation-left-arrow"
+              ui5-button=""
+            />
+          </div>
         </ui5-bar>
       </header>
       <section
@@ -59,13 +67,17 @@ exports[`Page Basic Page w/o back button 1`] = `
           design="Header"
           ui5-bar=""
         >
-          <ui5-title
-            level="H5"
+          <div
             slot="middleContent"
-            ui5-title=""
+            style="display: contents;"
           >
-            Page Demo
-          </ui5-title>
+            <ui5-title
+              level="H5"
+              ui5-title=""
+            >
+              Page Demo
+            </ui5-title>
+          </div>
         </ui5-bar>
       </header>
       <section

--- a/packages/main/src/internal/__snapshots__/withWebComponent.test.tsx.snap
+++ b/packages/main/src/internal/__snapshots__/withWebComponent.test.tsx.snap
@@ -6,11 +6,14 @@ exports[`withWebComponent conditional rendering 1`] = `
     design="Header"
     ui5-bar=""
   >
-    <span
+    <div
       slot="startContent"
+      style="display: contents;"
     >
-      I'm here!
-    </span>
+      <span>
+        I'm here!
+      </span>
+    </div>
   </ui5-bar>
 </DocumentFragment>
 `;

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -25,6 +25,8 @@ const createEventPropName = (eventName) => `on${capitalizeFirstLetter(kebabToCam
 
 type EventHandler = (event: CustomEvent<unknown>) => void;
 
+const staticSlotStyle = { display: 'contents' };
+
 export interface WithWebComponentPropTypes extends CommonProps {
   ref?: Ref<any>;
   children?: any | void;
@@ -82,7 +84,7 @@ export const withWebComponent = <T extends Record<string, any>>(
             const slotValue = rest[item] as ReactElement;
             if (!slotValue) return false;
             return (
-              <div slot={item} style={{ display: 'contents' }} key={item}>
+              <div slot={item} style={staticSlotStyle} key={item}>
                 {slotValue}
               </div>
             );

--- a/packages/main/src/webComponents/Bar/__snapshots__/Bar.test.tsx.snap
+++ b/packages/main/src/webComponents/Bar/__snapshots__/Bar.test.tsx.snap
@@ -6,21 +6,30 @@ exports[`Bar Basic Test (generated) 1`] = `
     design="Header"
     ui5-bar=""
   >
-    <span
+    <div
       slot="endContent"
+      style="display: contents;"
     >
-      End
-    </span>
-    <span
+      <span>
+        End
+      </span>
+    </div>
+    <div
       slot="middleContent"
+      style="display: contents;"
     >
-      Middle
-    </span>
-    <span
+      <span>
+        Middle
+      </span>
+    </div>
+    <div
       slot="startContent"
+      style="display: contents;"
     >
-      Start
-    </span>
+      <span>
+        Start
+      </span>
+    </div>
   </ui5-bar>
 </DocumentFragment>
 `;

--- a/packages/main/src/webComponents/NotificationListItem/__snapshots__/NotificationListItem.test.tsx.snap
+++ b/packages/main/src/webComponents/NotificationListItem/__snapshots__/NotificationListItem.test.tsx.snap
@@ -7,12 +7,16 @@ exports[`NotificationListItem Basic Test (generated) 1`] = `
     priority="High"
     show-close="true"
   >
-    <ui5-notification-action
-      design="Transparent"
+    <div
       slot="actions"
-      text="My Action"
-      ui5-notification-action=""
-    />
+      style="display: contents;"
+    >
+      <ui5-notification-action
+        design="Transparent"
+        text="My Action"
+        ui5-notification-action=""
+      />
+    </div>
   </ui5-li-notification>
 </DocumentFragment>
 `;

--- a/packages/main/src/webComponents/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/main/src/webComponents/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -3,18 +3,21 @@
 exports[`SideNavigation Basic Test (generated) 1`] = `
 <DocumentFragment>
   <ui5-side-navigation>
-    <ui5-side-navigation-item
-      icon="chain-link"
+    <div
       slot="fixedItems"
-      text="Useful Links"
-      ui5-side-navigation-item=""
-    />
-    <ui5-side-navigation-item
-      icon="history"
-      slot="fixedItems"
-      text="History"
-      ui5-side-navigation-item=""
-    />
+      style="display: contents;"
+    >
+      <ui5-side-navigation-item
+        icon="chain-link"
+        text="Useful Links"
+        ui5-side-navigation-item=""
+      />
+      <ui5-side-navigation-item
+        icon="history"
+        text="History"
+        ui5-side-navigation-item=""
+      />
+    </div>
     <ui5-side-navigation-item
       icon="home"
       text="Home"


### PR DESCRIPTION
Previously handling slots in our Web Components required some attention from the developer, e.g.:
- accept and handle the `slot` prop when using a Custom Component as Slot
- Only top level fragments were supported

This PR is now wrapping all slots with a div with `style:"display: contents;"` in order to allow any element as slot value.
As IE11 does not support the display: contents style this feature is not available there and you can't use nested fragments and have to make sure you are handling the slot prop correctly when using Custom Components.