### PR TITLE
fix(MessageBox): a11y - use correct title level

### DIFF
--- a/packages/main/src/components/MessageBox/MessageBox.jss.ts
+++ b/packages/main/src/components/MessageBox/MessageBox.jss.ts
@@ -17,9 +17,12 @@ const style = {
     color: ThemingParameters.sapContent_LabelColor,
     fontSize: '1rem',
     '& ui5-icon:first-child': {
-      padding: '0 0.25rem',
+      marginRight: '0.5rem',
       width: '1rem',
       height: '1rem'
+    },
+    '& [ui5-title]': {
+      fontSize: '1rem'
     },
     '&[data-type="Error"]': {
       '--sapPageFooter_BorderColor': ThemingParameters.sapErrorBorderColor,
@@ -42,9 +45,9 @@ const style = {
       '--sapContent_NonInteractiveIconColor': ThemingParameters.sapNeutralElementColor
     },
     '&[data-type="Information"]': {
-      '--sapPageFooter_BorderColor': ThemingParameters.sapNeutralBorderColor,
-      '--messageBoxBorderColor': ThemingParameters.sapNeutralBorderColor,
-      '--sapContent_NonInteractiveIconColor': ThemingParameters.sapNeutralElementColor
+      '--sapPageFooter_BorderColor': ThemingParameters.sapInformationBorderColor,
+      '--messageBoxBorderColor': ThemingParameters.sapInformationBorderColor,
+      '--sapContent_NonInteractiveIconColor': ThemingParameters.sapInformativeElementColor
     },
     '&[data-type="Highlight"]': {
       '--sapPageFooter_BorderColor': ThemingParameters.sapInformationBorderColor,

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`MessageBox Confirm - Cancel 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="question-mark"
+        name="sys-help-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Confirmation
@@ -85,11 +85,11 @@ exports[`MessageBox Confirm 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="question-mark"
+        name="sys-help-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Confirmation
@@ -135,11 +135,11 @@ exports[`MessageBox Custom Action Text 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="question-mark"
+        name="sys-help-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Confirmation
@@ -180,7 +180,7 @@ exports[`MessageBox Don't crash on unknown type 1`] = `
       slot="header"
     >
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       />
     </header>
@@ -219,11 +219,11 @@ exports[`MessageBox Error 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="message-error"
+        name="error"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Error
@@ -268,7 +268,7 @@ exports[`MessageBox Highlight 1`] = `
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Highlight
@@ -309,11 +309,11 @@ exports[`MessageBox Information 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="message-information"
+        name="information"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Information
@@ -361,11 +361,11 @@ exports[`MessageBox No Title 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="question-mark"
+        name="sys-help-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Confirmation
@@ -404,11 +404,11 @@ exports[`MessageBox Not open 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="message-success"
+        name="sys-enter-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Custom Success
@@ -456,11 +456,11 @@ exports[`MessageBox Show 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="question-mark"
+        name="sys-help-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Custom
@@ -501,11 +501,11 @@ exports[`MessageBox Success 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="message-success"
+        name="sys-enter-2"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Success
@@ -550,7 +550,7 @@ exports[`MessageBox Success w/ custom title 1`] = `
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Custom Success
@@ -591,11 +591,11 @@ exports[`MessageBox Warning 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="message-warning"
+        name="alert"
         ui5-icon=""
       />
       <ui5-title
-        level="H5"
+        level="H2"
         ui5-title=""
       >
         Warning

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`MessageBox Confirm - Cancel 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-help-2"
+        name="question-mark"
         ui5-icon=""
       />
       <ui5-title
@@ -85,7 +85,7 @@ exports[`MessageBox Confirm 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-help-2"
+        name="question-mark"
         ui5-icon=""
       />
       <ui5-title
@@ -135,7 +135,7 @@ exports[`MessageBox Custom Action Text 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-help-2"
+        name="question-mark"
         ui5-icon=""
       />
       <ui5-title
@@ -219,7 +219,7 @@ exports[`MessageBox Error 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="error"
+        name="message-error"
         ui5-icon=""
       />
       <ui5-title
@@ -309,7 +309,7 @@ exports[`MessageBox Information 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="information"
+        name="message-information"
         ui5-icon=""
       />
       <ui5-title
@@ -361,7 +361,7 @@ exports[`MessageBox No Title 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-help-2"
+        name="question-mark"
         ui5-icon=""
       />
       <ui5-title
@@ -404,7 +404,7 @@ exports[`MessageBox Not open 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-enter-2"
+        name="message-success"
         ui5-icon=""
       />
       <ui5-title
@@ -456,7 +456,7 @@ exports[`MessageBox Show 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-help-2"
+        name="question-mark"
         ui5-icon=""
       />
       <ui5-title
@@ -501,7 +501,7 @@ exports[`MessageBox Success 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="sys-enter-2"
+        name="message-success"
         ui5-icon=""
       />
       <ui5-title
@@ -591,7 +591,7 @@ exports[`MessageBox Warning 1`] = `
       slot="header"
     >
       <ui5-icon
-        name="alert"
+        name="message-warning"
         ui5-icon=""
       />
       <ui5-title

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -1,8 +1,8 @@
-import '@ui5/webcomponents-icons/dist/sys-help-2';
-import '@ui5/webcomponents-icons/dist/error';
-import '@ui5/webcomponents-icons/dist/information';
-import '@ui5/webcomponents-icons/dist/sys-enter-2';
-import '@ui5/webcomponents-icons/dist/alert';
+import '@ui5/webcomponents-icons/dist/message-error';
+import '@ui5/webcomponents-icons/dist/message-information';
+import '@ui5/webcomponents-icons/dist/message-success';
+import '@ui5/webcomponents-icons/dist/message-warning';
+import '@ui5/webcomponents-icons/dist/question-mark';
 import '@ui5/webcomponents-icons/dist/hint';
 import { useConsolidatedRef, useI18nBundle, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
@@ -99,15 +99,15 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
     if (isValidElement(icon)) return icon;
     switch (type) {
       case MessageBoxTypes.CONFIRM:
-        return <Icon name="sys-help-2" />;
+        return <Icon name="question-mark" />;
       case MessageBoxTypes.ERROR:
-        return <Icon name="error" />;
+        return <Icon name="message-error" />;
       case MessageBoxTypes.INFORMATION:
-        return <Icon name="information" />;
+        return <Icon name="message-information" />;
       case MessageBoxTypes.SUCCESS:
-        return <Icon name="sys-enter-2" />;
+        return <Icon name="message-success" />;
       case MessageBoxTypes.WARNING:
-        return <Icon name="alert" />;
+        return <Icon name="message-warning" />;
       case MessageBoxTypes.HIGHLIGHT:
         return <Icon name="hint" />;
       default:

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-icons/dist/sys-help-2';
+import '@ui5/webcomponents-icons/dist/error';
+import '@ui5/webcomponents-icons/dist/information';
+import '@ui5/webcomponents-icons/dist/sys-enter-2';
+import '@ui5/webcomponents-icons/dist/alert';
 import '@ui5/webcomponents-icons/dist/hint';
-import '@ui5/webcomponents-icons/dist/message-error';
-import '@ui5/webcomponents-icons/dist/message-information';
-import '@ui5/webcomponents-icons/dist/message-success';
-import '@ui5/webcomponents-icons/dist/message-warning';
-import '@ui5/webcomponents-icons/dist/question-mark';
-import { createUseStyles } from 'react-jss';
 import { useConsolidatedRef, useI18nBundle, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
@@ -45,6 +44,7 @@ import React, {
   useEffect,
   useMemo
 } from 'react';
+import { createUseStyles } from 'react-jss';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DialogDomRef } from '../../interfaces/Ui5DialogDomRef';
 import { stopPropagation } from '../../internal/stopPropagation';
@@ -99,15 +99,15 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
     if (isValidElement(icon)) return icon;
     switch (type) {
       case MessageBoxTypes.CONFIRM:
-        return <Icon name="question-mark" />;
+        return <Icon name="sys-help-2" />;
       case MessageBoxTypes.ERROR:
-        return <Icon name="message-error" />;
+        return <Icon name="error" />;
       case MessageBoxTypes.INFORMATION:
-        return <Icon name="message-information" />;
+        return <Icon name="information" />;
       case MessageBoxTypes.SUCCESS:
-        return <Icon name="message-success" />;
+        return <Icon name="sys-enter-2" />;
       case MessageBoxTypes.WARNING:
-        return <Icon name="message-warning" />;
+        return <Icon name="alert" />;
       case MessageBoxTypes.HIGHLIGHT:
         return <Icon name="hint" />;
       default:
@@ -197,7 +197,7 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
       header={
         <header className={classes.header} data-type={type}>
           {iconToRender}
-          <Title level={TitleLevel.H5}>{titleToRender()}</Title>
+          <Title level={TitleLevel.H2}>{titleToRender()}</Title>
         </header>
       }
       footer={


### PR DESCRIPTION
Use `h2` instead of `h5` for the Message Box Title and update the icons to match the latest specs:

![image](https://user-images.githubusercontent.com/8775211/112795510-e9e48c00-9068-11eb-982b-0b714edccb84.png)

Closes #1453 