### PR TITLE
feat(MessageBox): add `initialFocus`, `onBeforeOpen`, `onAfterOpen` props

### DIFF
--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`MessageBox Confirm - Cancel 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -43,6 +44,7 @@ exports[`MessageBox Confirm - Cancel 1`] = `
       <ui5-button
         data-action="Cancel"
         design="Transparent"
+        id="Cancel"
         ui5-button=""
       >
         Cancel
@@ -88,6 +90,7 @@ exports[`MessageBox Confirm 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -95,6 +98,7 @@ exports[`MessageBox Confirm 1`] = `
       <ui5-button
         data-action="Cancel"
         design="Transparent"
+        id="Cancel"
         ui5-button=""
       >
         Cancel
@@ -138,6 +142,7 @@ exports[`MessageBox Custom Action Text 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -145,6 +150,7 @@ exports[`MessageBox Custom Action Text 1`] = `
       <ui5-button
         data-action="My Custom Action"
         design="Transparent"
+        id="My Custom Action"
         ui5-button=""
       >
         My Custom Action
@@ -184,6 +190,7 @@ exports[`MessageBox Don't crash on unknown type 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -229,6 +236,7 @@ exports[`MessageBox Error 1`] = `
       <ui5-button
         data-action="Close"
         design="Emphasized"
+        id="Close"
         ui5-button=""
       >
         Close
@@ -274,6 +282,7 @@ exports[`MessageBox Highlight 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -319,6 +328,7 @@ exports[`MessageBox Information 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -364,6 +374,7 @@ exports[`MessageBox No Title 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -371,6 +382,7 @@ exports[`MessageBox No Title 1`] = `
       <ui5-button
         data-action="Cancel"
         design="Transparent"
+        id="Cancel"
         ui5-button=""
       >
         Cancel
@@ -414,6 +426,7 @@ exports[`MessageBox Not open 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -459,6 +472,7 @@ exports[`MessageBox Show 1`] = `
       <ui5-button
         data-action="Yes"
         design="Emphasized"
+        id="Yes"
         ui5-button=""
       >
         Yes
@@ -466,6 +480,7 @@ exports[`MessageBox Show 1`] = `
       <ui5-button
         data-action="No"
         design="Transparent"
+        id="No"
         ui5-button=""
       >
         No
@@ -511,6 +526,7 @@ exports[`MessageBox Success 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -556,6 +572,7 @@ exports[`MessageBox Success w/ custom title 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK
@@ -601,6 +618,7 @@ exports[`MessageBox Warning 1`] = `
       <ui5-button
         data-action="OK"
         design="Emphasized"
+        id="OK"
         ui5-button=""
       >
         OK

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -47,6 +47,7 @@ import React, {
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { Ui5DialogDomRef } from '@ui5/webcomponents-react/interfaces/Ui5DialogDomRef';
+import { Ui5CustomEvent } from '@ui5/webcomponents-react/interfaces/Ui5CustomEvent';
 import { stopPropagation } from '../../internal/stopPropagation';
 import styles from './MessageBox.jss';
 
@@ -78,9 +79,21 @@ export interface MessageBoxPropTypes extends CommonProps {
    */
   type?: MessageBoxTypes;
   /**
+   * Defines the ID of the HTML Element or the `MessageBoxAction`, which will get the initial focus.
+   */
+  initialFocus?: string | MessageBoxActions;
+  /**
    * Callback to be executed when the `MessageBox` is closed (either by pressing on one of the `actions` or by pressing the `ESC` key). `event.detail.action` contains the pressed action button.
    */
   onClose: (event: CustomEvent<{ action: MessageBoxActions }>) => void;
+  /**
+   * Fired before the component is opened. This event can be cancelled, which will prevent the popup from opening. This event does not bubble.
+   */
+  onBeforeOpen?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Fired after the component is opened. This event does not bubble.
+   */
+  onAfterOpen?: (event: Ui5CustomEvent<HTMLElement>) => void;
 }
 
 const useStyles = createUseStyles(styles, { name: 'MessageBox' });
@@ -90,7 +103,22 @@ const useStyles = createUseStyles(styles, { name: 'MessageBox' });
  * For convenience, it also provides an `open` prop, so it is not necessary to attach a `ref` to open the `MessageBox`.
  */
 const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTypes, ref: Ref<Ui5DialogDomRef>) => {
-  const { open, type, children, className, style, tooltip, slot, title, icon, actions, onClose } = props;
+  const {
+    open,
+    type,
+    children,
+    className,
+    style,
+    tooltip,
+    slot,
+    title,
+    icon,
+    actions,
+    onClose,
+    initialFocus,
+    onBeforeOpen,
+    onAfterOpen
+  } = props;
   const dialogRef = useConsolidatedRef<Ui5DialogDomRef>(ref);
 
   const classes = useStyles();
@@ -176,8 +204,7 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
   useEffect(() => {
     if (dialogRef.current) {
       if (open) {
-        dialogRef.current.open?.(true);
-        dialogRef.current.focus();
+        dialogRef.current.open?.();
       } else {
         dialogRef.current.close?.();
       }
@@ -195,7 +222,10 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
       style={style}
       tooltip={tooltip}
       className={messageBoxClassNames}
+      onAfterOpen={onAfterOpen}
+      onBeforeOpen={onBeforeOpen}
       onAfterClose={open ? handleOnClose : stopPropagation}
+      initialFocus={initialFocus}
       {...passThroughProps}
     >
       <header slot="header" className={classes.header} data-type={type}>
@@ -207,6 +237,7 @@ const MessageBox: FC<MessageBoxPropTypes> = forwardRef((props: MessageBoxPropTyp
         {getActions().map((action, index) => {
           return (
             <Button
+              id={action}
               key={`${action}-${index}`}
               design={index === 0 ? ButtonDesign.Emphasized : ButtonDesign.Transparent}
               onClick={handleOnClose}


### PR DESCRIPTION
The initial focus when opening a `MessageBox` is now the first focusable element. This can be changed with the `initialFocus` property or by calling `focus()` on the corresponding element within the `onBeforeOpen` or `onAfterOpen` callback. 