### PR TITLE
feat: allow disabling sapScrollBar

### DIFF
--- a/packages/main/src/components/ThemeProvider/GlobalStyleClasses.jss.ts
+++ b/packages/main/src/components/ThemeProvider/GlobalStyleClasses.jss.ts
@@ -3,7 +3,7 @@ import { GlobalStyleClasses } from '@ui5/webcomponents-react/dist/GlobalStyleCla
 
 export const GlobalStyleClassesStyles = {
   '@global': {
-    [`.${GlobalStyleClasses.sapScrollBar}`]: {
+    [`.${GlobalStyleClasses.sapScrollBar}:not([data-native-scrollbar])`]: {
       '&::-webkit-scrollbar': {
         backgroundColor: ThemingParameters.sapScrollBar_TrackColor,
         '&:horizontal': {


### PR DESCRIPTION
The `sapScrollBar` styles can now be suppressed by adding the `data-native-scrollbar` attribute to any element which has the `sapScrollBar` class applied. This will then fallback to the browser native scrollbar.

Closes #2050