### PR TITLE
fix(AnalyticalTable): remove filter without showing `undefined`

### DIFF
--- a/packages/main/src/components/AnalyticalTable/defaults/FilterComponent/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/FilterComponent/index.tsx
@@ -8,5 +8,5 @@ export const DefaultFilterComponent: FC<any> = ({ column }) => {
     },
     [column.setFilter]
   );
-  return <Input onInput={handleChange} value={column.filterValue} />;
+  return <Input onInput={handleChange} value={column.filterValue ?? ''} />;
 };


### PR DESCRIPTION
`undefined` as `Input` `value` shows undefined as string instead of clearing the input, that's why we need to set it to an empty string manually. (See https://github.com/SAP/ui5-webcomponents/issues/2616)

Fixes #2073 