### PR TITLE
chore: delete deprecated useI18nText hook

### DIFF
--- a/docs/2-MigrationGuide.stories.mdx
+++ b/docs/2-MigrationGuide.stories.mdx
@@ -102,7 +102,7 @@ const MyComponent = () => {
 
 ### Deleted Hooks
 
-The `useI18nText` hook has been removed and replaced by the `useI18nBundle` hook. <br />
+The deprecated `useI18nText` hook has been removed and replaced by the `useI18nBundle` hook. <br />
 Migration Path:
 
 ```js

--- a/packages/base/src/hooks/useI18nBundle.ts
+++ b/packages/base/src/hooks/useI18nBundle.ts
@@ -3,59 +3,12 @@ import { fetchI18nBundle, getI18nBundle } from '@ui5/webcomponents-base/dist/i18
 import { attachLanguageChange, detachLanguageChange } from '@ui5/webcomponents-base/dist/locale/languageChange';
 import { useIsomorphicLayoutEffect } from '@ui5/webcomponents-react-base/lib/hooks';
 import { useEffect, useState } from 'react';
-import { deprecationNotice } from '@ui5/webcomponents-react-base/lib/Utils';
 
 type TextWithDefault = { key: string; defaultText: string } | string;
-type TextWithPlaceholders = [TextWithDefault, ...string[]];
 
 interface I18nBundle {
   getText: (textObj: TextWithDefault, ...args: any[]) => string;
 }
-
-const resolveTranslations = (bundle, texts) => {
-  return texts.map((text) => {
-    if (Array.isArray(text)) {
-      const [key, ...replacements] = text;
-      return bundle.getText(key, replacements);
-    }
-    return bundle.getText(text);
-  });
-};
-
-export const useI18nText = (bundleName: string, ...texts: (TextWithDefault | TextWithPlaceholders)[]): string[] => {
-  const i18nBundle: I18nBundle = getI18nBundle(bundleName);
-  const [translations, setTranslations] = useState(resolveTranslations(i18nBundle, texts));
-
-  useEffect(() => {
-    deprecationNotice(
-      'useI18nText',
-      `'useI18nText' is deprecated and will be removed in the next release. Please use 'useI18nBundle' instead.
-A Migration Guide can be found here: https://sap.github.io/ui5-webcomponents-react/?path=/docs/migration-guide--page#migrating-from-013x-to-0140`
-    );
-  }, []);
-
-  useEffect(() => {
-    let didCancel = false;
-    const fetchAndLoadBundle = async () => {
-      await fetchI18nBundle(bundleName);
-      if (!didCancel) {
-        setTranslations((prev) => {
-          const next = resolveTranslations(i18nBundle, texts);
-          if (prev.length === next.length && prev.every((translation, index) => next[index] === translation)) {
-            return prev;
-          }
-          return next;
-        });
-      }
-    };
-    fetchAndLoadBundle();
-    return () => {
-      didCancel = true;
-    };
-  }, [fetchI18nBundle, bundleName, ...texts]);
-
-  return translations;
-};
 
 export const useI18nBundle = (bundleName: string): I18nBundle => {
   const [_, setUpdater] = useState(0);

--- a/packages/base/src/lib/hooks.ts
+++ b/packages/base/src/lib/hooks.ts
@@ -1,5 +1,5 @@
 import { useConsolidatedRef } from '../hooks/useConsolidatedRef';
-import { useI18nBundle, useI18nText } from '../hooks/useI18nBundle';
+import { useI18nBundle } from '../hooks/useI18nBundle';
 import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
 import { usePassThroughHtmlProps } from '../hooks/usePassThroughHtmlProps';
 import { useViewportRange } from '../hooks/useViewportRange';
@@ -9,7 +9,6 @@ export {
   useConsolidatedRef,
   usePassThroughHtmlProps,
   useViewportRange,
-  useI18nText,
   useIsomorphicLayoutEffect,
   useI18nBundle,
   useIsRTL


### PR DESCRIPTION
BREAKING CHANGE: `useI18nText` is replaced by `useI18nBundle`. For more details please consult our [migration guide](https://sap.github.io/ui5-webcomponents-react/?path=/docs/migration-guide--page#deleted-hooks).