### PR TITLE
chore: don't publish lib folder anymore

### DIFF
--- a/packages/base/.gitignore
+++ b/packages/base/.gitignore
@@ -2,7 +2,6 @@
 /Device
 /hooks
 /interfaces
-/lib
 /polyfill
 /styling
 /utils

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -18,7 +18,7 @@
     "intersection-observer"
   ],
   "scripts": {
-    "clean": "rimraf Device hooks lib polyfill styling utils index.esm.js index.d.ts dist",
+    "clean": "rimraf Device hooks polyfill styling utils index.esm.js index.d.ts dist",
     "build:rollup": "rollup -c rollup.config.mjs",
     "build:polyfills": "tsc ./src/polyfill/*.ts --outDir ./polyfill --skipLibCheck",
     "build": "npm-run-all -s build:rollup build:polyfills",
@@ -48,7 +48,6 @@
     "Device",
     "dist",
     "hooks",
-    "lib",
     "polyfill",
     "styling",
     "types",

--- a/packages/charts/.gitignore
+++ b/packages/charts/.gitignore
@@ -2,7 +2,6 @@
 /components
 /interfaces
 /internal
-/lib
 /themes
 /util
 /config.d.ts

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "scripts": {
-    "clean": "rimraf components interfaces internal lib util index.esm.js index.d.ts config.d.ts hooks dist",
+    "clean": "rimraf components interfaces internal util index.esm.js index.d.ts config.d.ts hooks dist",
     "build": "rollup -c rollup.config.mjs",
     "build:types": "tsc --declaration --emitDeclarationOnly --declarationDir . --removeComments false"
   },
@@ -39,7 +39,6 @@
     "hooks",
     "interfaces",
     "internal",
-    "lib",
     "CHANGELOG.md",
     "index.d.ts",
     "index.esm.js",

--- a/packages/main/.gitignore
+++ b/packages/main/.gitignore
@@ -3,7 +3,6 @@
 /enums
 /interfaces
 /internal
-/lib
 /webComponents
 /index.d.ts
 /index.esm.js

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -20,7 +20,7 @@
     "./dist/json-imports/*"
   ],
   "scripts": {
-    "clean": "rimraf components enums interfaces internal lib webComponents index.esm.js index.d.ts dist wrappers dist",
+    "clean": "rimraf components enums interfaces internal webComponents index.esm.js index.d.ts dist wrappers dist",
     "build": "npm-run-all -s build:i18n build:rollup",
     "build:rollup": "rollup -c rollup.config.mjs",
     "build:i18n": "npm-run-all -s build:i18n-bundles build:i18n-default build:i18n-imports build:assets",
@@ -64,7 +64,6 @@
     "enums",
     "interfaces",
     "internal",
-    "lib",
     "webComponents",
     "wrappers",
     "CHANGELOG.md",

--- a/scripts/rollup/configFactory.js
+++ b/scripts/rollup/configFactory.js
@@ -6,7 +6,6 @@ import micromatch from 'micromatch';
 import PATHS from '../../config/paths.js';
 import { asyncCopyTo, highlightLog } from '../utils.js';
 import glob from 'glob';
-import dedent from 'dedent';
 
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
@@ -92,27 +91,6 @@ const rollupConfigFactory = (pkgName, externals = []) => {
       external,
       treeshake,
       output: [
-        {
-          file: path.resolve(
-            PKG_BASE_PATH,
-            'lib',
-            file.replace(`${LIB_BASE_PATH}${path.sep}`, '').replace(/\.ts$/, '.js')
-          ),
-          format: 'es',
-          sourcemap: true,
-          footer: () => {
-            const componentName = file.replace(`${LIB_BASE_PATH}${path.sep}`, '').replace(/\.ts$/, '');
-            return dedent`
-              if ( console && console.warn && ( process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test' ) ) {
-                console.warn(
-                  "Deprecation Notice - '${packageJson.name}': " +
-                  "Using \"import { ${componentName} } from '${packageJson.name}/lib/${componentName}';\" is deprecated and will be removed with version 0.15.0. " +
-                  "Please use \"import { ${componentName} } from '${packageJson.name}';\" instead. You can find more details in our Migration Guide: https://bit.ly/2MV7KWw "
-                );
-              }
-              `;
-          }
-        },
         {
           file: path.resolve(
             PKG_BASE_PATH,


### PR DESCRIPTION
BREAKING CHANGE: `@ui5/webcomponents-react`, `@ui5/webcomponents-react-base` and `@ui5/webcomponents-react-charts` are no longer publishing the `lib` folder. Please use `dist` instead. More details can be found in our [MigrationGuide](https://sap.github.io/ui5-webcomponents-react/?path=/docs/migration-guide--page#replaced-lib-folder-with-dist-folder).
