### PR TITLE
feat: add `a11yConfig` prop to customize a11y properties

### DIFF
--- a/packages/base/src/hooks/usePassThroughHtmlProps.ts
+++ b/packages/base/src/hooks/usePassThroughHtmlProps.ts
@@ -1,4 +1,4 @@
-const PROP_INCLUDELIST = /^(aria-|data-|id$|on[A-Z]|slot$)/;
+const PROP_INCLUDELIST = /^(aria-|data-|id$|on[A-Z]|slot$|role$)/;
 
 export const usePassThroughHtmlProps = (props: Record<string, any>, propExcludeList: string[] = []) => {
   const componentPropExcludelist = new Set(propExcludeList);

--- a/packages/main/src/components/ActionSheet/ActionSheet.stories.mdx
+++ b/packages/main/src/components/ActionSheet/ActionSheet.stories.mdx
@@ -23,11 +23,6 @@ import { DocsHeader } from '@shared/stories/DocsHeader';
     a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
-    a11yConfig: {
-      actionSheetMobileContent: {
-        role: 'presentation'
-      }
-    },
     horizontalAlign: PopoverHorizontalAlign.Center,
     placementType: PopoverPlacementType.Right,
     verticalAlign: PopoverVerticalAlign.Center

--- a/packages/main/src/components/ActionSheet/ActionSheet.stories.mdx
+++ b/packages/main/src/components/ActionSheet/ActionSheet.stories.mdx
@@ -19,9 +19,15 @@ import { DocsHeader } from '@shared/stories/DocsHeader';
     },
     header: {
       type: null
-    }
+    },
+    a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
+    a11yConfig: {
+      actionSheetMobileContent: {
+        role: 'presentation'
+      }
+    },
     horizontalAlign: PopoverHorizontalAlign.Center,
     placementType: PopoverPlacementType.Right,
     verticalAlign: PopoverVerticalAlign.Center

--- a/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
+++ b/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ActionSheet Render without Crashing 1`] = `
   >
     <div
       aria-label="Available Actions"
+      data-component-name="ActionSheetMobileContent"
       role="presentation"
     >
       <ui5-button
@@ -67,6 +68,7 @@ exports[`ActionSheet does not crash with other component 1`] = `
   >
     <div
       aria-label="Available Actions"
+      data-component-name="ActionSheetMobileContent"
       role="presentation"
     >
       <ui5-label

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -26,13 +26,6 @@ import { ButtonPropTypes } from '../../webComponents/Button';
 import { ResponsivePopoverPropTypes } from '../../webComponents/ResponsivePopover';
 import styles from './ActionSheet.jss';
 
-interface A11Y {
-  actionSheetMobileContent?: {
-    role?: string;
-    ariaLabel?: string;
-  };
-}
-
 export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, 'children'> {
   /**
    * Defines the actions of the <code>ActionSheet</code>. <br><b>Note:</b> Although this slot accepts all HTML Elements, it is strongly recommended that you only use `Buttons` in order to preserve the intended design.
@@ -49,7 +42,12 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
   /**
    * Defines internally used a11y properties.
    */
-  a11yConfig?: A11Y;
+  a11yConfig?: {
+    actionSheetMobileContent?: {
+      role?: string;
+      ariaLabel?: string;
+    };
+  };
 }
 
 const useStyles = createUseStyles(styles, { name: 'ActionSheet' });

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -26,6 +26,13 @@ import { ButtonPropTypes } from '../../webComponents/Button';
 import { ResponsivePopoverPropTypes } from '../../webComponents/ResponsivePopover';
 import styles from './ActionSheet.jss';
 
+interface A11Y {
+  actionSheetMobileContent?: {
+    role?: string;
+    ariaLabel?: string;
+  };
+}
+
 export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, 'children'> {
   /**
    * Defines the actions of the <code>ActionSheet</code>. <br><b>Note:</b> Although this slot accepts all HTML Elements, it is strongly recommended that you only use `Buttons` in order to preserve the intended design.
@@ -39,6 +46,10 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
    * Defines whether the `header` or `headerText` should always be displayed or only on mobile devices.
    */
   alwaysShowHeader?: boolean;
+  /**
+   * Defines internally used a11y properties.
+   */
+  a11yConfig?: A11Y;
 }
 
 const useStyles = createUseStyles(styles, { name: 'ActionSheet' });
@@ -104,7 +115,8 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5R
     onBeforeClose,
     onBeforeOpen,
     showCancelButton,
-    alwaysShowHeader
+    alwaysShowHeader,
+    a11yConfig
   } = props;
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const classes = useStyles();
@@ -145,13 +157,14 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5R
   const renderActionSheetButton = (element, index: number, childrenArray) => {
     return cloneElement(element, {
       role: 'button',
-      key: index,
+      'aria-label': `${i18nBundle.getText(X_OF_Y, index + 1, childrenArray.length)} ${element.props?.children}`,
+      ...element.props,
       design: ButtonDesign.Transparent,
       onClick: onActionButtonClicked(element.props?.onClick),
-      'data-action-btn-index': index,
-      'aria-label': `${i18nBundle.getText(X_OF_Y, index + 1, childrenArray.length)} ${element.props?.children}`,
       tabIndex: focusedItem === index ? 0 : -1,
-      onFocus: setFocusedItem
+      onFocus: setFocusedItem,
+      key: index,
+      'data-action-btn-index': index
     });
   };
 
@@ -173,7 +186,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5R
     [onAfterOpen, actionBtnsRef.current, focusedItem]
   );
   const displayHeader = alwaysShowHeader || isPhone();
-
   return createPortal(
     <ResponsivePopover
       aria-modal
@@ -201,8 +213,9 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5R
     >
       <div
         className={isPhone() ? classes.contentMobile : undefined}
-        role="presentation"
-        aria-label={i18nBundle.getText(AVAILABLE_ACTIONS)}
+        data-component-name="ActionSheetMobileContent"
+        role={a11yConfig?.actionSheetMobileContent?.role ?? 'presentation'}
+        aria-label={a11yConfig?.actionSheetMobileContent?.ariaLabel ?? i18nBundle.getText(AVAILABLE_ACTIONS)}
         onKeyDown={handleKeyDown}
         ref={actionBtnsRef}
       >

--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -45,9 +45,13 @@ import { useReducer, useState } from 'react';
     },
     footer: {
       type: null
-    }
+    },
+    a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
+    a11yConfig: {
+      dynamicPageAnchorBar: { role: 'navigation' }
+    },
     backgroundDesign: PageBackgroundDesign.Solid,
     style: { maxHeight: '700px' },
     headerTitle: (

--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -49,9 +49,6 @@ import { useReducer, useState } from 'react';
     a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
-    a11yConfig: {
-      dynamicPageAnchorBar: { role: 'navigation' }
-    },
     backgroundDesign: PageBackgroundDesign.Solid,
     style: { maxHeight: '700px' },
     headerTitle: (

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -1,8 +1,8 @@
-import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
 import { useConsolidatedRef, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { StyleClassHelper } from '@ui5/webcomponents-react-base/dist/StyleClassHelper';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
+import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { GlobalStyleClasses } from '@ui5/webcomponents-react/dist/GlobalStyleClasses';
 import { PageBackgroundDesign } from '@ui5/webcomponents-react/dist/PageBackgroundDesign';
@@ -21,9 +21,9 @@ import React, {
   useState
 } from 'react';
 import { createUseStyles } from 'react-jss';
-import { useResponsiveContentPadding } from '../../internal/useResponsiveContentPadding';
-import { DynamicPageAnchorBar, DynamicPageAnchorBarA11Y } from '../DynamicPageAnchorBar';
 import { useObserveHeights } from '../../internal/useObserveHeights';
+import { useResponsiveContentPadding } from '../../internal/useResponsiveContentPadding';
+import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
 import { styles } from './DynamicPage.jss';
 
 export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
@@ -68,7 +68,11 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
   /**
    * Defines internally used a11y properties.
    */
-  a11yConfig?: DynamicPageAnchorBarA11Y;
+  a11yConfig?: {
+    dynamicPageAnchorBar?: {
+      role?: string;
+    };
+  };
 }
 
 /**
@@ -114,9 +118,9 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
 
   const anchorBarRef: RefObject<HTMLDivElement> = useRef();
   const dynamicPageRef: RefObject<HTMLDivElement> = useConsolidatedRef(ref);
-  //@ts-ignore
+  // @ts-ignore
   const topHeaderRef: RefObject<HTMLDivElement> = useConsolidatedRef(headerTitle?.ref);
-  //@ts-ignore
+  // @ts-ignore
   const headerContentRef: RefObject<HTMLDivElement> = useConsolidatedRef(headerContent?.ref);
 
   const [headerState, setHeaderState] = useState<HEADER_STATES>(

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -22,7 +22,7 @@ import React, {
 } from 'react';
 import { createUseStyles } from 'react-jss';
 import { useResponsiveContentPadding } from '../../internal/useResponsiveContentPadding';
-import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
+import { DynamicPageAnchorBar, DynamicPageAnchorBarA11Y } from '../DynamicPageAnchorBar';
 import { useObserveHeights } from '../../internal/useObserveHeights';
 import { styles } from './DynamicPage.jss';
 
@@ -65,6 +65,10 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
    * React element or node array which defines the content.
    */
   children?: ReactNode | ReactNodeArray;
+  /**
+   * Defines internally used a11y properties.
+   */
+  a11yConfig?: DynamicPageAnchorBarA11Y;
 }
 
 /**
@@ -98,7 +102,8 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
     alwaysShowContentHeader,
     children,
     className,
-    footer
+    footer,
+    a11yConfig
   } = props;
   const passThroughProps = usePassThroughHtmlProps(props, ['onScroll']);
 
@@ -260,6 +265,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
           setHeaderPinned={handleHeaderPinnedChange}
           headerPinned={headerState === HEADER_STATES.VISIBLE_PINNED || headerState === HEADER_STATES.HIDDEN_PINNED}
           onHoverToggleButton={onHoverToggleButton}
+          a11yConfig={a11yConfig}
         />
       </FlexBox>
       {isIE() && (

--- a/packages/main/src/components/DynamicPageAnchorBar/index.tsx
+++ b/packages/main/src/components/DynamicPageAnchorBar/index.tsx
@@ -188,7 +188,7 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
     <section
       data-component-name="DynamicPageAnchorBar"
       style={style}
-      role={a11yConfig.dynamicPageAnchorBar.role ?? 'navigation'}
+      role={a11yConfig?.dynamicPageAnchorBar?.role ?? 'navigation'}
       className={showHideHeaderButton || headerContentPinnable ? classes.anchorBarActionButton : null}
       ref={anchorBarRef}
     >

--- a/packages/main/src/components/DynamicPageAnchorBar/index.tsx
+++ b/packages/main/src/components/DynamicPageAnchorBar/index.tsx
@@ -96,12 +96,6 @@ const anchorBarStyles = {
   }
 };
 
-export interface DynamicPageAnchorBarA11Y {
-  dynamicPageAnchorBar?: {
-    role?: string;
-  };
-}
-
 const useStyles = createUseStyles(anchorBarStyles, { name: 'DynamicPageAnchorBar' });
 
 interface Props extends CommonProps {
@@ -136,7 +130,11 @@ interface Props extends CommonProps {
   /**
    * Defines internally used a11y properties.
    */
-  a11yConfig?: DynamicPageAnchorBarA11Y;
+  a11yConfig?: {
+    dynamicPageAnchorBar?: {
+      role?: string;
+    };
+  };
 }
 
 /**

--- a/packages/main/src/components/DynamicPageAnchorBar/index.tsx
+++ b/packages/main/src/components/DynamicPageAnchorBar/index.tsx
@@ -96,6 +96,12 @@ const anchorBarStyles = {
   }
 };
 
+export interface DynamicPageAnchorBarA11Y {
+  dynamicPageAnchorBar?: {
+    role?: string;
+  };
+}
+
 const useStyles = createUseStyles(anchorBarStyles, { name: 'DynamicPageAnchorBar' });
 
 interface Props extends CommonProps {
@@ -127,6 +133,10 @@ interface Props extends CommonProps {
    * Highlight title when hovered.
    */
   onHoverToggleButton?: (e: any) => void;
+  /**
+   * Defines internally used a11y properties.
+   */
+  a11yConfig?: DynamicPageAnchorBarA11Y;
 }
 
 /**
@@ -142,7 +152,8 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
     setHeaderPinned,
     onToggleHeaderContentVisibility,
     onHoverToggleButton,
-    style
+    style,
+    a11yConfig
   } = props;
 
   const classes = useStyles();
@@ -177,7 +188,7 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
     <section
       data-component-name="DynamicPageAnchorBar"
       style={style}
-      role="navigation"
+      role={a11yConfig.dynamicPageAnchorBar.role ?? 'navigation'}
       className={showHideHeaderButton || headerContentPinnable ? classes.anchorBarActionButton : null}
       ref={anchorBarRef}
     >

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -40,10 +40,6 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
     a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
-    a11yConfig: {
-      dynamicPageAnchorBar: { role: 'navigation' },
-      objectPageTopHeader: { role: 'banner', ariaRoledescription: 'Object Page header' }
-    },
     onSelectedSectionChanged: null,
     mode: ObjectPageMode.Default,
     showHideHeaderButton: true,

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -36,9 +36,14 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
     headerTitle: { control: { disable: true } },
     headerContent: { control: { disable: true } },
     footer: { control: { disable: true } },
-    children: { control: { disable: true } }
+    children: { control: { disable: true } },
+    a11yConfig: { table: { category: 'A11y props' } }
   }}
   args={{
+    a11yConfig: {
+      dynamicPageAnchorBar: { role: 'navigation' },
+      objectPageTopHeader: { role: 'banner', ariaRoledescription: 'Object Page header' }
+    },
     onSelectedSectionChanged: null,
     mode: ObjectPageMode.Default,
     showHideHeaderButton: true,

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -23,7 +23,7 @@ import { Ui5PopoverDomRef } from '../../interfaces/Ui5PopoverDomRef';
 import { stopPropagation } from '../../internal/stopPropagation';
 import { useObserveHeights } from '../../internal/useObserveHeights';
 import { useResponsiveContentPadding } from '../../internal/useResponsiveContentPadding';
-import { DynamicPageAnchorBar, DynamicPageAnchorBarA11Y } from '../DynamicPageAnchorBar';
+import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
 import { ObjectPageSectionPropTypes } from '../ObjectPageSection';
 import { ObjectPageSubSectionPropTypes } from '../ObjectPageSubSection';
 import { CollapsedAvatar } from './CollapsedAvatar';
@@ -44,13 +44,6 @@ addCustomCSS(
   }
   `
 );
-
-interface A11Y extends DynamicPageAnchorBarA11Y {
-  objectPageTopHeader?: {
-    role?: string;
-    ariaRoledescription?: string;
-  };
-}
 
 export interface ObjectPagePropTypes extends CommonProps {
   /**
@@ -138,7 +131,15 @@ export interface ObjectPagePropTypes extends CommonProps {
   /**
    * Defines internally used a11y properties.
    */
-  a11yConfig?: A11Y;
+  a11yConfig?: {
+    objectPageTopHeader?: {
+      role?: string;
+      ariaRoledescription?: string;
+    };
+    dynamicPageAnchorBar?: {
+      role?: string;
+    };
+  };
 }
 
 const useStyles = createUseStyles(styles, { name: 'ObjectPage' });

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -23,7 +23,7 @@ import { Ui5PopoverDomRef } from '../../interfaces/Ui5PopoverDomRef';
 import { stopPropagation } from '../../internal/stopPropagation';
 import { useObserveHeights } from '../../internal/useObserveHeights';
 import { useResponsiveContentPadding } from '../../internal/useResponsiveContentPadding';
-import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
+import { DynamicPageAnchorBar, DynamicPageAnchorBarA11Y } from '../DynamicPageAnchorBar';
 import { ObjectPageSectionPropTypes } from '../ObjectPageSection';
 import { ObjectPageSubSectionPropTypes } from '../ObjectPageSubSection';
 import { CollapsedAvatar } from './CollapsedAvatar';
@@ -44,6 +44,13 @@ addCustomCSS(
   }
   `
 );
+
+interface A11Y extends DynamicPageAnchorBarA11Y {
+  objectPageTopHeader?: {
+    role?: string;
+    ariaRoledescription?: string;
+  };
+}
 
 export interface ObjectPagePropTypes extends CommonProps {
   /**
@@ -128,6 +135,10 @@ export interface ObjectPagePropTypes extends CommonProps {
    * Defines whether the `headerContent` is pinnable.
    */
   headerContentPinnable?: boolean;
+  /**
+   * Defines internally used a11y properties.
+   */
+  a11yConfig?: A11Y;
 }
 
 const useStyles = createUseStyles(styles, { name: 'ObjectPage' });
@@ -155,7 +166,8 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     alwaysShowContentHeader,
     showTitleInHeaderContent,
     headerContent,
-    headerContentPinnable
+    headerContentPinnable,
+    a11yConfig
   } = props;
 
   const classes = useStyles();
@@ -729,9 +741,9 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
         onMouseLeave={onHoverToggleButton}
         data-component-name="ObjectPageTopHeader"
         ref={topHeaderRef}
-        role="banner"
+        role={a11yConfig?.objectPageTopHeader?.role ?? 'banner'}
         data-not-clickable={titleHeaderNotClickable}
-        aria-roledescription="Object Page header"
+        aria-roledescription={a11yConfig?.objectPageTopHeader?.ariaRoledescription ?? 'Object Page header'}
         className={`${classes.header} ${responsivePaddingClass}`}
         onClick={onTitleClick}
         style={{
@@ -767,6 +779,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
             setHeaderPinned={setHeaderPinned}
             headerPinned={headerPinned}
             onHoverToggleButton={onHoverToggleButton}
+            a11yConfig={a11yConfig}
           />
         </div>
       )}


### PR DESCRIPTION
This PR adds the `a11yConfig` prop to the `ObjectPage`, `DynamicPage` and `ActionSheet` component.

Closes: #2031