### PR TITLE
docs(Form): add min & max option to labelSpans & columns

### DIFF
--- a/packages/main/src/components/Form/Form.stories.mdx
+++ b/packages/main/src/components/Form/Form.stories.mdx
@@ -10,12 +10,24 @@ import { Option } from '@ui5/webcomponents-react/dist/Option';
 import { Select } from '@ui5/webcomponents-react/dist/Select';
 import { Label } from '@ui5/webcomponents-react/dist/Label';
 import { DocsHeader } from '@shared/stories/DocsHeader';
+import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
 
 <Meta
   title="Layouts & Floorplans / Form"
   component={Form}
   subcomponents={{ FormGroup, FormItem }}
-  argTypes={{ children: { type: null }, ref: { type: null } }}
+  argTypes={{
+    children: { type: null },
+    labelSpanS: { control: { type: 'number', min: 1, max: 12 } },
+    labelSpanM: { control: { type: 'number', min: 1, max: 12 } },
+    labelSpanL: { control: { type: 'number', min: 1, max: 12 } },
+    labelSpanXL: { control: { type: 'number', min: 1, max: 12 } },
+    columnsS: { control: { type: 'number', min: 1, max: 12 } },
+    columnsM: { control: { type: 'number', min: 1, max: 12 } },
+    columnsL: { control: { type: 'number', min: 1, max: 12 } },
+    columnsXL: { control: { type: 'number', min: 1, max: 12 } },
+    ...DocsCommonProps
+  }}
   args={{
     title: 'Test Form',
     labelSpanS: 12,

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -33,7 +33,7 @@ export interface FormPropTypes extends CommonProps {
    */
   title?: string;
   /**
-   * Form columns for small size (smaller than `600px`).
+   * Form columns for small size (`< 600px`).
    * Must be a number between 1 and 12.
    *
    * Default Value: 1
@@ -56,7 +56,7 @@ export interface FormPropTypes extends CommonProps {
    */
   columnsL?: number;
   /**
-   * Form columns for extra large size (greater than `1439px`).
+   * Form columns for extra large size (`>= 1440px`).
    * Must be a number between 1 and 12.
    *
    * Default Value: 2
@@ -65,7 +65,7 @@ export interface FormPropTypes extends CommonProps {
   columnsXL?: number;
 
   /**
-   * Default span for labels in small size (smaller than `600px`).
+   * Default span for labels in small size (`< 600px`).
    * Must be a number between 1 and 12.
    *
    * Default Value: 12
@@ -86,7 +86,7 @@ export interface FormPropTypes extends CommonProps {
    */
   labelSpanL?: number;
   /**
-   * Default span for labels in extra large size (greater than `1439px`).
+   * Default span for labels in extra large size (`>= 1440px`).
    * Must be a number between 1 and 12.
    *
    * Default Value: 4

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -44,6 +44,7 @@ export interface FormPropTypes extends CommonProps {
    * Must be a number between 1 and 12.
    *
    * Default Value: 1
+   *
    * __Note__: The number of columns for medium size must not be smaller than the number of columns for small size.
    */
   columnsM?: number;
@@ -52,6 +53,7 @@ export interface FormPropTypes extends CommonProps {
    * Must be a number between 1 and 12.
    *
    * Default Value: 1
+   *
    * __Note:__ The number of columns for large size must not be smaller than the number of columns for medium size.
    */
   columnsL?: number;
@@ -60,6 +62,7 @@ export interface FormPropTypes extends CommonProps {
    * Must be a number between 1 and 12.
    *
    * Default Value: 2
+   *
    * __Note:__ The number of columns for extra large size must not be smaller than the number of columns for large size.
    */
   columnsXL?: number;

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -33,51 +33,62 @@ export interface FormPropTypes extends CommonProps {
    */
   title?: string;
   /**
-   * Form columns for small size.
-   * Must be a number between 1 and 12.<br />
+   * Form columns for small size (smaller than `600px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 1
    */
   columnsS?: number;
   /**
-   * Form columns for medium size. The number of columns for medium size must not be smaller than the number of columns for small size.
-   * Must be a number between 1 and 12.<br />
+   * Form columns for medium size (`600px` - `1023px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 1
+   * __Note__: The number of columns for medium size must not be smaller than the number of columns for small size.
    */
   columnsM?: number;
   /**
-   * Form columns for large size. The number of columns for large size must not be smaller than the number of columns for medium size.
-   * Must be a number between 1 and 12.<br />
+   * Form columns for large size (`1024px` - `1439px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 1
+   * __Note:__ The number of columns for large size must not be smaller than the number of columns for medium size.
    */
   columnsL?: number;
   /**
-   * Form columns for extra large size. The number of columns for extra large size must not be smaller than the number of columns for large size.
-   * Must be a number between 1 and 12.<br />
+   * Form columns for extra large size (greater than `1439px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 2
+   * __Note:__ The number of columns for extra large size must not be smaller than the number of columns for large size.
    */
   columnsXL?: number;
 
   /**
-   * Default span for labels in small size.
-   * Must be a number between 1 and 12.<br />
+   * Default span for labels in small size (smaller than `600px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 12
    */
   labelSpanS?: number;
   /**
-   * Default span for labels in medium size.
-   * Must be a number between 1 and 12.<br />
+   * Default span for labels in medium size (`600px` - `1023px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 2
    */
   labelSpanM?: number;
   /**
-   * Default span for labels in large size.
-   * Must be a number between 1 and 12.<br />
+   * Default span for labels in large size (`1024px` - `1439px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 4
    */
   labelSpanL?: number;
   /**
-   * Default span for labels in extra large size.
-   * Must be a number between 1 and 12.<br />
+   * Default span for labels in extra large size (greater than `1439px`).
+   * Must be a number between 1 and 12.
+   *
    * Default Value: 4
    */
   labelSpanXL?: number;


### PR DESCRIPTION
Negative values set for the `labelSpan` crashed the storybook demo, that's why it's now restricted to only accept number in defined range.