### PR TITLE
feat(FilterBar): FilterBar without Toolbar spreads filters to available width

### DIFF
--- a/packages/main/src/components/FilterBar/FilterBar.jss.ts
+++ b/packages/main/src/components/FilterBar/FilterBar.jss.ts
@@ -3,13 +3,15 @@ import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingPar
 
 const styles = {
   outerContainer: {
+    background: ThemingParameters.sapObjectHeader_Background,
+    '--_ui5_input_width': '100%'
+  },
+  outerContainerWithToolbar: {
     paddingTop: '0.5rem',
     paddingLeft: '2rem',
     paddingRight: '2rem',
     paddingBottom: '1px',
-    background: ThemingParameters.sapObjectHeader_Background,
-    boxShadow: ThemingParameters.sapContent_HeaderShadow,
-    '--_ui5_input_width': '100%'
+    boxShadow: ThemingParameters.sapContent_HeaderShadow
   },
   filterBarHeader: {
     alignItems: 'center',

--- a/packages/main/src/components/FilterBar/FilterBar.jss.ts
+++ b/packages/main/src/components/FilterBar/FilterBar.jss.ts
@@ -39,14 +39,6 @@ const styles = {
   filterAreaOpen: {
     opacity: 1
   },
-  headerRowRight: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    flexGrow: 1,
-    '& ui5-button': {
-      marginLeft: '0.5rem'
-    }
-  },
   showFiltersBtn: { minWidth: '108px' },
   loadingContainer: {
     marginBottom: '0.5rem',
@@ -59,11 +51,28 @@ const styles = {
     alignItems: 'center',
     position: 'absolute',
     right: 0,
-    marginRight: '1rem',
     marginBottom: '1rem',
-    '& ui5-button': {
-      margin: '0 0.25rem 0 0.25rem'
+    '&:not(:first-child)': {
+      marginLeft: '0.25rem'
+    },
+    '&:not(:last-child)': {
+      marginRight: '0.25rem'
     }
+  },
+  spacer: {
+    height: 0,
+    marginTop: 0,
+    flexGrow: 1,
+    flexShrink: 0,
+    maxWidth: isIE() ? '26.25rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis) * 2)',
+    flexBasis: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))'
+  },
+  lastSpacer: {
+    height: 'var(--_ui5_input_height)',
+    flexGrow: 1,
+    flexShrink: 0,
+    maxWidth: isIE() ? '26.25rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis) * 2)',
+    flexBasis: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))'
   }
 };
 

--- a/packages/main/src/components/FilterBar/FilterBar.jss.ts
+++ b/packages/main/src/components/FilterBar/FilterBar.jss.ts
@@ -1,3 +1,4 @@
+import { isIE } from '@ui5/webcomponents-base/dist/Device';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 
 const styles = {
@@ -7,9 +8,7 @@ const styles = {
     paddingRight: '2rem',
     paddingBottom: '1px',
     background: ThemingParameters.sapObjectHeader_Background,
-    boxShadow: ThemingParameters.sapContent_HeaderShadow
-  },
-  filterItemExpand: {
+    boxShadow: ThemingParameters.sapContent_HeaderShadow,
     '--_ui5_input_width': '100%'
   },
   filterBarHeader: {
@@ -23,9 +22,10 @@ const styles = {
   },
   filterArea: {
     display: 'flex',
+    alignItems: 'center',
     flexWrap: 'wrap',
-    paddingTop: '1rem',
-    paddingBottom: '1rem',
+    marginTop: '1rem',
+    marginBottom: '1rem',
     background: ThemingParameters.sapObjectHeader_Background,
     transition: 'max-height 0.2s ease-out, opacity 0.2s ease-in'
   },
@@ -33,12 +33,11 @@ const styles = {
     maxHeight: '0',
     opacity: 0,
     padding: 0,
+    margin: 0,
     overflowY: 'auto'
   },
   filterAreaOpen: {
-    maxHeight: '500px',
-    opacity: 1,
-    overflowY: 'auto'
+    opacity: 1
   },
   headerRowRight: {
     display: 'flex',
@@ -54,6 +53,17 @@ const styles = {
     display: 'flex',
     width: '100%',
     justifyContent: 'center'
+  },
+  filterBarButtons: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'absolute',
+    right: 0,
+    marginRight: '1rem',
+    marginBottom: '1rem',
+    '& ui5-button': {
+      margin: '0 0.25rem 0 0.25rem'
+    }
   }
 };
 

--- a/packages/main/src/components/FilterBar/FilterBar.jss.ts
+++ b/packages/main/src/components/FilterBar/FilterBar.jss.ts
@@ -26,7 +26,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     flexWrap: 'wrap',
-    marginTop: '1rem',
+    paddingTop: '1rem',
     marginBottom: '1rem',
     background: ThemingParameters.sapObjectHeader_Background,
     transition: 'max-height 0.2s ease-out, opacity 0.2s ease-in'

--- a/packages/main/src/components/FilterBar/FilterBar.stories.mdx
+++ b/packages/main/src/components/FilterBar/FilterBar.stories.mdx
@@ -7,10 +7,9 @@ import { MultiComboBoxItem } from '@ui5/webcomponents-react/dist/MultiComboBoxIt
 import { Option } from '@ui5/webcomponents-react/dist/Option';
 import { Select } from '@ui5/webcomponents-react/dist/Select';
 import { Switch } from '@ui5/webcomponents-react/dist/Switch';
-import { DatePicker } from '@ui5/webcomponents-react/dist/DatePicker';
+import { DateRangePicker } from '@ui5/webcomponents-react/dist/DateRangePicker';
 import { VariantManagement } from '@ui5/webcomponents-react/dist/VariantManagement';
 import '@ui5/webcomponents-icons/dist/nav-back.js';
-import { createSelectArgTypes } from '@shared/stories/createSelectArgTypes';
 import { DocsHeader } from '@shared/stories/DocsHeader';
 import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
 
@@ -108,7 +107,7 @@ import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
             </MultiComboBox>
           </FilterGroupItem>
           <FilterGroupItem label="Date Picker" groupName="Group 2">
-            <DatePicker />
+            <DateRangePicker style={{ minWidth: 'auto' }} />
           </FilterGroupItem>
         </FilterBar>
       );

--- a/packages/main/src/components/FilterBar/__snapshots__/FilterBar.test.tsx.snap
+++ b/packages/main/src/components/FilterBar/__snapshots__/FilterBar.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`FilterBar Render without crashing - default props 1`] = `
 <DocumentFragment>
   <div
     class="FilterBar-outerContainer"
+    style="--_ui5wcr_filter_group_item_flex_basis: 13.125rem;"
   >
     <div
       class="Toolbar-outerContainer Toolbar-clear FilterBar-filterBarHeader"
@@ -28,9 +29,13 @@ exports[`FilterBar Render without crashing - default props 1`] = `
     </div>
     <div
       class="FilterBar-filterArea FilterBar-filterAreaOpen"
+      style="position: relative;"
     >
       <div
         class="FilterGroupItem-filterItem"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 13.125rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -82,7 +87,8 @@ exports[`FilterBar Render without crashing - default props 1`] = `
 exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
 <DocumentFragment>
   <div
-    class="FilterBar-outerContainer FilterBar-filterItemExpand"
+    class="FilterBar-outerContainer"
+    style="--_ui5wcr_filter_group_item_flex_basis: 12rem;"
   >
     <div
       class="Toolbar-outerContainer Toolbar-clear FilterBar-filterBarHeader"
@@ -174,10 +180,13 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
     </div>
     <div
       class="FilterBar-filterArea FilterBar-filterAreaOpen"
+      style="position: relative;"
     >
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -203,7 +212,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -226,7 +237,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -260,7 +273,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -306,7 +321,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -367,7 +384,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -410,7 +429,9 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
       </div>
       <div
         class="FilterGroupItem-filterItem"
-        style="width: 12rem;"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 12rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -442,6 +463,7 @@ exports[`FilterBar Toggle FilterBar filters 1`] = `
 <DocumentFragment>
   <div
     class="FilterBar-outerContainer"
+    style="--_ui5wcr_filter_group_item_flex_basis: 13.125rem;"
   >
     <div
       class="Toolbar-outerContainer Toolbar-clear FilterBar-filterBarHeader"
@@ -466,9 +488,13 @@ exports[`FilterBar Toggle FilterBar filters 1`] = `
     </div>
     <div
       class="FilterBar-filterArea FilterBar-filterAreaClosed"
+      style="position: relative;"
     >
       <div
         class="FilterGroupItem-filterItem"
+        data-in-fb="true"
+        data-with-toolbar="true"
+        style="margin-right: 1rem; width: 13.125rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -1544,13 +1570,18 @@ exports[`FilterBar useToolbar 1`] = `
 <DocumentFragment>
   <div
     class="FilterBar-outerContainer"
+    style="--_ui5wcr_filter_group_item_flex_basis: 13.125rem;"
   >
     <div
       class="FilterBar-filterArea FilterBar-filterAreaOpen"
+      style="position: relative;"
     >
       <div
         class="FilterGroupItem-filterItem"
+        data-in-fb="true"
         data-testid="filter-item"
+        data-with-toolbar="false"
+        style="margin-right: 1rem; width: 13.125rem;"
       >
         <div
           class="FilterGroupItem-innerFilterItemContainer"
@@ -1595,15 +1626,20 @@ exports[`FilterBar useToolbar 1`] = `
         </div>
       </div>
       <div
-        class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentEnd FlexBox-alignItemsCenter FlexBox-flexWrapNoWrap"
-        style="flex-grow: 1;"
+        class="FilterBar-lastSpacer"
+        style="width: 120px; min-width: 120px; margin-right: 1rem;"
       >
-        <ui5-button
-          design="Emphasized"
-          ui5-button=""
+        <div
+          class="FilterBar-filterBarButtons"
+          style="margin-right: 1rem; right: 0px;"
         >
-          Go
-        </ui5-button>
+          <ui5-button
+            design="Emphasized"
+            ui5-button=""
+          >
+            Go
+          </ui5-button>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/main/src/components/FilterBar/__snapshots__/FilterBar.test.tsx.snap
+++ b/packages/main/src/components/FilterBar/__snapshots__/FilterBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilterBar Render without crashing - default props 1`] = `
 <DocumentFragment>
   <div
-    class="FilterBar-outerContainer"
+    class="FilterBar-outerContainer FilterBar-outerContainerWithToolbar"
     style="--_ui5wcr_filter_group_item_flex_basis: 13.125rem;"
   >
     <div
@@ -87,7 +87,7 @@ exports[`FilterBar Render without crashing - default props 1`] = `
 exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
 <DocumentFragment>
   <div
-    class="FilterBar-outerContainer"
+    class="FilterBar-outerContainer FilterBar-outerContainerWithToolbar"
     style="--_ui5wcr_filter_group_item_flex_basis: 12rem;"
   >
     <div
@@ -462,7 +462,7 @@ exports[`FilterBar Render without crashing - w/ filter dialog 1`] = `
 exports[`FilterBar Toggle FilterBar filters 1`] = `
 <DocumentFragment>
   <div
-    class="FilterBar-outerContainer"
+    class="FilterBar-outerContainer FilterBar-outerContainerWithToolbar"
     style="--_ui5wcr_filter_group_item_flex_basis: 13.125rem;"
   >
     <div

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -74,6 +74,9 @@ export interface FilterBarPropTypes extends CommonProps {
   filterBarExpanded?: boolean;
   /**
    * Defines the width of the `FilterGroupItems`.
+   *
+   * __Note:__ If your filter elements (e.g. `DateRangePicker`) have a internal `minWidth`, please make sure to overwrite it with `minWidth:'auto'` or the corresponding `filterContainerWidth` otherwise it can lead to unintended behavior.
+   * __Note:__ This prop is not supported with IE11, there it defaults to `13.125rem`.
    */
   filterContainerWidth?: CSSProperties['width'];
   /**

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -5,6 +5,7 @@ import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/
 import {
   CLEAR,
   FILTERS,
+  ADAPT_FILTERS,
   GO,
   HIDE_FILTER_BAR,
   RESTORE,
@@ -238,7 +239,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
   const showFilterBarText = i18nBundle.getText(SHOW_FILTER_BAR);
   const hideFilterBarText = i18nBundle.getText(HIDE_FILTER_BAR);
   const goText = i18nBundle.getText(GO);
-  const filtersText = i18nBundle.getText(FILTERS);
+  const filtersText = useToolbar ? i18nBundle.getText(FILTERS) : i18nBundle.getText(ADAPT_FILTERS);
 
   const isRtl = useIsRTL(filterBarRef);
   const transformRightRTL = isRtl ? 'Left' : 'Right';

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -1,5 +1,4 @@
-import { isIE } from '@ui5/webcomponents-base/dist/Device';
-import { useI18nBundle } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useConsolidatedRef, useI18nBundle, useIsRTL } from '@ui5/webcomponents-react-base/dist/hooks';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
@@ -15,9 +14,6 @@ import { BusyIndicator } from '@ui5/webcomponents-react/dist/BusyIndicator';
 import { BusyIndicatorSize } from '@ui5/webcomponents-react/dist/BusyIndicatorSize';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/dist/ButtonDesign';
-import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
-import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignItems';
-import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJustifyContent';
 import { InputPropTypes } from '@ui5/webcomponents-react/dist/Input';
 import { Toolbar } from '@ui5/webcomponents-react/dist/Toolbar';
 import { ToolbarSeparator } from '@ui5/webcomponents-react/dist/ToolbarSeparator';
@@ -233,6 +229,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
   const prevSearchInputPropsValueRef = useRef<string>();
   const filterBarButtonsRef = useRef(null);
   const filterAreaRef = useRef(null);
+  const filterBarRef = useConsolidatedRef<HTMLDivElement>(ref);
 
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
 
@@ -242,6 +239,9 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
   const hideFilterBarText = i18nBundle.getText(HIDE_FILTER_BAR);
   const goText = i18nBundle.getText(GO);
   const filtersText = i18nBundle.getText(FILTERS);
+
+  const isRtl = useIsRTL(filterBarRef);
+  const transformRightRTL = isRtl ? 'Left' : 'Right';
 
   useEffect(() => {
     Children.toArray(children).forEach((item: ReactElement<any>) => {
@@ -507,7 +507,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
     return () => {
       filterAreaObserver.disconnect();
     };
-  }, [filterAreaRef.current]);
+  }, [filterAreaRef.current, useToolbar]);
 
   useEffect(() => {
     const filterAreaObserver = new ResizeObserver(
@@ -525,7 +525,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
     return () => {
       filterAreaObserver.disconnect();
     };
-  }, [filterAreaWidth, filterAreaRef.current]);
+  }, [filterAreaWidth, filterAreaRef.current, useToolbar]);
 
   useEffect(() => {
     const filterBarButtonsObserver = new ResizeObserver(
@@ -555,24 +555,16 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
         return null;
       }
       const usedSpaceLastRow = filterItemsWidth % filterAreaWidth;
-      // console.log(usedSpaceLastRow);
       const emptySpaceLastRow = filterAreaWidth - usedSpaceLastRow;
-      // console.log(emptySpaceLastRow);
       // deduct width of buttons container of the empty space in the last row to calculate number of spacers
       const numberOfSpacers = Math.floor((emptySpaceLastRow - filterBarButtonsWidth) / firstChildWidth);
-      // console.log(numberOfSpacers);
       for (let i = 0; i < numberOfSpacers; i++) {
         spacers.push(
           <div
             key={`filter-spacer-${i}`}
+            className={classes.spacer}
             style={{
-              height: 0,
-              marginTop: 0,
-              flexGrow: 1,
-              flexShrink: 0,
-              marginRight: '1rem',
-              maxWidth: isIE() ? '26.25rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis) * 2)',
-              flexBasis: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))'
+              [`margin${transformRightRTL}`]: '1rem'
             }}
           />
         );
@@ -608,7 +600,7 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
         </FilterDialog>
       )}
       <div
-        ref={ref}
+        ref={filterBarRef}
         className={cssClasses.toString()}
         style={{ ['--_ui5wcr_filter_group_item_flex_basis']: filterContainerWidth, ...style } as CSSProperties}
         title={tooltip}
@@ -638,15 +630,19 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
                       style={{
                         width: filterBarButtonsWidth ? `${filterBarButtonsWidth}px` : '120px',
                         minWidth: filterBarButtonsWidth ? `${filterBarButtonsWidth}px` : '120px',
-                        height: 'var(--_ui5_input_height)',
-                        flexGrow: 1,
-                        flexShrink: 0,
-                        marginRight: '0.75rem',
-                        maxWidth: isIE() ? '26.25rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis) * 2)',
-                        flexBasis: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))'
+                        [`margin${transformRightRTL}`]: '1rem'
                       }}
+                      className={classes.lastSpacer}
                     >
-                      <div className={classes.filterBarButtons} ref={filterBarButtonsRef}>
+                      <div
+                        className={classes.filterBarButtons}
+                        ref={filterBarButtonsRef}
+                        style={{
+                          [`margin${transformRightRTL}`]: '1rem',
+                          left: isRtl ? 0 : 'auto',
+                          right: isRtl ? 'auto' : 0
+                        }}
+                      >
                         {ToolbarButtons}
                       </div>
                     </div>

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -443,6 +443,9 @@ const FilterBar: FC<FilterBarPropTypes> = forwardRef((props: FilterBarPropTypes,
   if (className) {
     cssClasses.put(className);
   }
+  if (useToolbar) {
+    cssClasses.put(classes.outerContainerWithToolbar);
+  }
 
   useEffect(() => {
     prevSearchInputPropsValueRef.current = search?.props?.value;

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -75,7 +75,7 @@ export interface FilterBarPropTypes extends CommonProps {
   /**
    * Defines the width of the `FilterGroupItems`.
    *
-   * __Note:__ If your filter elements (e.g. `DateRangePicker`) have a internal `minWidth`, please make sure to overwrite it with `minWidth:'auto'` or the corresponding `filterContainerWidth` otherwise it can lead to unintended behavior.
+   * __Note:__ If your filter elements (e.g. `DateRangePicker`) have an internal `minWidth`, please make sure to overwrite it with `minWidth:'auto'` or the corresponding `filterContainerWidth` otherwise it can lead to unintended behavior.
    * __Note:__ This prop is not supported with IE11, there it defaults to `13.125rem`.
    */
   filterContainerWidth?: CSSProperties['width'];

--- a/packages/main/src/components/FilterGroupItem/FilterGroupItem.jss.ts
+++ b/packages/main/src/components/FilterGroupItem/FilterGroupItem.jss.ts
@@ -1,8 +1,16 @@
+import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
+
 const styles = {
   filterItem: {
-    width: 'var(--_ui5_input_width)',
     marginRight: '1rem',
-    marginBottom: '1rem'
+    marginBottom: '1rem',
+    flexBasis: isIE() ? '13.125rem' : 'var(--_ui5wcr_filter_group_item_flex_basis)',
+    maxWidth: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))',
+    flexGrow: 1,
+    flexShrink: 0,
+    '&[data-with-toolbar=false]': {
+      maxWidth: isIE() ? '26.25rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis) * 2)'
+    }
   },
   filterItemDialog: {
     flexGrow: 1,

--- a/packages/main/src/components/FilterGroupItem/FilterGroupItem.jss.ts
+++ b/packages/main/src/components/FilterGroupItem/FilterGroupItem.jss.ts
@@ -2,7 +2,6 @@ import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
 
 const styles = {
   filterItem: {
-    marginRight: '1rem',
     marginBottom: '1rem',
     flexBasis: isIE() ? '13.125rem' : 'var(--_ui5wcr_filter_group_item_flex_basis)',
     maxWidth: isIE() ? '13.125rem' : 'calc(var(--_ui5wcr_filter_group_item_flex_basis))',

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -76,12 +76,10 @@ export const FilterGroupItem: FC<FilterGroupItemPropTypes> = forwardRef(
       loading,
       className,
       tooltip,
-      slot,
-      // @ts-ignore
-      inFB
+      slot
     } = props;
-
     const passThroughProps = usePassThroughHtmlProps(props);
+    const inFB = props['data-in-fb'];
 
     const styleClasses = StyleClassHelper.of(inFB ? classes.filterItem : classes.filterItemDialog);
     if (className) {

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -1,3 +1,5 @@
+import { useConsolidatedRef } from '@ui5/webcomponents-react-base';
+import { useIsRTL } from '@ui5/webcomponents-react-base/hooks/useIsRTL';
 import { createUseStyles } from 'react-jss';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
@@ -80,21 +82,27 @@ export const FilterGroupItem: FC<FilterGroupItemPropTypes> = forwardRef(
     } = props;
     const passThroughProps = usePassThroughHtmlProps(props);
     const inFB = props['data-in-fb'];
+    const filterGroupItemRef = useConsolidatedRef<HTMLDivElement>(ref);
+
+    const isRtl = useIsRTL(filterGroupItemRef);
+    const transformMarginRight = isRtl ? 'marginLeft' : 'marginRight';
 
     const styleClasses = StyleClassHelper.of(inFB ? classes.filterItem : classes.filterItemDialog);
     if (className) {
       styleClasses.put(className);
     }
 
+    const inlineStyle = { [transformMarginRight]: '1rem', ...style };
+
     if (!required && (!visible || (inFB && !visibleInFilterBar))) return null;
     return (
       <div
-        ref={ref}
+        ref={filterGroupItemRef}
         title={tooltip}
         slot={slot}
         {...passThroughProps}
         className={styleClasses.valueOf()}
-        style={inFB ? style : emptyObject}
+        style={inFB ? inlineStyle : emptyObject}
       >
         <div className={inFB ? classes.innerFilterItemContainer : classes.innerFilterItemContainerDialog}>
           <FlexBox>

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -1,5 +1,4 @@
-import { useConsolidatedRef } from '@ui5/webcomponents-react-base';
-import { useIsRTL } from '@ui5/webcomponents-react-base/hooks/useIsRTL';
+import { useConsolidatedRef, useIsRTL } from '@ui5/webcomponents-react-base/dist/hooks';
 import { createUseStyles } from 'react-jss';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -78,25 +78,27 @@ EXPAND_GROUP=Expand Group
 #XTXT
 COLLAPSE_GROUP=Collapse Group
 
-#XBUT
+#XBUT: Displays the filter item section of the FilterBar
 SHOW_FILTER_BAR=Show Filter Bar
-#XBUT
+#XBUT: Hides the filter item section of the FilterBar
 HIDE_FILTER_BAR=Hide Filter Bar
-#XBUT
+#XBUT: Clears all values from the filter items inside the FilterBar
 CLEAR=Clear
-#XBUT
+#XBUT: Restores all filter items to initial value
 RESTORE=Restore
-#XBUT
+#XBUT: Opens the filters dialog of the FilterBar
 FILTERS=Filters
-#XBUT
+#XBUT: Opens the filters dialog of the FilterBar
+ADAPT_FILTERS=Adapt Filters
+#XBUT: Executes the search with given filter values of the FilterBar
 GO=Go
-#XBUT
+#XBUT: Saves the filter configuration set in the filter dialog
 SAVE=Save
-#XCKL
+#XCKL: Selects the filter to be displayed in the FilterBar.
 SHOW_ON_FILTER_BAR=Show on Filter Bar
-#XGRP
+#XGRP: Default filter group name inside the filter dialog.
 BASIC=Basic
-#XBUT
+#XBUT: Placeholder for search input.
 SEARCH_FOR_FILTERS=Search for filters
 
 #XACT

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,14 +3843,6 @@
     "@typescript-eslint/typescript-estree" "4.26.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz#9d86a5bcc46ef40acd03d85ad4e908e5aab8d4ca"
-  integrity sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==
-  dependencies:
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/visitor-keys" "4.25.0"
-
 "@typescript-eslint/scope-manager@4.26.0":
   version "4.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz#60d1a71df162404e954b9d1c6343ff3bee496194"
@@ -3859,28 +3851,10 @@
     "@typescript-eslint/types" "4.26.0"
     "@typescript-eslint/visitor-keys" "4.26.0"
 
-"@typescript-eslint/types@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.25.0.tgz#0e444a5c5e3c22d7ffa5e16e0e60510b3de5af87"
-  integrity sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==
-
 "@typescript-eslint/types@4.26.0":
   version "4.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.0.tgz#7c6732c0414f0a69595f4f846ebe12616243d546"
   integrity sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==
-
-"@typescript-eslint/typescript-estree@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz#942e4e25888736bff5b360d9b0b61e013d0cfa25"
-  integrity sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==
-  dependencies:
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/visitor-keys" "4.25.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.26.0":
   version "4.26.0"
@@ -3894,14 +3868,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz#863e7ed23da4287c5b469b13223255d0fde6aaa7"
-  integrity sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==
-  dependencies:
-    "@typescript-eslint/types" "4.25.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.26.0":
   version "4.26.0"
@@ -9081,7 +9047,7 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.0, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
+globby@^11.0.0, globby@^11.0.2, globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
@@ -16852,7 +16818,7 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
-tsutils@^3.17.1, tsutils@^3.21.0:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
When Toolbar is not displayed:

- fixes padding for FilterBar action buttons 
- replaces "Filters" button label with "Adapt Filters" 
- remove padding and boxShadow around filter section
- spread filters to available width
- align FilterBar action buttons with filter items
