### PR TITLE
fix(charts): downgrade recharts to version 2.0.10

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "react-content-loader": "6.0.3",
-    "recharts": "2.1.0"
+    "recharts": "2.0.10"
   },
   "peerDependencies": {
     "@ui5/webcomponents-react": "^0.18.0",


### PR DESCRIPTION
- using recharts version 2.0.10
-> responsive scaling in width isn't working in version 2.1.0

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/master/docs/Guidelines.md#commit-message-style)
