### PR TITLE
refactor(ObjectPage): rename `heading` to `titleText`

### DIFF
--- a/packages/base/codemods/renamePropsV18.js
+++ b/packages/base/codemods/renamePropsV18.js
@@ -169,6 +169,13 @@ const renamingMap = {
   // UI5 Web Components React
   AnalyticalTable: {
     title: 'header'
+  },
+  ObjectPageSection: {
+    heading: 'titleText',
+    headingUppercase: 'titleTextUppercase'
+  },
+  ObjectPageSubSection: {
+    heading: 'titleText'
   }
 };
 

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -110,7 +110,7 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
     {(args) => {
       return (
         <ObjectPage {...args}>
-          <ObjectPageSection heading="Goals" id="goals" aria-label="Goals">
+          <ObjectPageSection titleText="Goals" id="goals" aria-label="Goals">
             <Form columnsL={3} columnsXL={3} labelSpanXL={6} labelSpanL={6} columnsM={2} labelSpanM={6}>
               <FormItem label="Evangelize the UI framework across the company">
                 <Text>4 days overdue - Cascaded</Text>
@@ -123,8 +123,8 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
               </FormItem>
             </Form>
           </ObjectPageSection>
-          <ObjectPageSection heading="Personal" id="personal" aria-label="Personal">
-            <ObjectPageSubSection heading="Connect" id="personal-connect" aria-label="Connect">
+          <ObjectPageSection titleText="Personal" id="personal" aria-label="Personal">
+            <ObjectPageSubSection titleText="Connect" id="personal-connect" aria-label="Connect">
               <Form columnsXL={4} columnsL={4}>
                 <FormGroup title="Phone Numbers">
                   <FormItem label="Home">
@@ -158,7 +158,7 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
               </Form>
             </ObjectPageSubSection>
             <ObjectPageSubSection
-              heading="Payment Information"
+              titleText="Payment Information"
               id="personal-payment-information"
               aria-label="Payment Information"
             >
@@ -176,9 +176,9 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
               </Form>
             </ObjectPageSubSection>
           </ObjectPageSection>
-          <ObjectPageSection heading="Employment" id="employment" aria-label="Employment">
+          <ObjectPageSection titleText="Employment" id="employment" aria-label="Employment">
             <ObjectPageSubSection
-              heading="Job Information"
+              titleText="Job Information"
               id="employment-job-information"
               aria-label="Job Information"
             >
@@ -210,7 +210,7 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
               </Form>
             </ObjectPageSubSection>
             <ObjectPageSubSection
-              heading="Employee Details"
+              titleText="Employee Details"
               id="employment-employee-details"
               aria-label="Employee Details"
             >
@@ -236,7 +236,7 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
               </Form>
             </ObjectPageSubSection>
             <ObjectPageSubSection
-              heading="Job Relationship"
+              titleText="Job Relationship"
               id="employment-job-relationship"
               aria-label="Job Relationship"
             >

--- a/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
@@ -19,31 +19,31 @@ const footer = <Bar design={BarDesign.FloatingFooter} endContent={<div>Footer</d
 
 const renderComponent = (props = {}) => (
   <ObjectPage {...props}>
-    <ObjectPageSection heading="Title Section 1" id="1">
+    <ObjectPageSection titleText="Title Section 1" id="1">
       <Label>Content Section 1</Label>
     </ObjectPageSection>
-    <ObjectPageSection heading="Title Section 2" id="2">
+    <ObjectPageSection titleText="Title Section 2" id="2">
       <div>Content Section 2</div>
     </ObjectPageSection>
-    <ObjectPageSection heading="Title Section 3" id="3">
-      <ObjectPageSubSection heading="Title SubSection 3.1" id="3.1">
+    <ObjectPageSection titleText="Title Section 3" id="3">
+      <ObjectPageSubSection titleText="Title SubSection 3.1" id="3.1">
         Content Section 3.1
       </ObjectPageSubSection>
-      <ObjectPageSubSection heading="Title SubSection 3.2" id="3.2">
+      <ObjectPageSubSection titleText="Title SubSection 3.2" id="3.2">
         Content Section 3.2
       </ObjectPageSubSection>
-      <ObjectPageSubSection heading="Title SubSection 3.3" id="3.3">
+      <ObjectPageSubSection titleText="Title SubSection 3.3" id="3.3">
         Content Section 3.3
       </ObjectPageSubSection>
     </ObjectPageSection>
-    <ObjectPageSection heading="Title Section 4" id="4">
-      <ObjectPageSubSection heading="Title SubSection 4.1" id="4.1">
+    <ObjectPageSection titleText="Title Section 4" id="4">
+      <ObjectPageSubSection titleText="Title SubSection 4.1" id="4.1">
         Content Section 4.1
       </ObjectPageSubSection>
-      <ObjectPageSubSection heading="Title SubSection 4.2" id="4.2">
+      <ObjectPageSubSection titleText="Title SubSection 4.2" id="4.2">
         Content Section 4.2
       </ObjectPageSubSection>
-      <ObjectPageSubSection heading="Title SubSection 4.3" id="4.3">
+      <ObjectPageSubSection titleText="Title SubSection 4.3" id="4.3">
         Content Section 4.3
       </ObjectPageSubSection>
     </ObjectPageSection>
@@ -52,13 +52,13 @@ const renderComponent = (props = {}) => (
 
 const renderComponentWithSections = (props = {}) => (
   <ObjectPage {...props}>
-    <ObjectPageSection heading="Title 1" id="1">
+    <ObjectPageSection titleText="Title 1" id="1">
       Content 1
     </ObjectPageSection>
-    <ObjectPageSection heading="Title 2" id="2">
+    <ObjectPageSection titleText="Title 2" id="2">
       <Label>Content 2</Label>
     </ObjectPageSection>
-    <ObjectPageSection heading="Title 3" id="3">
+    <ObjectPageSection titleText="Title 3" id="3">
       <Text>Content 3</Text>
     </ObjectPageSection>
   </ObjectPage>

--- a/packages/main/src/components/ObjectPage/ObjectPageAnchorButton.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPageAnchorButton.tsx
@@ -39,7 +39,7 @@ export const ObjectPageAnchorButton: FC<ObjectPageAnchorPropTypes> = (props: Obj
       ref={ref}
       data-index={index}
       data-section-id={section.props.id}
-      text={section.props.heading}
+      text={section.props.titleText}
       selected={selected || undefined}
       with-sub-sections={hasSubSections || undefined}
     />

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -747,7 +747,7 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
                 .filter((item) => item.props && item.props.isSubSection)
                 .map((item) => (
                   <StandardListItem key={item.props.id} data-key={item.props.id}>
-                    {item.props.heading}
+                    {item.props.titleText}
                   </StandardListItem>
                 ))}
             </List>

--- a/packages/main/src/components/ObjectPageSection/ObjectPageSection.test.tsx
+++ b/packages/main/src/components/ObjectPageSection/ObjectPageSection.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 describe('ObjectPageSection', () => {
   test('Renders with children', () => {
     const { asFragment } = render(
-      <ObjectPageSection id={'1'} heading="Test" headingUppercase>
+      <ObjectPageSection id={'1'} titleText="Test" titleTextUppercase>
         This is my Text
       </ObjectPageSection>
     );
@@ -15,7 +15,7 @@ describe('ObjectPageSection', () => {
 
   test('ObjectPage w/ lowercase title', () => {
     const { asFragment } = render(
-      <ObjectPageSection id={'1'} heading="Test" headingUppercase={false}>
+      <ObjectPageSection id={'1'} titleText="Test" titleTextUppercase={false}>
         This is my Text
       </ObjectPageSection>
     );

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -9,18 +9,18 @@ import styles from './ObjectPageSection.jss';
 
 export interface ObjectPageSectionPropTypes extends CommonProps {
   /**
-   * Defines the heading of the `ObjectPageSection`.
+   * Defines the title of the `ObjectPageSection`.
    */
-  heading?: string;
+  titleText?: string;
   /**
    * Defines the ID of the `ObjectPageSection`.<br />
    * __Note:__ The `id` is taken into account when the section selection changes.
    */
   id: string;
   /**
-   * Defines whether the heading is always displayed in uppercase.
+   * Defines whether the title is always displayed in uppercase.
    */
-  headingUppercase?: boolean;
+  titleTextUppercase?: boolean;
   /**
    * Defines the content of the `ObjectPageSection`.
    */
@@ -33,7 +33,7 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSection' });
  */
 const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
   (props: ObjectPageSectionPropTypes, ref: RefObject<any>) => {
-    const { heading, id, children, headingUppercase, className, style, tooltip } = props;
+    const { titleText, id, children, titleTextUppercase, className, style, tooltip } = props;
     const classes = useStyles();
 
     if (!id) {
@@ -44,7 +44,7 @@ const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
     const htmlId = `ObjectPageSection-${id}`;
 
     const titleClasses = StyleClassHelper.of(classes.title);
-    if (headingUppercase) {
+    if (titleTextUppercase) {
       titleClasses.put(classes.uppercase);
     }
 
@@ -61,7 +61,7 @@ const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
         data-component-name="ObjectPageSection"
       >
         <div role="heading" aria-level={3} className={classes.header} data-component-name="ObjectPageSectionHeading">
-          <div className={titleClasses.className}>{heading}</div>
+          <div className={titleClasses.className}>{titleText}</div>
         </div>
         {/* TODO Check for subsections as they should win over the children */}
         <div className={classes.sectionContent}>
@@ -75,8 +75,8 @@ const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
 );
 
 ObjectPageSection.defaultProps = {
-  heading: '',
-  headingUppercase: true
+  titleText: '',
+  titleTextUppercase: true
 };
 
 ObjectPageSection.displayName = 'ObjectPageSection';

--- a/packages/main/src/components/ObjectPageSubSection/ObjectPageSubSection.test.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/ObjectPageSubSection.test.tsx
@@ -10,7 +10,7 @@ describe('ObjectPageSubSection', () => {
   });
 
   test('No ID should throw', () => {
-    const renderer = () => render(<ObjectPageSubSection heading="test">Content</ObjectPageSubSection>);
+    const renderer = () => render(<ObjectPageSubSection titleText="test">Content</ObjectPageSubSection>);
     expect(renderer).toThrow();
   });
 

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -9,9 +9,9 @@ import { EmptyIdPropException } from '../ObjectPage/EmptyIdPropException';
 
 export interface ObjectPageSubSectionPropTypes extends CommonProps {
   /**
-   * Defines the heading of the `ObjectPageSubSection`.
+   * Defines the title of the `ObjectPageSubSection`.
    */
-  heading?: string;
+  titleText?: string;
   /**
    * Defines the ID of the `ObjectPageSubSection`.
    */
@@ -46,7 +46,7 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSubSection' });
  */
 const ObjectPageSubSection: FC<ObjectPageSubSectionPropTypes> = forwardRef(
   (props: ObjectPageSubSectionPropTypes, ref: RefObject<any>) => {
-    const { children, id, heading, className, style, tooltip } = props;
+    const { children, id, titleText, className, style, tooltip } = props;
 
     if (!id) {
       throw new EmptyIdPropException('ObjectPageSubSection requires a unique ID property!');
@@ -80,7 +80,7 @@ const ObjectPageSubSection: FC<ObjectPageSubSectionPropTypes> = forwardRef(
           className={classes.objectPageSubSectionHeaderTitle}
           data-component-name="ObjectPageSubSectionHeading"
         >
-          {heading}
+          {titleText}
         </div>
         <div className={classes.subSectionContent} data-component-name="ObjectPageSubSectionContent">
           {children}


### PR DESCRIPTION
BREAKING CHANGE: **ObjectPageSection**: `heading` has been renamed to `titleText` and `headingUppercase` to `titleTextUppercase`
BREAKING CHANGE: **ObjectPageSubSection**: `heading` has been renamed to `titleText`

