### PR TITLE
fix(CardHeader): fire `onClick` only once

### DIFF
--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -93,6 +93,7 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
         eventProperties.forEach((eventName) => {
           const eventHandler = rest[createEventPropName(eventName)] as EventHandler;
           if (typeof eventHandler === 'function') {
+            //todo remove when UI5 Web Components have fixed this
             if (tagName === 'ui5-card-header' && eventName === 'click') {
               eventRegistry.current[eventName] = debounce(eventHandler, 100);
             } else {

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -1,4 +1,5 @@
 import { getEffectiveScopingSuffixForTag } from '@ui5/webcomponents-base/dist/CustomElementsScope';
+import { debounce } from '@ui5/webcomponents-react-base/dist/Utils';
 import { useConsolidatedRef } from '@ui5/webcomponents-react-base/dist/useConsolidatedRef';
 import React, {
   Children,
@@ -92,7 +93,11 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
         eventProperties.forEach((eventName) => {
           const eventHandler = rest[createEventPropName(eventName)] as EventHandler;
           if (typeof eventHandler === 'function') {
-            eventRegistry.current[eventName] = eventHandler;
+            if (tagName === 'ui5-card-header' && eventName === 'click') {
+              eventRegistry.current[eventName] = debounce(eventHandler, 100);
+            } else {
+              eventRegistry.current[eventName] = eventHandler;
+            }
             ref.current.addEventListener(eventName, eventRegistry.current[eventName]);
           }
         });


### PR DESCRIPTION
This PR adds a workaround to the React wrapper to fix the double triggering `onClick` event. (See https://github.com/SAP/ui5-webcomponents/issues/3786)