### PR TITLE
fix(charts): Export `ComposedChart` and `ComposedChartPlaceholder` in root export as well

### DIFF
--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -3,7 +3,7 @@ import { useConsolidatedRef, useIsRTL, usePassThroughHtmlProps } from '@ui5/webc
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { ChartDataLabel } from '@ui5/webcomponents-react-charts/dist/components/ChartDataLabel';
-import { ComposedChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/components/ComposedChartPlaceholder';
+import { ComposedChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/ComposedChartPlaceholder';
 import { XAxisTicks } from '@ui5/webcomponents-react-charts/dist/components/XAxisTicks';
 import { YAxisTicks } from '@ui5/webcomponents-react-charts/dist/components/YAxisTicks';
 import { useLegendItemClick } from '@ui5/webcomponents-react-charts/dist/useLegendItemClick';

--- a/packages/charts/src/dist/ComposedChartPlaceholder.ts
+++ b/packages/charts/src/dist/ComposedChartPlaceholder.ts
@@ -1,0 +1,3 @@
+import { ComposedChartPlaceholder } from '../components/ComposedChart/Placeholder';
+
+export { ComposedChartPlaceholder };

--- a/packages/charts/src/dist/components/ComposedChartPlaceholder.ts
+++ b/packages/charts/src/dist/components/ComposedChartPlaceholder.ts
@@ -1,3 +1,0 @@
-import { ComposedChartPlaceholder } from '../../components/ComposedChart/Placeholder';
-
-export { ComposedChartPlaceholder };

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,10 +1,10 @@
 // Library Export
-import { ComposedChartPlaceholder } from './components/ComposedChart/Placeholder';
 import { BarChart } from './dist/BarChart';
 import { BarChartPlaceholder } from './dist/BarChartPlaceholder';
 import { ColumnChart } from './dist/ColumnChart';
 import { ColumnChartPlaceholder } from './dist/ColumnChartPlaceholder';
 import { ComposedChart } from './dist/ComposedChart';
+import { ComposedChartPlaceholder } from './dist/ComposedChartPlaceholder';
 import { DonutChart } from './dist/DonutChart';
 import { LineChart } from './dist/LineChart';
 import { LineChartPlaceholder } from './dist/LineChartPlaceholder';

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,8 +1,10 @@
 // Library Export
+import { ComposedChartPlaceholder } from './components/ComposedChart/Placeholder';
 import { BarChart } from './dist/BarChart';
 import { BarChartPlaceholder } from './dist/BarChartPlaceholder';
 import { ColumnChart } from './dist/ColumnChart';
 import { ColumnChartPlaceholder } from './dist/ColumnChartPlaceholder';
+import { ComposedChart } from './dist/ComposedChart';
 import { DonutChart } from './dist/DonutChart';
 import { LineChart } from './dist/LineChart';
 import { LineChartPlaceholder } from './dist/LineChartPlaceholder';
@@ -15,17 +17,19 @@ import { ScatterChart } from './dist/ScatterChart';
 import { ScatterChartPlaceholder } from './dist/ScatterChartPlaceholder';
 
 export {
-  ColumnChart,
-  DonutChart,
   BarChart,
+  ColumnChart,
+  ComposedChart,
+  DonutChart,
   LineChart,
+  MicroBarChart,
   PieChart,
   RadarChart,
   RadialChart,
-  MicroBarChart,
   ScatterChart,
   BarChartPlaceholder,
   ColumnChartPlaceholder,
+  ComposedChartPlaceholder,
   LineChartPlaceholder,
   PieChartPlaceholder,
   ScatterChartPlaceholder


### PR DESCRIPTION
BREAKING CHANGE: `ComposedChartPlaceholder`: The import path has changed. You can now import the placeholder from `@ui5/webcomponents-react-charts/dist/ComposedChartPlaceholder` or directly from `@ui5/webcomponents-react-charts`.
