### PR TITLE
fix(useResponsiveContentPadding): don't crash in Safari

### DIFF
--- a/packages/main/src/internal/useResponsiveContentPadding.ts
+++ b/packages/main/src/internal/useResponsiveContentPadding.ts
@@ -14,18 +14,16 @@ const useStyles = createUseStyles(
 
 export const useResponsiveContentPadding = (element) => {
   const [currentRange, setCurrentRange] = useState(getCurrentRange().name);
-  let resizeTimeout = useRef(null);
+  const resizeTimeout = useRef(null);
   const classes = useStyles();
 
   useEffect(() => {
     const observer = new ResizeObserver(([el]) => {
-      // Firefox implements `contentBoxSize` as a single content rect, rather than an array
-      const contentBoxSize = Array.isArray(el.contentBoxSize) ? el.contentBoxSize[0] : el.contentBoxSize;
       if (resizeTimeout.current) {
         clearTimeout(resizeTimeout.current);
       }
       resizeTimeout.current = setTimeout(() => {
-        setCurrentRange(() => getCurrentRange(contentBoxSize.inlineSize).name);
+        setCurrentRange(() => getCurrentRange(el.contentRect.width).name);
       }, 150);
     });
     if (element) {

--- a/packages/main/src/internal/useResponsiveContentPadding.ts
+++ b/packages/main/src/internal/useResponsiveContentPadding.ts
@@ -23,7 +23,7 @@ export const useResponsiveContentPadding = (element) => {
         clearTimeout(resizeTimeout.current);
       }
       resizeTimeout.current = setTimeout(() => {
-        setCurrentRange(() => getCurrentRange(el.contentRect.width).name);
+        setCurrentRange(() => getCurrentRange(el.contentRect.width)?.name);
       }, 150);
     });
     if (element) {


### PR DESCRIPTION
part of #1835 