### PR TITLE
fix(FilterBar): only display toolbar separator & overflow button when necessary

### DIFF
--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -486,7 +486,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
       )}
     </>
   );
-  const hasButtons = ToolbarButtons.props.children.find(Boolean);
+  const hasButtons = ToolbarButtons.props.children.some(Boolean);
   return (
     <>
       {dialogOpen && showFilterConfiguration && (


### PR DESCRIPTION
- Don't show toolbar separator if `variants` is not set

- Don't show overflow button if no buttons are displayed
