### PR TITLE
fix(Breadcrumbs): add missing aria labels & allow navigation with arrow keys

### DIFF
--- a/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -2,270 +2,402 @@
 
 exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      \\
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      \\
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          \\
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          \\
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      \\\\
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      \\\\
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          \\\\
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          \\\\
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      &gt;&gt;
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      &gt;&gt;
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          &gt;&gt;
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          &gt;&gt;
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      //
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      //
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          //
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          //
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      &gt;
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      &gt;
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          &gt;
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          &gt;
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      /
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      /
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          /
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          /
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;
 
 exports[`Breadcrumbs with currentLocationText 1`] = `
 <DocumentFragment>
-  <div>
-    <ui5-link
-      design="Default"
-      ui5-link=""
+  <nav
+    aria-label="Breadcrumb Trail"
+  >
+    <ol
+      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
     >
-      Link 1
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      /
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 2
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      /
-    </ui5-label>
-    <ui5-link
-      design="Default"
-      ui5-link=""
-    >
-      Link 3
-    </ui5-link>
-    <ui5-label
-      style="margin: 0px 0.25rem;"
-      ui5-label=""
-    >
-      /
-    </ui5-label>
-    <ui5-label
-      ui5-label=""
-    >
-      Current Location
-    </ui5-label>
-  </div>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 1
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          /
+        </ui5-label>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 2
+        </ui5-link>
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          /
+        </ui5-label>
+      </li>
+      <li>
+        <ui5-link
+          design="Default"
+          ui5-link=""
+        >
+          Link 3
+        </ui5-link>
+      </li>
+      <li
+        style="display: flex;"
+      >
+        <ui5-label
+          aria-hidden="true"
+          style="margin: 0px 0.25rem;"
+          ui5-label=""
+        >
+          /
+        </ui5-label>
+        <ui5-label
+          aria-current="page"
+          ui5-label=""
+        >
+          Current Location
+        </ui5-label>
+      </li>
+    </ol>
+  </nav>
 </DocumentFragment>
 `;

--- a/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -8,9 +8,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -27,9 +25,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
           \\
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -46,9 +42,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
           \\
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -71,9 +65,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -90,9 +82,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
           \\\\
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -109,9 +99,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
           \\\\
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -134,9 +122,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -153,9 +139,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
           &gt;&gt;
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -172,9 +156,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
           &gt;&gt;
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -197,9 +179,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -216,9 +196,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
           //
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -235,9 +213,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
           //
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -260,9 +236,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -279,9 +253,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
           &gt;
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -298,9 +270,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
           &gt;
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -323,9 +293,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -342,9 +310,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
           /
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -361,9 +327,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
           /
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -386,9 +350,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
     <ol
       class="Breadcrumbs-list"
     >
-      <li
-        id="0"
-      >
+      <li>
         <ui5-link
           data-id="0"
           design="Default"
@@ -405,9 +367,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
           /
         </ui5-label>
       </li>
-      <li
-        id="1"
-      >
+      <li>
         <ui5-link
           data-id="1"
           design="Default"
@@ -424,9 +384,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
           /
         </ui5-label>
       </li>
-      <li
-        id="2"
-      >
+      <li>
         <ui5-link
           data-id="2"
           design="Default"
@@ -443,9 +401,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
           /
         </ui5-label>
       </li>
-      <li
-        id="3"
-      >
+      <li>
         <div
           aria-current="page"
           class="Breadcrumbs-currentLocation"

--- a/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -27,7 +27,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -44,7 +44,7 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -67,7 +67,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -84,7 +84,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -101,7 +101,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -124,7 +124,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -141,7 +141,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -158,7 +158,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -181,7 +181,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -198,7 +198,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -215,7 +215,7 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -238,7 +238,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -255,7 +255,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -272,7 +272,7 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -295,7 +295,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -312,7 +312,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -329,7 +329,7 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -352,7 +352,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
     >
       <li>
         <ui5-link
-          data-id="0"
+          data-breadcrumb-index="0"
           design="Default"
           tabindex="0"
           ui5-link=""
@@ -369,7 +369,7 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="1"
+          data-breadcrumb-index="1"
           design="Default"
           tabindex="-1"
           ui5-link=""
@@ -386,13 +386,15 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
       </li>
       <li>
         <ui5-link
-          data-id="2"
+          data-breadcrumb-index="2"
           design="Default"
           tabindex="-1"
           ui5-link=""
         >
           Link 3
         </ui5-link>
+      </li>
+      <li>
         <ui5-label
           aria-hidden="true"
           class="Breadcrumbs-separatorInline"
@@ -400,12 +402,10 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
         >
           /
         </ui5-label>
-      </li>
-      <li>
         <div
           aria-current="page"
           class="Breadcrumbs-currentLocation"
-          data-id="3"
+          data-breadcrumb-index="3"
           tabindex="-1"
         >
           Current Location

--- a/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/main/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -6,45 +6,53 @@ exports[`Breadcrumbs separatorStyle: 'BackSlash' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           \\
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           \\
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -61,45 +69,53 @@ exports[`Breadcrumbs separatorStyle: 'DoubleBackSlash' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           \\\\
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           \\\\
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -116,45 +132,53 @@ exports[`Breadcrumbs separatorStyle: 'DoubleGreaterThan' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           &gt;&gt;
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           &gt;&gt;
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -171,45 +195,53 @@ exports[`Breadcrumbs separatorStyle: 'DoubleSlash' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           //
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           //
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -226,45 +258,53 @@ exports[`Breadcrumbs separatorStyle: 'GreaterThan' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           &gt;
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           &gt;
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -281,45 +321,53 @@ exports[`Breadcrumbs separatorStyle: 'Slash' 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           /
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           /
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
@@ -336,66 +384,76 @@ exports[`Breadcrumbs with currentLocationText 1`] = `
     aria-label="Breadcrumb Trail"
   >
     <ol
-      style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+      class="Breadcrumbs-list"
     >
       <li
-        style="display: flex;"
+        id="0"
       >
         <ui5-link
+          data-id="0"
           design="Default"
+          tabindex="0"
           ui5-link=""
         >
           Link 1
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           /
         </ui5-label>
       </li>
       <li
-        style="display: flex;"
+        id="1"
       >
         <ui5-link
+          data-id="1"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 2
         </ui5-link>
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           /
         </ui5-label>
       </li>
-      <li>
+      <li
+        id="2"
+      >
         <ui5-link
+          data-id="2"
           design="Default"
+          tabindex="-1"
           ui5-link=""
         >
           Link 3
         </ui5-link>
-      </li>
-      <li
-        style="display: flex;"
-      >
         <ui5-label
           aria-hidden="true"
-          style="margin: 0px 0.25rem;"
+          class="Breadcrumbs-separatorInline"
           ui5-label=""
         >
           /
         </ui5-label>
-        <ui5-label
+      </li>
+      <li
+        id="3"
+      >
+        <div
           aria-current="page"
-          ui5-label=""
+          class="Breadcrumbs-currentLocation"
+          data-id="3"
+          tabindex="-1"
         >
           Current Location
-        </ui5-label>
+        </div>
       </li>
     </ol>
   </nav>

--- a/packages/main/src/components/Breadcrumbs/index.tsx
+++ b/packages/main/src/components/Breadcrumbs/index.tsx
@@ -1,7 +1,20 @@
+import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { BreadcrumbsSeparatorStyle } from '@ui5/webcomponents-react/dist/BreadcrumbsSeparatorStyle';
 import { Label } from '@ui5/webcomponents-react/dist/Label';
-import React, { Children, FC, forwardRef, Fragment, ReactNode, ReactNodeArray, Ref } from 'react';
+import React, {
+  Children,
+  cloneElement,
+  FC,
+  forwardRef,
+  ReactElement,
+  ReactNode,
+  ReactNodeArray,
+  Ref,
+  useRef,
+  useState
+} from 'react';
+import { createUseStyles } from 'react-jss';
 import { CommonProps } from '../../interfaces/CommonProps';
 
 const SeparatorStyles = {
@@ -12,8 +25,6 @@ const SeparatorStyles = {
   GreaterThan: '>',
   Slash: '/'
 };
-
-const separatorInlineStyles = { margin: '0 0.25rem' };
 
 export interface BreadcrumbsPropTypes extends CommonProps {
   /**
@@ -30,14 +41,67 @@ export interface BreadcrumbsPropTypes extends CommonProps {
   currentLocationText?: string;
 }
 
+const useStyles = createUseStyles(
+  {
+    list: {
+      listStyleType: 'none',
+      display: 'flex',
+      alignItems: 'center',
+      marginBlock: 0,
+      paddingInline: 0,
+      flexWrap: 'wrap',
+      '& li': {
+        display: 'flex',
+        overflow: 'hidden'
+      }
+    },
+    separatorInline: {
+      margin: '0 0.25rem'
+    },
+    currentLocation: {
+      fontFamily: ThemingParameters.sapFontFamily,
+      fontSize: ThemingParameters.sapFontSize,
+      color: ThemingParameters.sapContent_LabelColor,
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      '&:focus': {
+        outline: `${ThemingParameters.sapContent_FocusWidth} ${ThemingParameters.sapContent_FocusStyle} ${ThemingParameters.sapContent_FocusColor}`,
+        outlineOffset: '-0.0625rem'
+      }
+    }
+  },
+  { name: 'Breadcrumbs' }
+);
+
 /**
  * Enables users to navigate between items by providing a list of links to previous steps in the user's navigation path.
  */
 const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsPropTypes, ref: Ref<HTMLDivElement>) => {
   const { children, separatorStyle, currentLocationText, tooltip, style, className, slot } = props;
+  const classes = useStyles();
   const childrenArray = Children.toArray(children).filter(Boolean);
+  const [focusedItem, setFocusedItem] = useState(0);
+
+  const handleItemFocus = (e) => {
+    const currentId = parseInt(e.target.dataset.id);
+    setFocusedItem(currentId);
+  };
+
+  const handleKeyDownInList = (e) => {
+    const target = e.target as HTMLElement;
+    const currentId = parseInt(target.parentElement.id);
+    if (e.key === 'ArrowRight' && currentId + 1 <= childrenArray.length) {
+      breadcrumbsRef.current.children[currentId + 1].children[0].focus();
+    }
+    if (e.key === 'ArrowLeft' && currentId > 0) {
+      breadcrumbsRef.current.children[currentId - 1].children[0].focus();
+    }
+  };
 
   const passThroughProps = usePassThroughHtmlProps(props);
+
+  const breadcrumbsRef = useRef(null);
 
   return (
     <nav
@@ -49,35 +113,48 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
       aria-label="Breadcrumb Trail"
       {...passThroughProps}
     >
-      <ol
-        style={{
-          listStyleType: 'none',
-          display: 'flex',
-          alignItems: 'center',
-          marginBlock: 0,
-          paddingInline: 0,
-          flexWrap: 'wrap'
-        }}
-      >
+      <ol className={classes.list} ref={breadcrumbsRef} onKeyDown={handleKeyDownInList}>
         {childrenArray.map((item, index) => {
           if (index === childrenArray.length - 1) {
-            return <li key={`bc-${index}`}>{item}</li>;
+            return (
+              <li key={`bc-${index}`} id={`${index}`}>
+                {cloneElement(item as ReactElement, {
+                  tabIndex: focusedItem === index ? 0 : -1,
+                  onFocus: handleItemFocus,
+                  'data-id': index
+                })}
+                {currentLocationText && (
+                  <Label className={classes.separatorInline} aria-hidden="true">
+                    {SeparatorStyles[separatorStyle]}
+                  </Label>
+                )}
+              </li>
+            );
           }
           return (
-            <li key={`bc-${index}`} style={{ display: 'flex' }}>
-              {item}
-              <Label style={separatorInlineStyles} aria-hidden="true">
+            <li key={`bc-${index}`} id={`${index}`}>
+              {cloneElement(item as ReactElement, {
+                tabIndex: focusedItem === index ? 0 : -1,
+                onFocus: handleItemFocus,
+                'data-id': index
+              })}
+              <Label className={classes.separatorInline} aria-hidden="true">
                 {SeparatorStyles[separatorStyle]}
               </Label>
             </li>
           );
         })}
         {currentLocationText && (
-          <li key={`bc-${currentLocationText}`} style={{ display: 'flex' }}>
-            <Label style={separatorInlineStyles} aria-hidden="true">
-              {SeparatorStyles[separatorStyle]}
-            </Label>
-            <Label aria-current="page">{currentLocationText}</Label>
+          <li key={`bc-${currentLocationText}`} id={`${childrenArray.length}`}>
+            <div
+              aria-current="page"
+              tabIndex={focusedItem === childrenArray.length ? 0 : -1}
+              className={classes.currentLocation}
+              onFocus={handleItemFocus}
+              data-id={childrenArray.length}
+            >
+              {currentLocationText}
+            </div>
           </li>
         )}
       </ol>

--- a/packages/main/src/components/Breadcrumbs/index.tsx
+++ b/packages/main/src/components/Breadcrumbs/index.tsx
@@ -40,25 +40,48 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
   const passThroughProps = usePassThroughHtmlProps(props);
 
   return (
-    <div ref={ref} title={tooltip} style={style} className={className} slot={slot} {...passThroughProps}>
-      {childrenArray.map((item, index) => {
-        if (index === childrenArray.length - 1) {
-          return item;
-        }
-        return (
-          <Fragment key={index}>
-            {item}
-            <Label style={separatorInlineStyles} children={SeparatorStyles[separatorStyle]} />
-          </Fragment>
-        );
-      })}
-      {currentLocationText && (
-        <>
-          <Label style={separatorInlineStyles}>{SeparatorStyles[separatorStyle]}</Label>
-          <Label>{currentLocationText}</Label>
-        </>
-      )}
-    </div>
+    <nav
+      ref={ref}
+      title={tooltip}
+      style={style}
+      className={className}
+      slot={slot}
+      aria-label="Breadcrumb Trail"
+      {...passThroughProps}
+    >
+      <ol
+        style={{
+          listStyleType: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          marginBlock: 0,
+          paddingInline: 0,
+          flexWrap: 'wrap'
+        }}
+      >
+        {childrenArray.map((item, index) => {
+          if (index === childrenArray.length - 1) {
+            return <li key={`bc-${index}`}>{item}</li>;
+          }
+          return (
+            <li key={`bc-${index}`} style={{ display: 'flex' }}>
+              {item}
+              <Label style={separatorInlineStyles} aria-hidden="true">
+                {SeparatorStyles[separatorStyle]}
+              </Label>
+            </li>
+          );
+        })}
+        {currentLocationText && (
+          <li key={`bc-${currentLocationText}`} style={{ display: 'flex' }}>
+            <Label style={separatorInlineStyles} aria-hidden="true">
+              {SeparatorStyles[separatorStyle]}
+            </Label>
+            <Label aria-current="page">{currentLocationText}</Label>
+          </li>
+        )}
+      </ol>
+    </nav>
   );
 });
 

--- a/packages/main/src/components/Breadcrumbs/index.tsx
+++ b/packages/main/src/components/Breadcrumbs/index.tsx
@@ -11,6 +11,7 @@ import React, {
   ReactNode,
   ReactNodeArray,
   Ref,
+  useCallback,
   useRef,
   useState
 } from 'react';
@@ -82,26 +83,29 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
   const classes = useStyles();
   const childrenArray = Children.toArray(children).filter(Boolean);
   const [focusedItem, setFocusedItem] = useState(0);
+  const breadcrumbsRef = useRef(null);
 
   const handleItemFocus = (e) => {
     const currentId = parseInt(e.target.dataset.id);
     setFocusedItem(currentId);
   };
 
-  const handleKeyDownInList = (e) => {
-    const target = e.target as HTMLElement;
-    const currentId = parseInt(target.parentElement.id);
-    if (e.key === 'ArrowRight' && currentId + 1 <= childrenArray.length) {
-      breadcrumbsRef.current.children[currentId + 1].children[0].focus();
-    }
-    if (e.key === 'ArrowLeft' && currentId > 0) {
-      breadcrumbsRef.current.children[currentId - 1].children[0].focus();
-    }
-  };
+  const handleKeyDownInList = useCallback(
+    (e) => {
+      const target = e.target as HTMLElement;
+      const currentId = parseInt(target.parentElement.id);
+      const childrenLength = currentLocationText ? childrenArray.length : childrenArray.length - 1;
+      if (e.key === 'ArrowRight' && currentId + 1 <= childrenLength) {
+        breadcrumbsRef.current.children[currentId + 1].children[0].focus();
+      }
+      if (e.key === 'ArrowLeft' && currentId > 0) {
+        breadcrumbsRef.current.children[currentId - 1].children[0].focus();
+      }
+    },
+    [currentLocationText, childrenArray.length, breadcrumbsRef.current]
+  );
 
   const passThroughProps = usePassThroughHtmlProps(props);
-
-  const breadcrumbsRef = useRef(null);
 
   return (
     <nav

--- a/packages/main/src/components/Breadcrumbs/index.tsx
+++ b/packages/main/src/components/Breadcrumbs/index.tsx
@@ -92,8 +92,7 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
 
   const handleKeyDownInList = useCallback(
     (e) => {
-      const target = e.target as HTMLElement;
-      const currentId = parseInt(target.parentElement.id);
+      const currentId = parseInt(e.target.dataset.id);
       const childrenLength = currentLocationText ? childrenArray.length : childrenArray.length - 1;
       if (e.key === 'ArrowRight' && currentId + 1 <= childrenLength) {
         breadcrumbsRef.current.children[currentId + 1].children[0].focus();
@@ -121,7 +120,7 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
         {childrenArray.map((item, index) => {
           if (index === childrenArray.length - 1) {
             return (
-              <li key={`bc-${index}`} id={`${index}`}>
+              <li key={`bc-${index}`}>
                 {cloneElement(item as ReactElement, {
                   tabIndex: focusedItem === index ? 0 : -1,
                   onFocus: handleItemFocus,
@@ -136,7 +135,7 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
             );
           }
           return (
-            <li key={`bc-${index}`} id={`${index}`}>
+            <li key={`bc-${index}`}>
               {cloneElement(item as ReactElement, {
                 tabIndex: focusedItem === index ? 0 : -1,
                 onFocus: handleItemFocus,
@@ -149,7 +148,7 @@ const Breadcrumbs: FC<BreadcrumbsPropTypes> = forwardRef((props: BreadcrumbsProp
           );
         })}
         {currentLocationText && (
-          <li key={`bc-${currentLocationText}`} id={`${childrenArray.length}`}>
+          <li key={`bc-${currentLocationText}`}>
             <div
               aria-current="page"
               tabIndex={focusedItem === childrenArray.length ? 0 : -1}

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`DynamicPage always show content header 1`] = `
           >
             <li>
               <ui5-link
-                data-id="0"
+                data-breadcrumb-index="0"
                 design="Default"
                 tabindex="0"
                 ui5-link=""
@@ -37,7 +37,7 @@ exports[`DynamicPage always show content header 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="1"
+                data-breadcrumb-index="1"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -54,7 +54,7 @@ exports[`DynamicPage always show content header 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="2"
+                data-breadcrumb-index="2"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -71,7 +71,7 @@ exports[`DynamicPage always show content header 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="3"
+                data-breadcrumb-index="3"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -88,7 +88,7 @@ exports[`DynamicPage always show content header 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="4"
+                data-breadcrumb-index="4"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -105,7 +105,7 @@ exports[`DynamicPage always show content header 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="5"
+                data-breadcrumb-index="5"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -341,7 +341,7 @@ exports[`DynamicPage hider header button 1`] = `
           >
             <li>
               <ui5-link
-                data-id="0"
+                data-breadcrumb-index="0"
                 design="Default"
                 tabindex="0"
                 ui5-link=""
@@ -358,7 +358,7 @@ exports[`DynamicPage hider header button 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="1"
+                data-breadcrumb-index="1"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -375,7 +375,7 @@ exports[`DynamicPage hider header button 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="2"
+                data-breadcrumb-index="2"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -392,7 +392,7 @@ exports[`DynamicPage hider header button 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="3"
+                data-breadcrumb-index="3"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -409,7 +409,7 @@ exports[`DynamicPage hider header button 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="4"
+                data-breadcrumb-index="4"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -426,7 +426,7 @@ exports[`DynamicPage hider header button 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="5"
+                data-breadcrumb-index="5"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -817,7 +817,7 @@ exports[`DynamicPage with content 1`] = `
           >
             <li>
               <ui5-link
-                data-id="0"
+                data-breadcrumb-index="0"
                 design="Default"
                 tabindex="0"
                 ui5-link=""
@@ -834,7 +834,7 @@ exports[`DynamicPage with content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="1"
+                data-breadcrumb-index="1"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -851,7 +851,7 @@ exports[`DynamicPage with content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="2"
+                data-breadcrumb-index="2"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -868,7 +868,7 @@ exports[`DynamicPage with content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="3"
+                data-breadcrumb-index="3"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -885,7 +885,7 @@ exports[`DynamicPage with content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="4"
+                data-breadcrumb-index="4"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -902,7 +902,7 @@ exports[`DynamicPage with content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="5"
+                data-breadcrumb-index="5"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -1794,7 +1794,7 @@ exports[`DynamicPage without content 1`] = `
           >
             <li>
               <ui5-link
-                data-id="0"
+                data-breadcrumb-index="0"
                 design="Default"
                 tabindex="0"
                 ui5-link=""
@@ -1811,7 +1811,7 @@ exports[`DynamicPage without content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="1"
+                data-breadcrumb-index="1"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -1828,7 +1828,7 @@ exports[`DynamicPage without content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="2"
+                data-breadcrumb-index="2"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -1845,7 +1845,7 @@ exports[`DynamicPage without content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="3"
+                data-breadcrumb-index="3"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -1862,7 +1862,7 @@ exports[`DynamicPage without content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="4"
+                data-breadcrumb-index="4"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""
@@ -1879,7 +1879,7 @@ exports[`DynamicPage without content 1`] = `
             </li>
             <li>
               <ui5-link
-                data-id="5"
+                data-breadcrumb-index="5"
                 design="Default"
                 tabindex="-1"
                 ui5-link=""

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -16,96 +16,110 @@ exports[`DynamicPage always show content header 1`] = `
           aria-label="Breadcrumb Trail"
         >
           <ol
-            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+            class="Breadcrumbs-list"
           >
             <li
-              style="display: flex;"
+              id="0"
             >
               <ui5-link
+                data-id="0"
                 design="Default"
+                tabindex="0"
                 ui5-link=""
               >
                 Home
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="1"
             >
               <ui5-link
+                data-id="1"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 1
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="2"
             >
               <ui5-link
+                data-id="2"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 2
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="3"
             >
               <ui5-link
+                data-id="3"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 3
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="4"
             >
               <ui5-link
+                data-id="4"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 4
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
-            <li>
+            <li
+              id="5"
+            >
               <ui5-link
+                data-id="5"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 5
@@ -335,96 +349,110 @@ exports[`DynamicPage hider header button 1`] = `
           aria-label="Breadcrumb Trail"
         >
           <ol
-            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+            class="Breadcrumbs-list"
           >
             <li
-              style="display: flex;"
+              id="0"
             >
               <ui5-link
+                data-id="0"
                 design="Default"
+                tabindex="0"
                 ui5-link=""
               >
                 Home
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="1"
             >
               <ui5-link
+                data-id="1"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 1
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="2"
             >
               <ui5-link
+                data-id="2"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 2
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="3"
             >
               <ui5-link
+                data-id="3"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 3
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="4"
             >
               <ui5-link
+                data-id="4"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 4
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
-            <li>
+            <li
+              id="5"
+            >
               <ui5-link
+                data-id="5"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 5
@@ -809,96 +837,110 @@ exports[`DynamicPage with content 1`] = `
           aria-label="Breadcrumb Trail"
         >
           <ol
-            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+            class="Breadcrumbs-list"
           >
             <li
-              style="display: flex;"
+              id="0"
             >
               <ui5-link
+                data-id="0"
                 design="Default"
+                tabindex="0"
                 ui5-link=""
               >
                 Home
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="1"
             >
               <ui5-link
+                data-id="1"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 1
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="2"
             >
               <ui5-link
+                data-id="2"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 2
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="3"
             >
               <ui5-link
+                data-id="3"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 3
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="4"
             >
               <ui5-link
+                data-id="4"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 4
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
-            <li>
+            <li
+              id="5"
+            >
               <ui5-link
+                data-id="5"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 5
@@ -1784,96 +1826,110 @@ exports[`DynamicPage without content 1`] = `
           aria-label="Breadcrumb Trail"
         >
           <ol
-            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+            class="Breadcrumbs-list"
           >
             <li
-              style="display: flex;"
+              id="0"
             >
               <ui5-link
+                data-id="0"
                 design="Default"
+                tabindex="0"
                 ui5-link=""
               >
                 Home
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="1"
             >
               <ui5-link
+                data-id="1"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 1
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="2"
             >
               <ui5-link
+                data-id="2"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 2
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="3"
             >
               <ui5-link
+                data-id="3"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 3
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
             <li
-              style="display: flex;"
+              id="4"
             >
               <ui5-link
+                data-id="4"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 4
               </ui5-link>
               <ui5-label
                 aria-hidden="true"
-                style="margin: 0px 0.25rem;"
+                class="Breadcrumbs-separatorInline"
                 ui5-label=""
               >
                 /
               </ui5-label>
             </li>
-            <li>
+            <li
+              id="5"
+            >
               <ui5-link
+                data-id="5"
                 design="Default"
+                tabindex="-1"
                 ui5-link=""
               >
                 Page 5

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -12,74 +12,107 @@ exports[`DynamicPage always show content header 1`] = `
       <div
         class="DynamicPageTitle-breadcrumbs"
       >
-        <div>
-          <ui5-link
-            design="Default"
-            ui5-link=""
+        <nav
+          aria-label="Breadcrumb Trail"
+        >
+          <ol
+            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
           >
-            Home
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 1
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 2
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 3
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 4
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 5
-          </ui5-link>
-        </div>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Home
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 1
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 2
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 3
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 4
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li>
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 5
+              </ui5-link>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsCenter FlexBox-flexWrapNoWrap"
@@ -298,74 +331,107 @@ exports[`DynamicPage hider header button 1`] = `
       <div
         class="DynamicPageTitle-breadcrumbs"
       >
-        <div>
-          <ui5-link
-            design="Default"
-            ui5-link=""
+        <nav
+          aria-label="Breadcrumb Trail"
+        >
+          <ol
+            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
           >
-            Home
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 1
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 2
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 3
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 4
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 5
-          </ui5-link>
-        </div>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Home
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 1
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 2
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 3
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 4
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li>
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 5
+              </ui5-link>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsCenter FlexBox-flexWrapNoWrap"
@@ -739,74 +805,107 @@ exports[`DynamicPage with content 1`] = `
       <div
         class="DynamicPageTitle-breadcrumbs"
       >
-        <div>
-          <ui5-link
-            design="Default"
-            ui5-link=""
+        <nav
+          aria-label="Breadcrumb Trail"
+        >
+          <ol
+            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
           >
-            Home
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 1
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 2
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 3
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 4
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 5
-          </ui5-link>
-        </div>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Home
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 1
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 2
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 3
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 4
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li>
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 5
+              </ui5-link>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsCenter FlexBox-flexWrapNoWrap"
@@ -1681,74 +1780,107 @@ exports[`DynamicPage without content 1`] = `
       <div
         class="DynamicPageTitle-breadcrumbs"
       >
-        <div>
-          <ui5-link
-            design="Default"
-            ui5-link=""
+        <nav
+          aria-label="Breadcrumb Trail"
+        >
+          <ol
+            style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
           >
-            Home
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 1
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 2
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 3
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 4
-          </ui5-link>
-          <ui5-label
-            style="margin: 0px 0.25rem;"
-            ui5-label=""
-          >
-            /
-          </ui5-label>
-          <ui5-link
-            design="Default"
-            ui5-link=""
-          >
-            Page 5
-          </ui5-link>
-        </div>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Home
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 1
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 2
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 3
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li
+              style="display: flex;"
+            >
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 4
+              </ui5-link>
+              <ui5-label
+                aria-hidden="true"
+                style="margin: 0px 0.25rem;"
+                ui5-label=""
+              >
+                /
+              </ui5-label>
+            </li>
+            <li>
+              <ui5-link
+                design="Default"
+                ui5-link=""
+              >
+                Page 5
+              </ui5-link>
+            </li>
+          </ol>
+        </nav>
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsCenter FlexBox-flexWrapNoWrap"

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -18,9 +18,7 @@ exports[`DynamicPage always show content header 1`] = `
           <ol
             class="Breadcrumbs-list"
           >
-            <li
-              id="0"
-            >
+            <li>
               <ui5-link
                 data-id="0"
                 design="Default"
@@ -37,9 +35,7 @@ exports[`DynamicPage always show content header 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="1"
-            >
+            <li>
               <ui5-link
                 data-id="1"
                 design="Default"
@@ -56,9 +52,7 @@ exports[`DynamicPage always show content header 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="2"
-            >
+            <li>
               <ui5-link
                 data-id="2"
                 design="Default"
@@ -75,9 +69,7 @@ exports[`DynamicPage always show content header 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="3"
-            >
+            <li>
               <ui5-link
                 data-id="3"
                 design="Default"
@@ -94,9 +86,7 @@ exports[`DynamicPage always show content header 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="4"
-            >
+            <li>
               <ui5-link
                 data-id="4"
                 design="Default"
@@ -113,9 +103,7 @@ exports[`DynamicPage always show content header 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="5"
-            >
+            <li>
               <ui5-link
                 data-id="5"
                 design="Default"
@@ -351,9 +339,7 @@ exports[`DynamicPage hider header button 1`] = `
           <ol
             class="Breadcrumbs-list"
           >
-            <li
-              id="0"
-            >
+            <li>
               <ui5-link
                 data-id="0"
                 design="Default"
@@ -370,9 +356,7 @@ exports[`DynamicPage hider header button 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="1"
-            >
+            <li>
               <ui5-link
                 data-id="1"
                 design="Default"
@@ -389,9 +373,7 @@ exports[`DynamicPage hider header button 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="2"
-            >
+            <li>
               <ui5-link
                 data-id="2"
                 design="Default"
@@ -408,9 +390,7 @@ exports[`DynamicPage hider header button 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="3"
-            >
+            <li>
               <ui5-link
                 data-id="3"
                 design="Default"
@@ -427,9 +407,7 @@ exports[`DynamicPage hider header button 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="4"
-            >
+            <li>
               <ui5-link
                 data-id="4"
                 design="Default"
@@ -446,9 +424,7 @@ exports[`DynamicPage hider header button 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="5"
-            >
+            <li>
               <ui5-link
                 data-id="5"
                 design="Default"
@@ -839,9 +815,7 @@ exports[`DynamicPage with content 1`] = `
           <ol
             class="Breadcrumbs-list"
           >
-            <li
-              id="0"
-            >
+            <li>
               <ui5-link
                 data-id="0"
                 design="Default"
@@ -858,9 +832,7 @@ exports[`DynamicPage with content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="1"
-            >
+            <li>
               <ui5-link
                 data-id="1"
                 design="Default"
@@ -877,9 +849,7 @@ exports[`DynamicPage with content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="2"
-            >
+            <li>
               <ui5-link
                 data-id="2"
                 design="Default"
@@ -896,9 +866,7 @@ exports[`DynamicPage with content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="3"
-            >
+            <li>
               <ui5-link
                 data-id="3"
                 design="Default"
@@ -915,9 +883,7 @@ exports[`DynamicPage with content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="4"
-            >
+            <li>
               <ui5-link
                 data-id="4"
                 design="Default"
@@ -934,9 +900,7 @@ exports[`DynamicPage with content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="5"
-            >
+            <li>
               <ui5-link
                 data-id="5"
                 design="Default"
@@ -1828,9 +1792,7 @@ exports[`DynamicPage without content 1`] = `
           <ol
             class="Breadcrumbs-list"
           >
-            <li
-              id="0"
-            >
+            <li>
               <ui5-link
                 data-id="0"
                 design="Default"
@@ -1847,9 +1809,7 @@ exports[`DynamicPage without content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="1"
-            >
+            <li>
               <ui5-link
                 data-id="1"
                 design="Default"
@@ -1866,9 +1826,7 @@ exports[`DynamicPage without content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="2"
-            >
+            <li>
               <ui5-link
                 data-id="2"
                 design="Default"
@@ -1885,9 +1843,7 @@ exports[`DynamicPage without content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="3"
-            >
+            <li>
               <ui5-link
                 data-id="3"
                 design="Default"
@@ -1904,9 +1860,7 @@ exports[`DynamicPage without content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="4"
-            >
+            <li>
               <ui5-link
                 data-id="4"
                 design="Default"
@@ -1923,9 +1877,7 @@ exports[`DynamicPage without content 1`] = `
                 /
               </ui5-label>
             </li>
-            <li
-              id="5"
-            >
+            <li>
               <ui5-link
                 data-id="5"
                 design="Default"

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -336,7 +336,7 @@ exports[`ObjectPage Key Infos 1`] = `
               >
                 <li>
                   <ui5-link
-                    data-id="0"
+                    data-breadcrumb-index="0"
                     design="Default"
                     href="PathSegment1"
                     tabindex="0"
@@ -354,7 +354,7 @@ exports[`ObjectPage Key Infos 1`] = `
                 </li>
                 <li>
                   <ui5-link
-                    data-id="1"
+                    data-breadcrumb-index="1"
                     design="Default"
                     href="PathSegment2"
                     tabindex="-1"
@@ -372,7 +372,7 @@ exports[`ObjectPage Key Infos 1`] = `
                 </li>
                 <li>
                   <ui5-link
-                    data-id="2"
+                    data-breadcrumb-index="2"
                     design="Default"
                     href="PathSegment3"
                     tabindex="-1"

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -334,9 +334,7 @@ exports[`ObjectPage Key Infos 1`] = `
               <ol
                 class="Breadcrumbs-list"
               >
-                <li
-                  id="0"
-                >
+                <li>
                   <ui5-link
                     data-id="0"
                     design="Default"
@@ -354,9 +352,7 @@ exports[`ObjectPage Key Infos 1`] = `
                     /
                   </ui5-label>
                 </li>
-                <li
-                  id="1"
-                >
+                <li>
                   <ui5-link
                     data-id="1"
                     design="Default"
@@ -374,9 +370,7 @@ exports[`ObjectPage Key Infos 1`] = `
                     /
                   </ui5-label>
                 </li>
-                <li
-                  id="2"
-                >
+                <li>
                   <ui5-link
                     data-id="2"
                     design="Default"

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -328,39 +328,57 @@ exports[`ObjectPage Key Infos 1`] = `
           <div
             class="FlexBox-flexBox FlexBox-flexBoxDirectionColumn FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap ObjectPage-container"
           >
-            <div>
-              <ui5-link
-                design="Default"
-                href="PathSegment1"
-                ui5-link=""
+            <nav
+              aria-label="Breadcrumb Trail"
+            >
+              <ol
+                style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
               >
-                Path1
-              </ui5-link>
-              <ui5-label
-                style="margin: 0px 0.25rem;"
-                ui5-label=""
-              >
-                /
-              </ui5-label>
-              <ui5-link
-                design="Default"
-                href="PathSegment2"
-                ui5-link=""
-              >
-                Path2
-              </ui5-link>
-              <ui5-label
-                style="margin: 0px 0.25rem;"
-                ui5-label=""
-              >
-                /
-              </ui5-label>
-              <ui5-link
-                design="Default"
-                href="PathSegment3"
-                ui5-link=""
-              />
-            </div>
+                <li
+                  style="display: flex;"
+                >
+                  <ui5-link
+                    design="Default"
+                    href="PathSegment1"
+                    ui5-link=""
+                  >
+                    Path1
+                  </ui5-link>
+                  <ui5-label
+                    aria-hidden="true"
+                    style="margin: 0px 0.25rem;"
+                    ui5-label=""
+                  >
+                    /
+                  </ui5-label>
+                </li>
+                <li
+                  style="display: flex;"
+                >
+                  <ui5-link
+                    design="Default"
+                    href="PathSegment2"
+                    ui5-link=""
+                  >
+                    Path2
+                  </ui5-link>
+                  <ui5-label
+                    aria-hidden="true"
+                    style="margin: 0px 0.25rem;"
+                    ui5-label=""
+                  >
+                    /
+                  </ui5-label>
+                </li>
+                <li>
+                  <ui5-link
+                    design="Default"
+                    href="PathSegment3"
+                    ui5-link=""
+                  />
+                </li>
+              </ol>
+            </nav>
             <div
               class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsBaseline FlexBox-flexWrapNoWrap"
             >

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -332,48 +332,56 @@ exports[`ObjectPage Key Infos 1`] = `
               aria-label="Breadcrumb Trail"
             >
               <ol
-                style="list-style-type: none; display: flex; align-items: center; margin-block: 0; padding-inline: 0; flex-wrap: wrap;"
+                class="Breadcrumbs-list"
               >
                 <li
-                  style="display: flex;"
+                  id="0"
                 >
                   <ui5-link
+                    data-id="0"
                     design="Default"
                     href="PathSegment1"
+                    tabindex="0"
                     ui5-link=""
                   >
                     Path1
                   </ui5-link>
                   <ui5-label
                     aria-hidden="true"
-                    style="margin: 0px 0.25rem;"
+                    class="Breadcrumbs-separatorInline"
                     ui5-label=""
                   >
                     /
                   </ui5-label>
                 </li>
                 <li
-                  style="display: flex;"
+                  id="1"
                 >
                   <ui5-link
+                    data-id="1"
                     design="Default"
                     href="PathSegment2"
+                    tabindex="-1"
                     ui5-link=""
                   >
                     Path2
                   </ui5-link>
                   <ui5-label
                     aria-hidden="true"
-                    style="margin: 0px 0.25rem;"
+                    class="Breadcrumbs-separatorInline"
                     ui5-label=""
                   >
                     /
                   </ui5-label>
                 </li>
-                <li>
+                <li
+                  id="2"
+                >
                   <ui5-link
+                    data-id="2"
                     design="Default"
                     href="PathSegment3"
+                    tabindex="-1"
                     ui5-link=""
                   />
                 </li>


### PR DESCRIPTION
- Add missing aria labels
- Use unordered list to display items
- Only focus first or previously focused item with tab
- Allow right and left navigation between breadcrumbs with arrow keys
