### PR TITLE
fix(AnalyticalTable): add totalRowCount to event.detail param of onLoadMore event, fix rowCount number for expandable rows

### DIFF
--- a/packages/main/src/components/AnalyticalTable/TableBody/VirtualTableBodyContainer.tsx
+++ b/packages/main/src/components/AnalyticalTable/TableBody/VirtualTableBodyContainer.tsx
@@ -42,9 +42,11 @@ export const VirtualTableBodyContainer = (props) => {
           (popInRowHeight === internalRowHeight ? visibleRows : Math.floor(tableBodyHeight / popInRowHeight));
         if (rows.length - currentLastRow < infiniteScrollThreshold) {
           if (!firedInfiniteLoadEvents.current.has(rows.length)) {
+            const rootNodes = rows.filter((row) => row.depth === 0);
             onLoadMore({
               detail: {
-                rowCount: rows.length
+                rowCount: rootNodes.length,
+                totalRowCount: rows.length
               }
             });
           }

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -241,8 +241,11 @@ export interface TableProps extends Omit<CommonProps, 'title'> {
   onColumnsReordered?: (e?: CustomEvent<{ columnsNewOrder: string[]; column: unknown }>) => void;
   /**
    * Fired when the `infiniteScrollThreshold` is reached.
+   *
+   * @param {number} e.detail.rowCount - The number of rows
+   * @param {number} e.detail.totalRowCount - The total number of rows, including sub-rows
    */
-  onLoadMore?: (e?: { detail: { rowCount: number } }) => void;
+  onLoadMore?: (e?: { detail: { rowCount: number; totalRowCount: number } }) => void;
   /**
    * Additional options which will be passed to [react-table´s useTable hook](https://react-table.tanstack.com/docs/api/useTable#table-options)
    */


### PR DESCRIPTION
- Add `totalRowCount` property to `onLoadMore` event (`e.detail.totalRowCount`) that returns the total number of rows, which includes expanded rows in, for example, a tree table.

- Fix `rowCount` property of the `onLoadMore` event (`e.detail.rowCount`) to only show the number of root rows. Therefore, it does not return the number of expanded rows.