### PR TITLE
fix(FilterBar): update filter item refs on every dialog save

### DIFF
--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -294,6 +294,8 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
 
   const handleDialogSave = useCallback(
     (e, newRefs, updatedToggledFilters) => {
+      setMountFilters(false);
+      setMountFilters(true);
       setDialogRefs(newRefs);
       setToggledFilters((old) => ({ ...old, ...updatedToggledFilters }));
       if (onFiltersDialogSave) {


### PR DESCRIPTION
Enforces that children receive an update on each dialog save, otherwise refs won't be updated.

Fixes #2008