### PR TITLE
fix(ObjectPage): fire `onSelectedSectionChange` on every section change

### DIFF
--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -262,6 +262,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const [timeStamp, setTimeStamp] = useState(0);
   useEffect(() => {
     if (selectedSectionId) {
+      // wait for DOM draw, otherwise initial scroll won't work as intended
       if (timeStamp < 750 && timeStamp !== undefined) {
         requestAnimationFrame((internalTimestamp) => {
           setTimeStamp(internalTimestamp);

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -4,7 +4,7 @@ import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassH
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/dist/useConsolidatedRef';
 import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
-import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { AvatarPropTypes } from '@ui5/webcomponents-react/dist/Avatar';
 import { AvatarSize } from '@ui5/webcomponents-react/dist/AvatarSize';
 import { GlobalStyleClasses } from '@ui5/webcomponents-react/dist/GlobalStyleClasses';
@@ -97,7 +97,7 @@ export interface ObjectPagePropTypes extends CommonProps {
    * Fired when the selected section changes.
    */
   onSelectedSectionChanged?: (
-    event: CustomEvent<{ selectedSectionIndex: number; selectedSectionId: string; section: ComponentType }>
+    event: CustomEvent<{ selectedSectionIndex: number; selectedSectionId: string; section: HTMLDivElement }>
   ) => void;
 
   // appearance
@@ -161,6 +161,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const classes = useStyles();
 
   const firstSectionId = safeGetChildrenArray<ReactElement>(children)[0]?.props?.id;
+
   const [internalSelectedSectionId, setInternalSelectedSectionId] = useState(selectedSectionId ?? firstSectionId);
   const [selectedSubSectionId, setSelectedSubSectionId] = useState(props.selectedSubSectionId);
   const [headerPinned, setHeaderPinned] = useState(alwaysShowContentHeader);
@@ -168,11 +169,26 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
 
   const objectPageRef: RefObject<HTMLDivElement> = useConsolidatedRef(ref);
   const topHeaderRef: RefObject<HTMLDivElement> = useRef();
+  const scrollEvent = useRef();
   //@ts-ignore
   const headerContentRef: RefObject<HTMLDivElement> = useConsolidatedRef(headerContent?.ref);
   const anchorBarRef: RefObject<HTMLDivElement> = useRef();
   const scrollTimeout = useRef(null);
   const [isAfterScroll, setIsAfterScroll] = useState(false);
+
+  const prevInternalSelectedSectionId = useRef(internalSelectedSectionId);
+  const fireOnSelectedChangedEvent = (targetEvent, index, id, section) => {
+    if (typeof onSelectedSectionChanged === 'function' && prevInternalSelectedSectionId.current !== id) {
+      onSelectedSectionChanged(
+        enrichEventWithDetails(targetEvent, {
+          selectedSectionIndex: parseInt(index, 10),
+          selectedSectionId: id,
+          section
+        })
+      );
+      prevInternalSelectedSectionId.current = id;
+    }
+  };
 
   const isRTL = useIsRTL(objectPageRef);
   const responsivePaddingClass = useResponsiveContentPadding(objectPageRef.current);
@@ -250,34 +266,51 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     ]
   );
 
-  // change selected section when prop is changed (external change)
+  // wait for DOM draw, otherwise scroll won't work as intended
+  const [initialRender, setInitialRender] = useState(!!selectedSectionId);
   useEffect(() => {
-    isProgrammaticallyScrolled.current = true;
-    setInternalSelectedSectionId(selectedSectionId ?? firstSectionId);
-  }, [selectedSectionId, isProgrammaticallyScrolled, firstSectionId]);
+    setInitialRender(false);
+  }, []);
+
+  // change selected section when prop is changed (external change)
+  const prevSelectedSectionId = useRef();
+  useEffect(() => {
+    if (!initialRender) {
+      const currentId = selectedSectionId ?? firstSectionId;
+      if (currentId !== prevSelectedSectionId.current) {
+        isProgrammaticallyScrolled.current = true;
+        setInternalSelectedSectionId(currentId);
+        prevSelectedSectionId.current = currentId;
+        const sections = objectPageRef.current?.querySelectorAll('section[data-component-name="ObjectPageSection"]');
+        const currentIndex = safeGetChildrenArray(children).findIndex((objectPageSection: ReactElement, index) => {
+          return objectPageSection.props?.id === currentId;
+        });
+        fireOnSelectedChangedEvent({} as any, currentIndex, currentId, sections[0]);
+      }
+    }
+  }, [selectedSectionId, firstSectionId, fireOnSelectedChangedEvent, initialRender]);
 
   // section was selected by clicking on the anchor bar buttons
   const handleOnSectionSelected = useCallback(
-    (e) => {
+    (targetEvent, newSelectionSectionId, index, section) => {
       isProgrammaticallyScrolled.current = true;
-      const newSelectionSection = e.detail.props?.id;
       setInternalSelectedSectionId((oldSelectedSection) => {
-        if (oldSelectedSection === newSelectionSection) {
-          scrollToSection(newSelectionSection);
+        if (oldSelectedSection === newSelectionSectionId) {
+          scrollToSection(newSelectionSectionId);
         }
-        return newSelectionSection;
+        return newSelectionSectionId;
       });
-      fireOnSelectedChangedEvent(e);
+      fireOnSelectedChangedEvent(targetEvent, index, newSelectionSectionId, section);
     },
     [onSelectedSectionChanged, setInternalSelectedSectionId, isProgrammaticallyScrolled, scrollToSection]
   );
 
   // do internal scrolling
   useEffect(() => {
-    if (mode === ObjectPageMode.Default && isProgrammaticallyScrolled.current === true) {
+    if (mode === ObjectPageMode.Default && isProgrammaticallyScrolled.current === true && !selectedSubSectionId) {
       scrollToSection(internalSelectedSectionId);
     }
-  }, [internalSelectedSectionId, mode, isProgrammaticallyScrolled, scrollToSection]);
+  }, [internalSelectedSectionId, mode, isProgrammaticallyScrolled, scrollToSection, selectedSubSectionId]);
 
   // Scrolling for Sub Section Selection
   useEffect(() => {
@@ -303,7 +336,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     }
   }, [
     selectedSubSectionId,
-    isProgrammaticallyScrolled,
+    isProgrammaticallyScrolled.current,
     topHeaderHeight,
     anchorBarHeight,
     headerPinned,
@@ -340,14 +373,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
         }
       }
     }
-  }, [
-    props.selectedSubSectionId,
-    setInternalSelectedSectionId,
-    setSelectedSubSectionId,
-    children,
-    mode,
-    isProgrammaticallyScrolled
-  ]);
+  }, [props.selectedSubSectionId, setInternalSelectedSectionId, setSelectedSubSectionId, children, mode]);
 
   useEffect(() => {
     const fillerDivObserver = new ResizeObserver(() => {
@@ -384,29 +410,23 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     };
   }, [totalHeaderHeight, objectPageRef, children, mode, footer]);
 
-  const fireOnSelectedChangedEvent = debounce((e) => {
-    if (typeof onSelectedSectionChanged === 'function') {
-      onSelectedSectionChanged(
-        enrichEventWithDetails(e, {
-          selectedSectionIndex: e.detail.index,
-          selectedSectionId: e.detail.props.id,
-          section: e.detail
-        })
-      );
-    }
-  }, 500);
-
   const handleOnSubSectionSelected = useCallback(
     (e) => {
       isProgrammaticallyScrolled.current = true;
       if (mode === ObjectPageMode.IconTabBar) {
         const sectionId = e.detail.section.props?.id;
         setInternalSelectedSectionId(sectionId);
+
+        const sections = objectPageRef.current?.querySelectorAll('section[data-component-name="ObjectPageSection"]');
+        const currentIndex = safeGetChildrenArray(children).findIndex((objectPageSection: ReactElement) => {
+          return objectPageSection.props?.id === sectionId;
+        });
+        fireOnSelectedChangedEvent(e, currentIndex, sectionId, sections[currentIndex]);
       }
       const subSection = e.detail.subSection;
       setSelectedSubSectionId(subSection.props.id);
     },
-    [mode, setInternalSelectedSectionId, setSelectedSubSectionId, isProgrammaticallyScrolled]
+    [mode, setInternalSelectedSectionId, setSelectedSubSectionId, isProgrammaticallyScrolled, children]
   );
   const [scrolledHeaderExpanded, setScrolledHeaderExpanded] = useState(false);
   const onToggleHeaderContentVisibility = useCallback(
@@ -433,6 +453,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const passThroughProps = usePassThroughHtmlProps(props, ['onSelectedSectionChanged', 'onScroll']);
 
   useEffect(() => {
+    if (initialRender) return;
     const sections = objectPageRef.current?.querySelectorAll('section[data-component-name="ObjectPageSection"]');
     const objectPageHeight = objectPageRef.current?.clientHeight ?? 1000;
     const marginBottom = objectPageHeight - totalHeaderHeight - /*TabContainer*/ 48;
@@ -444,7 +465,12 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
             objectPageRef.current.getBoundingClientRect().top + totalHeaderHeight + 48 <=
             section.target.getBoundingClientRect().bottom
           ) {
-            setInternalSelectedSectionId(extractSectionIdFromHtmlId(section.target.id));
+            const currentId = extractSectionIdFromHtmlId(section.target.id);
+            setInternalSelectedSectionId(currentId);
+            const currentIndex = safeGetChildrenArray(children).findIndex((objectPageSection: ReactElement) => {
+              return objectPageSection.props?.id === currentId;
+            });
+            fireOnSelectedChangedEvent(scrollEvent.current, currentIndex, currentId, section.target);
           }
         }
       },
@@ -457,6 +483,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     // Fallback when scrolling faster than the IntersectionObserver can observe (in most cases faster than 60fps)
     if (isAfterScroll) {
       let currentSection = sections[sections.length - 1];
+      let currentIndex;
       for (let i = 0; i <= sections.length - 1; i++) {
         const section = sections[i];
         if (
@@ -464,11 +491,19 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
           section.getBoundingClientRect().bottom
         ) {
           currentSection = section;
+          currentIndex = i;
           break;
         }
       }
-      if (extractSectionIdFromHtmlId(currentSection.id) !== internalSelectedSectionId) {
-        setInternalSelectedSectionId(extractSectionIdFromHtmlId(currentSection.id));
+      const currentSectionId = extractSectionIdFromHtmlId(currentSection.id);
+      if (currentSectionId !== internalSelectedSectionId) {
+        setInternalSelectedSectionId(currentSectionId);
+        fireOnSelectedChangedEvent(
+          scrollEvent.current,
+          currentIndex ?? sections.length - 1,
+          currentSectionId,
+          currentSection
+        );
       }
       setIsAfterScroll(false);
     }
@@ -481,6 +516,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
       observer.disconnect();
     };
   }, [
+    initialRender,
     objectPageRef.current,
     children,
     totalHeaderHeight,
@@ -565,12 +601,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     (event) => {
       const { sectionId, index } = event.detail.tab.dataset;
       const section = safeGetChildrenArray<ReactElement>(children).find((el) => el.props.id == sectionId);
-      handleOnSectionSelected(
-        enrichEventWithDetails({} as any, {
-          ...section,
-          index
-        })
-      );
+      handleOnSectionSelected(event, section?.props?.id, index, section);
     },
     [children]
   );
@@ -600,6 +631,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const prevScrollTop = useRef();
   const onObjectPageScroll = useCallback(
     (e) => {
+      scrollEvent.current = e;
       if (typeof props.onScroll === 'function') {
         props.onScroll(e);
       }

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -186,7 +186,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
       debouncedOnSectionChange.cancel();
       clearTimeout(scrollTimeout.current);
     };
-  });
+  }, []);
 
   const isRTL = useIsRTL(objectPageRef);
   const responsivePaddingClass = useResponsiveContentPadding(objectPageRef.current);


### PR DESCRIPTION
Fixes:

- event not firing when scrolling or programatically changing sections
- programatically changing sections now scrolls to respective section

Fixes #1952