### PR TITLE
feat(PieChart & DonutChart): add callback to `hideDataLabel` measure prop

### DIFF
--- a/packages/charts/src/components/DonutChart/DonutChart.stories.mdx
+++ b/packages/charts/src/components/DonutChart/DonutChart.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { DocsHeader } from '@shared/stories/DocsHeader';
 import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { DonutChart } from '@ui5/webcomponents-react-charts/dist/DonutChart';
-import { simpleDataSet } from '../../resources/DemoProps';
+import { simpleDataSet, simpleDataSetWithSmallValues } from '../../resources/DemoProps';
 import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
 
 <Meta
@@ -122,6 +122,27 @@ import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
         activeSegment: 9,
         showActiveSegmentDataLabel: true
       }
+    }}
+  >
+    {(props) => <DonutChart {...props} />}
+  </Story>
+</Canvas>
+
+### Hide labels
+
+<Canvas>
+  <Story
+    name="Hide Labels"
+    args={{
+      measure: {
+        accessor: 'users',
+        hideDataLabel: (chartConfig) => {
+          if (chartConfig.percent < 0.01) {
+            return true;
+          }
+        }
+      },
+      dataset: simpleDataSetWithSmallValues
     }}
   >
     {(props) => <DonutChart {...props} />}

--- a/packages/charts/src/components/PieChart/PieChart.stories.mdx
+++ b/packages/charts/src/components/PieChart/PieChart.stories.mdx
@@ -1,12 +1,22 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { DocsHeader } from '@shared/stories/DocsHeader';
 import { PieChart } from '@ui5/webcomponents-react-charts/dist/PieChart';
-import { simpleDataSet } from '../../resources/DemoProps';
+import { simpleDataSet, simpleDataSetWithSmallValues } from '../../resources/DemoProps';
 import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
 
 <Meta
   title="Charts /  PieChart"
   component={PieChart}
+  args={{
+    dimension: {
+      accessor: 'name'
+    },
+    measure: {
+      accessor: 'users'
+    },
+    dataset: simpleDataSet,
+    style: { width: '50%' }
+  }}
   argTypes={{
     ...DocsCommonProps,
     dataset: {
@@ -20,21 +30,7 @@ import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
 ## Example
 
 <Canvas>
-  <Story
-    name="Default"
-    args={{
-      dimension: {
-        accessor: 'name'
-      },
-      measure: {
-        accessor: 'users'
-      },
-      dataset: simpleDataSet,
-      style: { width: '50%' }
-    }}
-  >
-    {(props) => <PieChart {...props} />}
-  </Story>
+  <Story name="Default">{(props) => <PieChart {...props} />}</Story>
 </Canvas>
 
 ## Properties
@@ -52,15 +48,10 @@ import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
   <Story
     name="With Custom Color"
     args={{
-      dimension: {
-        accessor: 'name'
-      },
       measure: {
         accessor: 'users',
         colors: ['#f00', 'green', 'var(--sapNegativeColor)']
-      },
-      dataset: simpleDataSet,
-      style: { width: '50%' }
+      }
     }}
   >
     {(props) => <PieChart {...props} />}
@@ -79,19 +70,35 @@ import { DocsCommonProps } from '@shared/stories/DocsCommonProps';
   <Story
     name="With Formatter"
     args={{
-      dimension: {
-        accessor: 'name'
-      },
       measure: {
         accessor: 'users',
         formatter: (d) => (d > 200 ? 'over 200' : 'lower')
       },
-      dataset: simpleDataSet,
-      style: { width: '50%' },
       chartConfig: {
         activeSegment: 1,
         showActiveSegmentDataLabel: true
       }
+    }}
+  >
+    {(props) => <PieChart {...props} />}
+  </Story>
+</Canvas>
+
+### Hide labels
+
+<Canvas>
+  <Story
+    name="Hide Labels"
+    args={{
+      measure: {
+        accessor: 'users',
+        hideDataLabel: (chartConfig) => {
+          if (chartConfig.percent < 0.01) {
+            return true;
+          }
+        }
+      },
+      dataset: simpleDataSetWithSmallValues
     }}
   >
     {(props) => <PieChart {...props} />}

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -4,10 +4,9 @@ import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { PieChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/PieChartPlaceholder';
 import { useLegendItemClick } from '@ui5/webcomponents-react-charts/dist/useLegendItemClick';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo, isValidElement, cloneElement } from 'react';
-import { Cell, Label, Legend, Pie, PieChart as PieChartLib, Tooltip, Text, Sector } from 'recharts';
+import React, { cloneElement, CSSProperties, FC, forwardRef, isValidElement, Ref, useCallback, useMemo } from 'react';
+import { Cell, Label, Legend, Pie, PieChart as PieChartLib, Sector, Text, Tooltip } from 'recharts';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
-import { ComposedChart as ComposedChartLib } from 'recharts/types/chart/ComposedChart';
 import { useOnClickInternal } from '../../hooks/useOnClickInternal';
 import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
 import { IChartDimension } from '../../interfaces/IChartDimension';
@@ -16,7 +15,7 @@ import { IPolarChartConfig } from '../../interfaces/IPolarChartConfig';
 import { defaultFormatter } from '../../internal/defaults';
 import { tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
 
-interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'color'> {
+interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'color' | 'hideDataLabel'> {
   /**
    * A string containing the path to the dataset key this pie should display.
    * Supports object structures by using `'parent.child'`. Can also be a getter.
@@ -26,6 +25,11 @@ interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'colo
    * array of any valid CSS Color or CSS Variable. Defaults to the `sapChart_OrderedColor_` colors
    */
   colors?: CSSProperties['color'][];
+  /**
+   * Flag whether the data labels should be hidden in the chart for this segment.
+   * When passed a function it will be called for each data label with the corresponding chart properties.
+   */
+  hideDataLabel?: boolean | ((chartConfig: any) => boolean);
 }
 
 export interface PieChartProps extends IChartBaseProps<IPolarChartConfig> {
@@ -56,9 +60,9 @@ export interface PieChartProps extends IChartBaseProps<IPolarChartConfig> {
    * #### Optional properties
    *
    * - `formatter`: function will be called for each data label and allows you to format it according to your needs
-   * - `hideDataLabel`: flag whether the data labels should be hidden in the chart for this pie.
    * - `DataLabel`: a custom component to be used for the data label
    * - `colors`: array of any valid CSS Color or CSS Variable. Defaults to the `sapChart_OrderedColor_` colors
+   * - `hideDataLabel`: flag whether the data labels should be hidden in the chart for this segment. When passed a function it will be called for each data label with the corresponding chart properties.
    */
   measure: MeasureConfig;
 }
@@ -121,7 +125,9 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
 
   const dataLabel = useCallback(
     (props) => {
-      if (measure.hideDataLabel || chartConfig.activeSegment === props.index) return null;
+      const hideDataLabel =
+        typeof measure.hideDataLabel === 'function' ? measure.hideDataLabel(props) : measure.hideDataLabel;
+      if (hideDataLabel || chartConfig.activeSegment === props.index) return null;
 
       if (isValidElement(measure.DataLabel)) {
         return cloneElement(measure.DataLabel, { ...props, config: measure });
@@ -136,10 +142,10 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     [measure, chartConfig.activeSegment]
   );
 
-  const tooltipValueFormatter = useCallback((value, name) => [measure.formatter(value), dimension.formatter(name)], [
-    measure.formatter,
-    dimension.formatter
-  ]);
+  const tooltipValueFormatter = useCallback(
+    (value, name) => [measure.formatter(value), dimension.formatter(name)],
+    [measure.formatter, dimension.formatter]
+  );
   const chartRef = useConsolidatedRef<any>(ref);
 
   const onItemLegendClick = useLegendItemClick(onLegendClick, () => measure.accessor);
@@ -219,7 +225,9 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
 
   const renderLabelLine = useCallback(
     (props) => {
-      if (measure.hideDataLabel || chartConfig.activeSegment === props.index) return null;
+      const hideDataLabel =
+        typeof measure.hideDataLabel === 'function' ? measure.hideDataLabel(props) : measure.hideDataLabel;
+      if (hideDataLabel || chartConfig.activeSegment === props.index) return null;
       return Pie.renderLabelLineItem(undefined, props);
     },
     [chartConfig.activeSegment, measure.hideDataLabel]

--- a/packages/charts/src/resources/DemoProps.ts
+++ b/packages/charts/src/resources/DemoProps.ts
@@ -147,6 +147,57 @@ export const simpleDataSet = [
   }
 ];
 
+export const simpleDataSetWithSmallValues = [
+  {
+    name: 'January / Month',
+    users: 100
+  },
+  {
+    name: 'February / Month',
+    users: 10
+  },
+  {
+    name: 'March / Month',
+    users: 240
+  },
+  {
+    name: 'April / Month',
+    users: 5
+  },
+  {
+    name: 'May / Month',
+    users: 34
+  },
+  {
+    name: 'June / Month',
+    users: 230
+  },
+  {
+    name: 'July / Month',
+    users: 20
+  },
+  {
+    name: 'August / Month',
+    users: 220
+  },
+  {
+    name: 'September / Month',
+    users: 27
+  },
+  {
+    name: 'October / Month',
+    users: 250
+  },
+  {
+    name: 'November / Month',
+    users: 240
+  },
+  {
+    name: 'December / Month',
+    users: 280
+  }
+];
+
 export const secondaryDimensionDataSet = [
   {
     name: 'January / Month',


### PR DESCRIPTION
Enables passing a callback to `hideDataLabel` of the `PieChart` and `DonutChart` .

With this it is now possible to e.g. hide data labels depending on the percentage of space allocated to the individual segments.

```
hideDataLabel: (chartConfig) => {
  if (chartConfig.percent < 0.01) {
    return true;
  }
}
```