### PR TITLE
feat(charts): add `tooltipConfig` prop to allow control of Tooltip

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -44,9 +44,11 @@ const measureDefaults = {
   opacity: 1
 };
 
-const valueAccessor = (attribute) => ({ payload }) => {
-  return getValueByDataKey(payload, attribute);
-};
+const valueAccessor =
+  (attribute) =>
+  ({ payload }) => {
+    return getValueByDataKey(payload, attribute);
+  };
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -119,6 +121,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
     dataset,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -296,6 +299,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
           formatter={tooltipValueFormatter}
           contentStyle={tooltipContentStyle}
           labelFormatter={labelFormatter}
+          {...tooltipConfig}
         />
         {chartConfig.zoomingTool && (
           <Brush

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -104,9 +104,11 @@ const measureDefaults = {
   opacity: 1
 };
 
-const valueAccessor = (attribute) => ({ payload }) => {
-  return getValueByDataKey(payload, attribute);
-};
+const valueAccessor =
+  (attribute) =>
+  ({ payload }) => {
+    return getValueByDataKey(payload, attribute);
+  };
 
 /**
  * A `ColumnChart` is a data visualization where each category is represented by a rectangle, with the height of the rectangle being proportional to the values being plotted.
@@ -117,6 +119,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
     dataset,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -315,6 +318,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
           formatter={tooltipValueFormatter}
           labelFormatter={labelFormatter}
           contentStyle={tooltipContentStyle}
+          {...tooltipConfig}
         />
         {chartConfig.zoomingTool && (
           <Brush

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -129,6 +129,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     onDataPointClick,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onLegendClick,
     onClick,
     layout,
@@ -371,6 +372,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
           formatter={tooltipValueFormatter}
           labelFormatter={labelFormatter}
           contentStyle={tooltipContentStyle}
+          {...tooltipConfig}
         />
         {!noLegend && (
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -383,7 +385,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
           />
         )}
         {measures?.map((element, index) => {
-          const ChartElement = (ChartTypes[element.type] as any) as FC<any>;
+          const ChartElement = ChartTypes[element.type] as any as FC<any>;
 
           const chartElementProps: any = {
             isAnimationActive: noAnimation === false

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -109,6 +109,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
     loading,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -300,6 +301,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
           formatter={tooltipValueFormatter}
           contentStyle={tooltipContentStyle}
           labelFormatter={labelFormatter}
+          {...tooltipConfig}
         />
         {chartConfig.zoomingTool && (
           <Brush

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -31,7 +31,10 @@ interface MeasureConfig extends Omit<IChartMeasure, 'color'> {
 }
 
 export interface MicroBarChartProps
-  extends Omit<IChartBaseProps, 'noLegend' | 'onLegendClick' | 'noAnimation' | 'chartConfig' | 'children'> {
+  extends Omit<
+    IChartBaseProps,
+    'noLegend' | 'onLegendClick' | 'noAnimation' | 'chartConfig' | 'children' | 'tooltipConfig'
+  > {
   /**
    * A object which contains the configuration of the dimension.
    *

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -82,6 +82,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     dataset,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -305,6 +306,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
           contentStyle={tooltipContentStyle}
           itemStyle={chartConfig.tooltipItemStyle}
           labelStyle={chartConfig.tooltipLabelStyle}
+          {...tooltipConfig}
         />
         {!noLegend && (
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -83,6 +83,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
     dataset,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -207,6 +208,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
           formatter={tooltipValueFormatter}
           contentStyle={tooltipContentStyle}
           labelFormatter={labelFormatter}
+          {...tooltipConfig}
         />
         {!noLegend && (
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/charts/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/src/components/ScatterChart/ScatterChart.tsx
@@ -136,6 +136,7 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
     loading,
     noLegend,
     noAnimation,
+    tooltipConfig,
     onDataPointClick,
     onLegendClick,
     onClick,
@@ -309,7 +310,12 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
             <Label>{chartConfig.referenceLineX.label}</Label>
           </ReferenceLine>
         )}
-        <Tooltip cursor={tooltipFillOpacity} formatter={tooltipValueFormatter} contentStyle={tooltipContentStyle} />
+        <Tooltip
+          cursor={tooltipFillOpacity}
+          formatter={tooltipValueFormatter}
+          contentStyle={tooltipContentStyle}
+          {...tooltipConfig}
+        />
         {props.children}
       </ScatterChartLib>
     </ChartContainer>

--- a/packages/charts/src/interfaces/IChartBaseProps.ts
+++ b/packages/charts/src/interfaces/IChartBaseProps.ts
@@ -1,6 +1,7 @@
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { ReactNode, ReactNodeArray } from 'react';
 import { ICartesianChartConfig } from './ICartesianChartConfig';
+import { TooltipProps } from 'recharts';
 
 export interface IChartBaseProps<T = ICartesianChartConfig> extends Omit<CommonProps, 'onClick'> {
   /**
@@ -84,4 +85,11 @@ export interface IChartBaseProps<T = ICartesianChartConfig> extends Omit<CommonP
      */
     resizeDebounce?: number;
   };
+  /**
+   * Defines the configuration object for the internally used `recharts` Tooltip popover that is displayed when hovering over data points.
+   * You can find all possible configuration properties [here](https://recharts.org/en-US/api/Tooltip).
+   *
+   * __Note:__ It is possible to overwrite internally used tooltip props, so use with caution!
+   */
+  tooltipConfig?: TooltipProps<number | string | Array<number | string>, number | string>;
 }


### PR DESCRIPTION
This PR adds the possibility to control the position, behavior and appearance of the tooltip popover that is shown when hovering over data points.