### PR TITLE
chore: update stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,26 +6,22 @@ on:
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/stale@v3.0.19
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         # The number of days old an issue can be before marking it stale. Set to -1 to never mark issues or pull requests as stale automatically.
-        days-before-stale: 21
+        days-before-stale: 14
         # The number of days to wait to close an issue or pull request after it being marked stale. Set to -1 to never close stale issues.
-        days-before-close: 30
+        days-before-close: 7
         # The message to post on the issue when tagging it. If none provided, will not mark issues stale.
         stale-issue-message: >
           Hi everyone! 
           Seems like there hasn't been much going on in this issue lately. If there are still questions, comments, or bugs, please feel free to continue the discussion. 
-          Inactive issues will be closed after 30 days. Thanks.
+          Inactive issues will be closed after 7 days. Thanks.
         # The message to post on the issue when closing it. If none provided, will not comment when closing an issue.
         close-issue-message: >
           Hey there, it's me again! 
           I am going close this issue to help our maintainers focus on the current development roadmap instead. 
           If the issue mentioned is still a concern, please open a new ticket and mention this old one. 
-        # The labels to apply when an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2")
-        exempt-issue-labels: 'good first issue,todo,feature-request'
+        any-of-labels: 'author action'


### PR DESCRIPTION
We're now watching only issues with the label `author action`, mark them as stale after 14 days and close them after another 7 days.