### PR TITLE
fix(AnalyticalTable): unselect rows in single-select mode & correctly select rows with row-selector only behavior

### DIFF
--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -48,7 +48,7 @@ const Cell = ({ row, webComponentsReactProperties: { selectionBehavior, selectio
         row.getRowProps().onClick(e, true);
       }
     },
-    [selectionMode, row]
+    [selectionMode, row.getRowProps]
   );
   if (row.isGrouped && selectionMode === TableSelectionMode.SINGLE_SELECT) {
     return null;
@@ -56,6 +56,7 @@ const Cell = ({ row, webComponentsReactProperties: { selectionBehavior, selectio
   if (selectionMode === TableSelectionMode.SINGLE_SELECT) {
     return <div style={divStyle} onClick={handleCellClick} data-name="internal_selection_column" />;
   }
+
   return (
     <CheckBox
       {...row.getToggleRowSelectedProps()}

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -42,14 +42,12 @@ const Header = ({
 };
 
 const Cell = ({ row, webComponentsReactProperties: { selectionBehavior, selectionMode } }) => {
-  const handleCellClick = useCallback(
-    (e) => {
-      if (TableSelectionBehavior.ROW_SELECTOR === selectionBehavior) {
-        row.getRowProps().onClick(e, true);
-      }
-    },
-    [selectionMode, row.getRowProps]
-  );
+  const handleCellClick = (e) => {
+    if (TableSelectionBehavior.ROW_SELECTOR === selectionBehavior) {
+      row.getRowProps().onClick(e, true);
+    }
+  };
+
   if (row.isGrouped && selectionMode === TableSelectionMode.SINGLE_SELECT) {
     return null;
   }

--- a/packages/main/src/components/AnalyticalTable/hooks/useSingleRowStateSelection.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useSingleRowStateSelection.ts
@@ -34,7 +34,7 @@ const tagNamesWhichShouldNotSelectARow = new Set([
 ]);
 
 const getRowProps = (rowProps, { row, instance }) => {
-  const { webComponentsReactProperties, toggleRowSelected, selectedFlatRows } = instance;
+  const { webComponentsReactProperties, toggleRowSelected, selectedFlatRows, flatRows } = instance;
   const handleRowSelect = (e, selectionCellClick = false) => {
     if (
       e.target?.dataset?.name !== 'internal_selection_column' &&
@@ -84,7 +84,8 @@ const getRowProps = (rowProps, { row, instance }) => {
       const payload = {
         row,
         isSelected: !row.isSelected,
-        selectedFlatRows: !row.isSelected ? [row.id] : []
+        selectedFlatRows: !row.isSelected ? [row.id] : [],
+        allRowsSelected: false
       };
       if (selectionMode === TableSelectionMode.MULTI_SELECT) {
         const isRowSelected = selectionCellClick ? row.isSelected : !row.isSelected;
@@ -94,6 +95,10 @@ const getRowProps = (rowProps, { row, instance }) => {
         payload.selectedFlatRows = isRowSelected
           ? [...selectedFlatRows, row]
           : selectedFlatRows.filter((prevRow) => prevRow.id !== row.id);
+
+        if (payload.selectedFlatRows.length === flatRows.length) {
+          payload.allRowsSelected = true;
+        }
       }
       onRowSelected(enrichEventWithDetails(e, payload));
     }

--- a/packages/main/src/components/AnalyticalTable/hooks/useSingleRowStateSelection.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useSingleRowStateSelection.ts
@@ -71,8 +71,10 @@ const getRowProps = (rowProps, { row, instance }) => {
     }
 
     if (selectionMode === TableSelectionMode.SINGLE_SELECT) {
-      for (const row of selectedFlatRows) {
-        toggleRowSelected(row.id, false);
+      for (const selectedRow of selectedFlatRows) {
+        if (selectedRow.id !== row.id) {
+          toggleRowSelected(selectedRow.id, false);
+        }
       }
     }
     instance.toggleRowSelected(row.id);
@@ -85,13 +87,18 @@ const getRowProps = (rowProps, { row, instance }) => {
         selectedFlatRows: !row.isSelected ? [row.id] : []
       };
       if (selectionMode === TableSelectionMode.MULTI_SELECT) {
-        payload.selectedFlatRows = !row.isSelected
+        const isRowSelected = selectionCellClick ? row.isSelected : !row.isSelected;
+        if (selectionCellClick) {
+          payload.isSelected = row.isSelected;
+        }
+        payload.selectedFlatRows = isRowSelected
           ? [...selectedFlatRows, row]
           : selectedFlatRows.filter((prevRow) => prevRow.id !== row.id);
       }
       onRowSelected(enrichEventWithDetails(e, payload));
     }
   };
+
   return [
     rowProps,
     {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -262,7 +262,14 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
   /**
    * Fired when a row is selected or unselected.
    */
-  onRowSelected?: (e?: CustomEvent<{ allRowsSelected?: boolean; row?: unknown; isSelected?: boolean }>) => void;
+  onRowSelected?: (
+    e?: CustomEvent<{
+      allRowsSelected?: boolean;
+      row?: Record<string, unknown>;
+      isSelected?: boolean;
+      selectedFlatRows?: Record<string, unknown>[] | string[];
+    }>
+  ) => void;
   /**
    * Fired when a row is clicked
    */


### PR DESCRIPTION
- Fixes selection of rows in `MULTI_SELECT` mode and with `ROW_SELECTOR` only behavior.
- In `SINGLE_SELECT` mode, it is now possible to unselect a selected row by clicking on it (or the respective row-selector)

Fixes #1907