### PR TITLE
feat(AnalyticalTable): add offset-top support to visibleRowCountMode "Auto"

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -649,7 +649,7 @@ By adding the `visibleRowCountMode` prop and setting it to `TableVisibleRowCount
 <Canvas>
   <Story
     name="Adjust number of rows to container height"
-    args={{ visibleRowCountMode: TableVisibleRowCountMode.AUTO, containerHeight: 240 }}
+    args={{ visibleRowCountMode: TableVisibleRowCountMode.AUTO, containerHeight: 250 }}
     argTypes={{
       columns: { table: { disable: true } },
       data: { table: { disable: true } },
@@ -695,21 +695,26 @@ By adding the `visibleRowCountMode` prop and setting it to `TableVisibleRowCount
       className: { table: { disable: true } },
       tooltip: { table: { disable: true } },
       onRowClick: { table: { disable: true } },
+      withNavigationHighlight: { table: { disable: true } },
+      markNavigatedRow: { table: { disable: true } },
       containerHeight: {
-        control: { type: 'range', min: 0, max: 3000, step: 30 },
+        control: {
+          type: 'radio',
+          options: [250, 500, 750, 1000]
+        },
         description:
-          'Drag the slider to change the height of the surrounding container of the table (in `px`). <br /> __Note__: This is not an actual prop of the table.'
+          'Select an option to change the height of the surrounding container of the table (in `px`). <br /> __Note__: This is not an actual prop of the table.'
       }
     }}
   >
     {(args) => {
       return (
-        <div style={{ height: args.containerHeight ? `${args.containerHeight}px` : 0 }}>
+        <div style={{ height: `${args.containerHeight}px` }}>
           <AnalyticalTable
             data={args.data}
             columns={args.columns}
             visibleRowCountMode={args.visibleRowCountMode}
-            title={`Current height: ${args.containerHeight}px - Change the height by dragging the slider`}
+            title={`Current height: ${args.containerHeight}px - Change the height in the table above`}
           />
         </div>
       );
@@ -836,7 +841,7 @@ In the example below you can have a look at this behavior:
           options: [400, 600, 800, 'auto']
         },
         description:
-          'Select an option to change the surrounding container of the table (in `px`). <br /> __Note__: This is not an actual prop of the table.'
+          'Select an option to change the width of the surrounding container of the table (in `px`). <br /> __Note__: This is not an actual prop of the table.'
       }
     }}
   >

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
@@ -619,6 +619,11 @@ describe('AnalyticalTable', () => {
         configurable: true
       }
     });
+    window.HTMLElement.prototype.getBoundingClientRect = function () {
+      return {
+        height: 100
+      };
+    };
     const { asFragment, rerender } = render(
       <AnalyticalTable
         data={[...data, ...moreData]}
@@ -637,6 +642,11 @@ describe('AnalyticalTable', () => {
         configurable: true
       }
     });
+    window.HTMLElement.prototype.getBoundingClientRect = function () {
+      return {
+        height: 1000
+      };
+    };
 
     rerender(
       <AnalyticalTable

--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -6860,6 +6860,132 @@ exports[`AnalyticalTable render rows 1`] = `
                 </span>
               </div>
             </div>
+            <div
+              aria-rowindex="3"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(132px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="bar"
+                >
+                  bar
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="77"
+                >
+                  77
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="la"
+                >
+                  la
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="66"
+                >
+                  66
+                </span>
+              </div>
+            </div>
+            <div
+              aria-rowindex="4"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(176px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="lorem"
+                >
+                  lorem
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="18"
+                >
+                  18
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="ipsum"
+                >
+                  ipsum
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="28"
+                >
+                  28
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -7246,6 +7372,132 @@ exports[`AnalyticalTable render rows 2`] = `
                 </span>
               </div>
             </div>
+            <div
+              aria-rowindex="3"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(132px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="bar"
+                >
+                  bar
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="77"
+                >
+                  77
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="la"
+                >
+                  la
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="66"
+                >
+                  66
+                </span>
+              </div>
+            </div>
+            <div
+              aria-rowindex="4"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(176px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="lorem"
+                >
+                  lorem
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="18"
+                >
+                  18
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="ipsum"
+                >
+                  ipsum
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="28"
+                >
+                  28
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -7595,6 +7847,132 @@ exports[`AnalyticalTable render rows 3`] = `
                   title="meh"
                 >
                   meh
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="28"
+                >
+                  28
+                </span>
+              </div>
+            </div>
+            <div
+              aria-rowindex="3"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(132px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="bar"
+                >
+                  bar
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="77"
+                >
+                  77
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="la"
+                >
+                  la
+                </span>
+              </div>
+              <div
+                aria-colindex="4"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(450px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="66"
+                >
+                  66
+                </span>
+              </div>
+            </div>
+            <div
+              aria-rowindex="4"
+              class="AnalyticalTable-tr"
+              role="row"
+              style="height: 44px; transform: translateY(176px); position: absolute;"
+            >
+              <div
+                aria-colindex="1"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(0px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="lorem"
+                >
+                  lorem
+                </span>
+              </div>
+              <div
+                aria-colindex="2"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(150px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="18"
+                >
+                  18
+                </span>
+              </div>
+              <div
+                aria-colindex="3"
+                class="AnalyticalTable-tableCell"
+                role="cell"
+                style="width: 150px; align-items: center; position: absolute; top: 0px; transform: translateX(300px); left: 0px;"
+                tabindex="-1"
+              >
+                <span
+                  class="Text-text Text-noWrap"
+                  title="ipsum"
+                >
+                  ipsum
                 </span>
               </div>
               <div

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -458,15 +458,22 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
 
   const updateRowsCount = useCallback(() => {
     if (visibleRowCountMode === TableVisibleRowCountMode.AUTO && analyticalTableRef.current?.parentElement) {
-      const rowCount = Math.floor(
-        ((analyticalTableRef.current?.parentElement?.clientHeight ?? 0) - extensionsHeight) / popInRowHeight
-      );
+      const tableYPosition = analyticalTableRef.current?.offsetTop;
+      const parentHeight = analyticalTableRef.current?.parentElement?.getBoundingClientRect().height;
+      const tableHeight = tableYPosition && parentHeight ? parentHeight - tableYPosition : 0;
+      const rowCount = Math.floor((tableHeight - extensionsHeight) / popInRowHeight);
       dispatch({
         type: 'VISIBLE_ROWS',
         payload: { visibleRows: rowCount }
       });
     }
-  }, [analyticalTableRef.current?.parentElement?.clientHeight, extensionsHeight, popInRowHeight, visibleRowCountMode]);
+  }, [
+    analyticalTableRef.current?.parentElement?.getBoundingClientRect().height,
+    analyticalTableRef.current?.getBoundingClientRect().y,
+    extensionsHeight,
+    popInRowHeight,
+    visibleRowCountMode
+  ]);
 
   useEffect(() => {
     const tableWidthObserver = new ResizeObserver(debounce(updateTableClientWidth, 500));

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -458,9 +458,9 @@ const AnalyticalTable: FC<TableProps> = forwardRef((props: TableProps, ref: Ref<
 
   const updateRowsCount = useCallback(() => {
     if (visibleRowCountMode === TableVisibleRowCountMode.AUTO && analyticalTableRef.current?.parentElement) {
-      const tableYPosition = analyticalTableRef.current?.offsetTop;
+      const tableYPosition = analyticalTableRef.current?.offsetTop ?? 0;
       const parentHeight = analyticalTableRef.current?.parentElement?.getBoundingClientRect().height;
-      const tableHeight = tableYPosition && parentHeight ? parentHeight - tableYPosition : 0;
+      const tableHeight = parentHeight ? parentHeight - tableYPosition : 0;
       const rowCount = Math.floor((tableHeight - extensionsHeight) / popInRowHeight);
       dispatch({
         type: 'VISIBLE_ROWS',


### PR DESCRIPTION
The `visibleRowCountMode="Auto"` now supports elements rendered above the table in the same container.

E.g.
```jsx
<div style={{ height: '600px' }}>
   <div style={{ height: '100px', width: '100%' }} />
   <AnalyticalTable data={data} columns={columns} visibleRowCountMode={TableVisibleRowCountMode.AUTO} />
</div>
```
This implementation will no longer lead to a vertical overflow of the outer container.