### PR TITLE
refactor(DynamicPageTitle): rename props

### DIFF
--- a/packages/base/codemods/renamePropsV18.js
+++ b/packages/base/codemods/renamePropsV18.js
@@ -175,6 +175,11 @@ const renamingMap = {
   AnalyticalTable: {
     title: 'header'
   },
+  DynamicPageTitle: {
+    heading: 'header',
+    subheading: 'subHeader',
+    showSubheadingRight: 'showSubHeaderRight'
+  },
   Form: {
     title: 'titleText'
   },

--- a/packages/main/src/components/AnalyticalCard/AnalyticalCard.stories.mdx
+++ b/packages/main/src/components/AnalyticalCard/AnalyticalCard.stories.mdx
@@ -58,8 +58,8 @@ import { LineChart } from '@ui5/webcomponents-react-charts/dist/LineChart';
         <AnalyticalCard
           header={
             <AnalyticalCardHeader
-              titleText="Heading"
-              subtitleText="Subheading"
+              titleText="Title"
+              subtitleText="Sub Title"
               arrowIndicator={DeviationIndicator.Down}
               indicatorState={ValueState.Success}
               value="Value"
@@ -121,7 +121,7 @@ import { LineChart } from '@ui5/webcomponents-react-charts/dist/LineChart';
     }}
     argTypes={{
       titleText: { description: 'Defines the title of the `AnalyticalCardHeader`.' },
-      subtitleText: { description: 'Defines the subheading of the `AnalyticalCardHeader`.' },
+      subtitleText: { description: 'Defines the sub title of the `AnalyticalCardHeader`.' },
       value: { description: 'Defines the value of the `AnalyticalCardHeader`.' },
       unit: { description: 'Defines the unit displayed next to the value of the `AnalyticalCardHeader`.' },
       target: { description: 'Defines the target value.' },

--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -78,8 +78,8 @@ import { useReducer, useState } from 'react';
             <Link>Page 5</Link>
           </Breadcrumbs>
         }
-        heading={<Title>Header Title</Title>}
-        subheading={<Label>This is a subheading</Label>}
+        header={<Title>Header Title</Title>}
+        subHeader={<Label>This is a sub header</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -221,7 +221,7 @@ import { useReducer, useState } from 'react';
                       <Link>Page 5</Link>
                     </Breadcrumbs>
                   }
-                  heading={
+                  header={
                     <VariantManagement
                       onSelect={selectVariant}
                       variantItems={[
@@ -231,7 +231,7 @@ import { useReducer, useState } from 'react';
                       selectedKey={headerVariant}
                     />
                   }
-                  subheading={<Label>This is a subheading</Label>}
+                  subHeader={<Label>This is a sub header</Label>}
                 >
                   <Badge>Status: OK</Badge>
                 </DynamicPageTitle>

--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -50,8 +50,8 @@ const renderComponent = () => (
             <Link>Page 5</Link>
           </Breadcrumbs>
         }
-        heading={<Title>Header Title</Title>}
-        subheading={<Label>This is a subheading</Label>}
+        header={<Title>Header Title</Title>}
+        subHeader={<Label>This is a subheading</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -231,8 +231,8 @@ const renderComponentWithoutContent = () => (
             <Link>Page 5</Link>
           </Breadcrumbs>
         }
-        heading={<Title>Header Title</Title>}
-        subheading={<Label>This is a subheading</Label>}
+        header={<Title>Header Title</Title>}
+        subHeader={<Label>This is a subheading</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -280,8 +280,8 @@ const renderComponentWithAlwaysShowContentHeader = () => (
             <Link>Page 5</Link>
           </Breadcrumbs>
         }
-        heading={<Title>Header Title</Title>}
-        subheading={<Label>This is a subheading</Label>}
+        header={<Title>Header Title</Title>}
+        subHeader={<Label>This is a subheading</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -315,8 +315,8 @@ const renderComponentHideHeaderButton = () => (
           <Button design={ButtonDesign.Transparent}>Toggle Footer</Button>,
           <Button icon="action" design={ButtonDesign.Transparent}></Button>
         ]}
-        heading={<Title>Header Title</Title>}
-        subheading={<Label>This is a subheading</Label>}
+        header={<Title>Header Title</Title>}
+        subHeader={<Label>This is a subheading</Label>}
       />
     }
     headerContent={

--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -51,7 +51,7 @@ const renderComponent = () => (
           </Breadcrumbs>
         }
         header={<Title>Header Title</Title>}
-        subHeader={<Label>This is a subheading</Label>}
+        subHeader={<Label>This is a sub header</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -232,7 +232,7 @@ const renderComponentWithoutContent = () => (
           </Breadcrumbs>
         }
         header={<Title>Header Title</Title>}
-        subHeader={<Label>This is a subheading</Label>}
+        subHeader={<Label>This is a sub header</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -281,7 +281,7 @@ const renderComponentWithAlwaysShowContentHeader = () => (
           </Breadcrumbs>
         }
         header={<Title>Header Title</Title>}
-        subHeader={<Label>This is a subheading</Label>}
+        subHeader={<Label>This is a sub header</Label>}
       >
         <Badge>Status: OK</Badge>
       </DynamicPageTitle>
@@ -316,7 +316,7 @@ const renderComponentHideHeaderButton = () => (
           <Button icon="action" design={ButtonDesign.Transparent}></Button>
         ]}
         header={<Title>Header Title</Title>}
-        subHeader={<Label>This is a subheading</Label>}
+        subHeader={<Label>This is a sub header</Label>}
       />
     }
     headerContent={

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`DynamicPage always show content header 1`] = `
         >
           <div
             class="DynamicPageTitle-title"
-            data-component-name="DynamicPageTitleHeading"
+            data-component-name="DynamicPageTitleHeader"
           >
             <ui5-title
               level="H2"
@@ -266,12 +266,12 @@ exports[`DynamicPage always show content header 1`] = `
       >
         <div
           class="DynamicPageTitle-subTitleBottom"
-          data-component-name="DynamicPageTitleSubheading"
+          data-component-name="DynamicPageTitleSubHeader"
         >
           <ui5-label
             ui5-label=""
           >
-            This is a subheading
+            This is a sub header
           </ui5-label>
         </div>
       </div>
@@ -368,7 +368,7 @@ exports[`DynamicPage hider header button 1`] = `
         >
           <div
             class="DynamicPageTitle-title"
-            data-component-name="DynamicPageTitleHeading"
+            data-component-name="DynamicPageTitleHeader"
           >
             <ui5-title
               level="H2"
@@ -452,12 +452,12 @@ exports[`DynamicPage hider header button 1`] = `
       >
         <div
           class="DynamicPageTitle-subTitleBottom"
-          data-component-name="DynamicPageTitleSubheading"
+          data-component-name="DynamicPageTitleSubHeader"
         >
           <ui5-label
             ui5-label=""
           >
-            This is a subheading
+            This is a sub header
           </ui5-label>
         </div>
       </div>
@@ -872,7 +872,7 @@ exports[`DynamicPage with content 1`] = `
         >
           <div
             class="DynamicPageTitle-title"
-            data-component-name="DynamicPageTitleHeading"
+            data-component-name="DynamicPageTitleHeader"
           >
             <ui5-title
               level="H2"
@@ -1007,12 +1007,12 @@ exports[`DynamicPage with content 1`] = `
       >
         <div
           class="DynamicPageTitle-subTitleBottom"
-          data-component-name="DynamicPageTitleSubheading"
+          data-component-name="DynamicPageTitleSubHeader"
         >
           <ui5-label
             ui5-label=""
           >
-            This is a subheading
+            This is a sub header
           </ui5-label>
         </div>
       </div>
@@ -1877,7 +1877,7 @@ exports[`DynamicPage without content 1`] = `
         >
           <div
             class="DynamicPageTitle-title"
-            data-component-name="DynamicPageTitleHeading"
+            data-component-name="DynamicPageTitleHeader"
           >
             <ui5-title
               level="H2"
@@ -2012,12 +2012,12 @@ exports[`DynamicPage without content 1`] = `
       >
         <div
           class="DynamicPageTitle-subTitleBottom"
-          data-component-name="DynamicPageTitleSubheading"
+          data-component-name="DynamicPageTitleSubHeader"
         >
           <ui5-label
             ui5-label=""
           >
-            This is a subheading
+            This is a sub header
           </ui5-label>
         </div>
       </div>

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -194,7 +194,7 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
       <FlexBox alignItems={FlexBoxAlignItems.Center} style={{ flexGrow: 1, width: '100%' }}>
         <FlexBox className={classes.titleMainSection}>
           {header && (
-            <div className={classes.title} data-component-name="DynamicPageTitleHeading">
+            <div className={classes.title} data-component-name="DynamicPageTitleHeader">
               {header}
             </div>
           )}
@@ -202,7 +202,7 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
             <div
               className={classes.subTitleRight}
               style={{ [paddingLeftRtl]: '0.5rem' }}
-              data-component-name="DynamicPageTitleSubheading"
+              data-component-name="DynamicPageTitleSubHeader"
             >
               {subHeader}
             </div>
@@ -235,7 +235,7 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
       </FlexBox>
       {subHeader && !showSubHeaderRight && (
         <FlexBox>
-          <div className={classes.subTitleBottom} data-component-name="DynamicPageTitleSubheading">
+          <div className={classes.subTitleBottom} data-component-name="DynamicPageTitleSubHeader">
             {subHeader}
           </div>
         </FlexBox>

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -49,15 +49,15 @@ export interface DynamicPageTitleProps extends CommonProps {
   children?: ReactNode | ReactNodeArray;
 
   /**
-   * The `heading` is positioned in the `DynamicPageTitle` left area.
-   * Use this aggregation to display a `Title` (or any other component that serves as a heading)
+   * The `header` is positioned in the `DynamicPageTitle` left area.
+   * Use this aggregation to display a `Title` (or any other component that serves as a header)
    */
-  heading?: ReactNode;
+  header?: ReactNode;
   /**
-   * The `subheading` is positioned in the `DynamicPageTitle` left area below the `heading`.
-   * Use this aggregation to display a component like `Label` or any other component that serves as subheading.
+   * The `subHeader` is positioned in the `DynamicPageTitle` left area below the `header`.
+   * Use this aggregation to display a component like `Label` or any other component that serves as sub header.
    */
-  subheading?: ReactNode;
+  subHeader?: ReactNode;
   /**
    * The `DynamicPageTitle` navigation actions.<br />
    * *Note*: The `navigationActions` position depends on the control size.
@@ -68,9 +68,9 @@ export interface DynamicPageTitleProps extends CommonProps {
    */
   navigationActions?: ReactElement | ReactElement[];
   /**
-   * Display the subheading on the right instead of below the heading.
+   * Display the `subHeader` on the right instead of below the `header`.
    */
-  showSubheadingRight?: boolean;
+  showSubHeaderRight?: boolean;
 }
 
 interface InternalProps extends DynamicPageTitleProps {
@@ -92,9 +92,9 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
     onToggleHeaderContentVisibility,
     breadcrumbs,
     children,
-    heading,
-    subheading,
-    showSubheadingRight,
+    header,
+    subHeader,
+    showSubHeaderRight,
     navigationActions,
     className,
     style,
@@ -193,18 +193,18 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
       )}
       <FlexBox alignItems={FlexBoxAlignItems.Center} style={{ flexGrow: 1, width: '100%' }}>
         <FlexBox className={classes.titleMainSection}>
-          {heading && (
+          {header && (
             <div className={classes.title} data-component-name="DynamicPageTitleHeading">
-              {heading}
+              {header}
             </div>
           )}
-          {subheading && showSubheadingRight && (
+          {subHeader && showSubHeaderRight && (
             <div
               className={classes.subTitleRight}
               style={{ [paddingLeftRtl]: '0.5rem' }}
               data-component-name="DynamicPageTitleSubheading"
             >
-              {subheading}
+              {subHeader}
             </div>
           )}
           {children && (
@@ -233,10 +233,10 @@ const DynamicPageTitle: FC<DynamicPageTitleProps> = forwardRef((props: InternalP
           {!showNavigationInTopArea && navigationActions}
         </Toolbar>
       </FlexBox>
-      {subheading && !showSubheadingRight && (
+      {subHeader && !showSubHeaderRight && (
         <FlexBox>
           <div className={classes.subTitleBottom} data-component-name="DynamicPageTitleSubheading">
-            {subheading}
+            {subHeader}
           </div>
         </FlexBox>
       )}

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -58,9 +58,9 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
     ),
     headerTitle: (
       <DynamicPageTitle
-        showSubheadingRight
-        heading="Denise Smith"
-        subheading="Senior UI Developer"
+        showSubHeaderRight
+        header="Denise Smith"
+        subHeader="Senior UI Developer"
         actions={
           <>
             <Button key="1" design={ButtonDesign.Emphasized}>

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`ObjectPage Default with Sections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -89,7 +89,7 @@ exports[`ObjectPage Default with Sections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -121,7 +121,7 @@ exports[`ObjectPage Default with Sections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -219,7 +219,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -251,7 +251,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -281,7 +281,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -306,7 +306,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -327,7 +327,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -348,7 +348,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -371,7 +371,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -396,7 +396,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -417,7 +417,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -438,7 +438,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -527,7 +527,7 @@ exports[`ObjectPage IconTabBar Mode 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -552,7 +552,7 @@ exports[`ObjectPage IconTabBar Mode 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -573,7 +573,7 @@ exports[`ObjectPage IconTabBar Mode 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -594,7 +594,7 @@ exports[`ObjectPage IconTabBar Mode 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -700,7 +700,7 @@ exports[`ObjectPage Not crashing with 1 section - Default Mode 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -772,7 +772,7 @@ exports[`ObjectPage Not crashing with 1 section - IconTabBar Mode 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -937,7 +937,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -969,7 +969,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -999,7 +999,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1024,7 +1024,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -1045,7 +1045,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -1066,7 +1066,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -1089,7 +1089,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1114,7 +1114,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -1135,7 +1135,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -1156,7 +1156,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -1264,7 +1264,7 @@ exports[`ObjectPage with footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1296,7 +1296,7 @@ exports[`ObjectPage with footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1326,7 +1326,7 @@ exports[`ObjectPage with footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1351,7 +1351,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -1372,7 +1372,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -1393,7 +1393,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -1416,7 +1416,7 @@ exports[`ObjectPage with footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1441,7 +1441,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -1462,7 +1462,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -1483,7 +1483,7 @@ exports[`ObjectPage with footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -1606,7 +1606,7 @@ exports[`ObjectPage with header 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1638,7 +1638,7 @@ exports[`ObjectPage with header 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1668,7 +1668,7 @@ exports[`ObjectPage with header 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1693,7 +1693,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -1714,7 +1714,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -1735,7 +1735,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -1758,7 +1758,7 @@ exports[`ObjectPage with header 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -1783,7 +1783,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -1804,7 +1804,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -1825,7 +1825,7 @@ exports[`ObjectPage with header 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -2002,7 +2002,7 @@ exports[`ObjectPage with img 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2034,7 +2034,7 @@ exports[`ObjectPage with img 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2064,7 +2064,7 @@ exports[`ObjectPage with img 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2089,7 +2089,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -2110,7 +2110,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -2131,7 +2131,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -2154,7 +2154,7 @@ exports[`ObjectPage with img 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2179,7 +2179,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -2200,7 +2200,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -2221,7 +2221,7 @@ exports[`ObjectPage with img 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -2411,7 +2411,7 @@ exports[`ObjectPage with img 2`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2443,7 +2443,7 @@ exports[`ObjectPage with img 2`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2473,7 +2473,7 @@ exports[`ObjectPage with img 2`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2498,7 +2498,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -2519,7 +2519,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -2540,7 +2540,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -2563,7 +2563,7 @@ exports[`ObjectPage with img 2`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2588,7 +2588,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -2609,7 +2609,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -2630,7 +2630,7 @@ exports[`ObjectPage with img 2`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -2775,7 +2775,7 @@ exports[`ObjectPage with title 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2807,7 +2807,7 @@ exports[`ObjectPage with title 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2837,7 +2837,7 @@ exports[`ObjectPage with title 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2862,7 +2862,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -2883,7 +2883,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -2904,7 +2904,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -2927,7 +2927,7 @@ exports[`ObjectPage with title 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -2952,7 +2952,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -2973,7 +2973,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -2994,7 +2994,7 @@ exports[`ObjectPage with title 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3
@@ -3145,7 +3145,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -3177,7 +3177,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -3207,7 +3207,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -3232,7 +3232,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.1
@@ -3253,7 +3253,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.2
@@ -3274,7 +3274,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 3.3
@@ -3297,7 +3297,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
         <div
           aria-level="3"
           class="ObjectPageSection-header"
-          data-component-name="ObjectPageSectionHeading"
+          data-component-name="ObjectPageSectionTitleText"
           role="heading"
         >
           <div
@@ -3322,7 +3322,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.1
@@ -3343,7 +3343,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.2
@@ -3364,7 +3364,7 @@ exports[`ObjectPage with title, header & footer 1`] = `
               <div
                 aria-level="4"
                 class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-                data-component-name="ObjectPageSubSectionHeading"
+                data-component-name="ObjectPageSubSectionTitleText"
                 role="heading"
               >
                 Title SubSection 4.3

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -61,7 +61,7 @@ export interface ObjectPagePropTypes extends CommonProps {
    * Defines the the upper, always static, title section of the `ObjectPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageTitle` in order to preserve the intended design.
-   * __Note:__ If not defined otherwise the prop `showSubheadingRight` of the `DynamicPageTitle` is set to `true` by default.
+   * __Note:__ If not defined otherwise the prop `showSubHeaderRight` of the `DynamicPageTitle` is set to `true` by default.
    */
   headerTitle?: ReactElement;
   /**
@@ -508,9 +508,9 @@ const ObjectPage: FC<ObjectPagePropTypes> = forwardRef((props: ObjectPagePropTyp
     (inHeader = false) => {
       const titleStyles = { ...(inHeader ? { padding: 0 } : {}), ...(headerTitle?.props?.style ?? {}) };
 
-      if (headerTitle?.props && headerTitle.props?.showSubheadingRight === undefined) {
+      if (headerTitle?.props && headerTitle.props?.showSubHeaderRight === undefined) {
         return React.cloneElement(headerTitle, {
-          showSubheadingRight: true,
+          showSubHeaderRight: true,
           style: titleStyles,
           'data-not-clickable': titleHeaderNotClickable,
           onToggleHeaderContentVisibility: onTitleClick

--- a/packages/main/src/components/ObjectPageSection/__snapshots__/ObjectPageSection.test.tsx.snap
+++ b/packages/main/src/components/ObjectPageSection/__snapshots__/ObjectPageSection.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ObjectPageSection ObjectPage w/ lowercase title 1`] = `
     <div
       aria-level="3"
       class="ObjectPageSection-header"
-      data-component-name="ObjectPageSectionHeading"
+      data-component-name="ObjectPageSectionTitleText"
       role="heading"
     >
       <div
@@ -43,7 +43,7 @@ exports[`ObjectPageSection Renders with children 1`] = `
     <div
       aria-level="3"
       class="ObjectPageSection-header"
-      data-component-name="ObjectPageSectionHeading"
+      data-component-name="ObjectPageSectionTitleText"
       role="heading"
     >
       <div

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -60,7 +60,7 @@ const ObjectPageSection: FC<ObjectPageSectionPropTypes> = forwardRef(
         id={htmlId}
         data-component-name="ObjectPageSection"
       >
-        <div role="heading" aria-level={3} className={classes.header} data-component-name="ObjectPageSectionHeading">
+        <div role="heading" aria-level={3} className={classes.header} data-component-name="ObjectPageSectionTitleText">
           <div className={titleClasses.className}>{titleText}</div>
         </div>
         {/* TODO Check for subsections as they should win over the children */}

--- a/packages/main/src/components/ObjectPageSubSection/__snapshots__/ObjectPageSubSection.test.tsx.snap
+++ b/packages/main/src/components/ObjectPageSubSection/__snapshots__/ObjectPageSubSection.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ObjectPageSubSection Render without Crashing 1`] = `
     <div
       aria-level="4"
       class="ObjectPageSubSection-objectPageSubSectionHeaderTitle"
-      data-component-name="ObjectPageSubSectionHeading"
+      data-component-name="ObjectPageSubSectionTitleText"
       role="heading"
     />
     <div

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -78,7 +78,7 @@ const ObjectPageSubSection: FC<ObjectPageSubSectionPropTypes> = forwardRef(
           role="heading"
           aria-level={4}
           className={classes.objectPageSubSectionHeaderTitle}
-          data-component-name="ObjectPageSubSectionHeading"
+          data-component-name="ObjectPageSubSectionTitleText"
         >
           {titleText}
         </div>


### PR DESCRIPTION
BREAKING CHANGE: `heading` has been renamed to `header`,  `subheading` to `subHeader` and `showSubheadingRight` to `showSubHeaderRight`

Closes #1600