### PR TITLE
chore(base): create type definitions for theme configuration

### DIFF
--- a/packages/base/types/Theme.d.ts
+++ b/packages/base/types/Theme.d.ts
@@ -8,10 +8,14 @@ declare module '@ui5/webcomponents-base/dist/config/Theme' {
     | 'sap_fiori_3_hcb'
     | 'sap_fiori_3_hcw'
     | string;
-
+  
+  /**
+   * Getter for the currenty applied theme.
+   */ 
   export function getTheme(): ThemeId;
 
+  /**
+   * Apply a new theme to the application.
+   */ 
   export function setTheme(theme: ThemeId): Promise<void>;
-
-
 }

--- a/packages/base/types/Theme.d.ts
+++ b/packages/base/types/Theme.d.ts
@@ -1,12 +1,17 @@
-declare module "@ui5/webcomponents-base/dist/config/Theme" {
-  export function getTheme(): ThemeString;
-  export function setTheme(theme: ThemeString): Promise<void>;
-  export type ThemeString =
-    | "sap_fiori_3"
-    | "sap_fiori_3_dark"
-    | "sap_belize"
-    | "sap_belize_hcb"
-    | "sap_belize_hcw"
-    | "sap_fiori_3_hcb"
-    | "sap_fiori_3_hcw";
+declare module '@ui5/webcomponents-base/dist/config/Theme' {
+  export type ThemeId =
+    | 'sap_fiori_3'
+    | 'sap_fiori_3_dark'
+    | 'sap_belize'
+    | 'sap_belize_hcb'
+    | 'sap_belize_hcw'
+    | 'sap_fiori_3_hcb'
+    | 'sap_fiori_3_hcw'
+    | string;
+
+  export function getTheme(): ThemeId;
+
+  export function setTheme(theme: ThemeId): Promise<void>;
+
+
 }

--- a/packages/base/types/Theme.d.ts
+++ b/packages/base/types/Theme.d.ts
@@ -1,13 +1,12 @@
 declare module "@ui5/webcomponents-base/dist/config/Theme" {
-  export function getTheme(): keyof ThemeKeys;
-  export function setTheme(theme: keyof ThemeKeys): void;
-  export interface ThemeKeys {
-    sap_fiori_3: never;
-    sap_fiori_3_dark: never;
-    sap_belize: never;
-    sap_belize_hcb: never;
-    sap_belize_hcw: never;
-    sap_fiori_3_hcb: never;
-    sap_fiori_3_hcw: never;
-  }
+  export function getTheme(): ThemeString;
+  export function setTheme(theme: ThemeString): Promise<void>;
+  export type ThemeString =
+    | "sap_fiori_3"
+    | "sap_fiori_3_dark"
+    | "sap_belize"
+    | "sap_belize_hcb"
+    | "sap_belize_hcw"
+    | "sap_fiori_3_hcb"
+    | "sap_fiori_3_hcw";
 }

--- a/packages/base/types/Theme.d.ts
+++ b/packages/base/types/Theme.d.ts
@@ -1,0 +1,13 @@
+declare module "@ui5/webcomponents-base/dist/config/Theme" {
+  export function getTheme(): keyof ThemeKeys;
+  export function setTheme(theme: keyof ThemeKeys): void;
+  export interface ThemeKeys {
+    sap_fiori_3: never;
+    sap_fiori_3_dark: never;
+    sap_belize: never;
+    sap_belize_hcb: never;
+    sap_belize_hcw: never;
+    sap_fiori_3_hcb: never;
+    sap_fiori_3_hcw: never;
+  }
+}


### PR DESCRIPTION
Hey, following what I've seen in #1057 and #1136, I believe we could follow the same approach we did for  `UI5Devices.d.ts` and create a type definition for the base Theming config. 

I'm using these types in my project (internally at SAP).

I created the themes as an interface only so the user can use https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation to add a new theme in their project without disrupting the already established themes, like so:

```ts
declare module "@ui5/webcomponents-base/dist/config/Theme" {
  export interface ThemeKeys {
    my_new_theme: never;
  }
}
```

The only issue is with the themes themselves, since that when a new theme is created this file here will have to be updated.