### PR TITLE
chore(charts):remove unused or deprecated imports from stories

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.stories.mdx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.mdx
@@ -1,6 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
-import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { BarChart } from '@ui5/webcomponents-react-charts/dist/BarChart';
 import { complexDataSet, secondaryDimensionDataSet, simpleDataSet } from '../../resources/DemoProps';
 

--- a/packages/charts/src/components/BulletChart/BulletChart.stories.mdx
+++ b/packages/charts/src/components/BulletChart/BulletChart.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
 import { BulletChart } from '@ui5/webcomponents-react-charts/dist/BulletChart';
-import { complexBulletDataset, complexDataSet, secondaryDimensionDataSet } from '../../resources/DemoProps';
+import { complexBulletDataset, complexDataSet } from '../../resources/DemoProps';
 
 <Meta
   title="Charts /  BulletChart"

--- a/packages/charts/src/components/ColumnChart/ColumnChart.stories.mdx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.stories.mdx
@@ -1,6 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
-import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { ColumnChart } from '@ui5/webcomponents-react-charts/dist/ColumnChart';
 import { complexDataSet, secondaryDimensionDataSet, simpleDataSet } from '../../resources/DemoProps';
 

--- a/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.stories.mdx
+++ b/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.stories.mdx
@@ -1,6 +1,5 @@
-import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
-import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { ColumnChartWithTrend } from '@ui5/webcomponents-react-charts/dist/ColumnChartWithTrend';
 import { complexDataSet } from '../../resources/DemoProps';
 

--- a/packages/charts/src/components/ComposedChart/ComposedChart.stories.mdx
+++ b/packages/charts/src/components/ComposedChart/ComposedChart.stories.mdx
@@ -1,8 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
-import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { ComposedChart } from '@ui5/webcomponents-react-charts/dist/ComposedChart';
-import { bigDataSet, complexDataSet, secondaryDimensionDataSet, simpleDataSet } from '../../resources/DemoProps';
+import { bigDataSet, complexDataSet, simpleDataSet } from '../../resources/DemoProps';
 
 <Meta
   title="Charts /  ComposedChart"

--- a/packages/charts/src/components/DonutChart/DonutChart.stories.mdx
+++ b/packages/charts/src/components/DonutChart/DonutChart.stories.mdx
@@ -1,6 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@shared/stories/DocsHeader';
-import '@ui5/webcomponents-icons/dist/person-placeholder.js';
 import { DonutChart } from '@ui5/webcomponents-react-charts/dist/DonutChart';
 import { simpleDataSet, simpleDataSetWithSmallValues } from '../../resources/DemoProps';
 

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.stories.mdx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Title, Description, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { MicroBarChart } from '@ui5/webcomponents-react-charts/dist/MicroBarChart';
 import { DocsHeader } from '@shared/stories/DocsHeader';
 


### PR DESCRIPTION
This prevents the deprecation warning:
```
browser.js:39 Importing from '@storybook/addon-docs/blocks' is deprecated, import directly from '@storybook/addon-docs' instead:

https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-scoped-blocks-imports
```