### PR TITLE
fix(ObjectPage): consistently toggle header after scrolling 

### DIFF
--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -479,10 +479,8 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const onToggleHeaderContentVisibility = (e) => {
     scrollTimout.current = performance.now() + 500;
     if (!e.detail.visible) {
-      console.log('collapse');
       objectPageRef.current?.classList.add(classes.headerCollapsed);
     } else {
-      console.log('expand');
       setScrolledHeaderExpanded(true);
       objectPageRef.current?.classList.remove(classes.headerCollapsed);
     }

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -475,17 +475,18 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     [mode, setInternalSelectedSectionId, setSelectedSubSectionId, isProgrammaticallyScrolled, children]
   );
   const [scrolledHeaderExpanded, setScrolledHeaderExpanded] = useState(false);
-  const onToggleHeaderContentVisibility = useCallback(
-    (e) => {
-      if (!e.detail.visible) {
-        objectPageRef.current?.classList.add(classes.headerCollapsed);
-      } else {
-        setScrolledHeaderExpanded(true);
-        objectPageRef.current?.classList.remove(classes.headerCollapsed);
-      }
-    },
-    [objectPageRef.current, classes.headerCollapsed]
-  );
+  const scrollTimout = useRef(0);
+  const onToggleHeaderContentVisibility = (e) => {
+    scrollTimout.current = performance.now() + 500;
+    if (!e.detail.visible) {
+      console.log('collapse');
+      objectPageRef.current?.classList.add(classes.headerCollapsed);
+    } else {
+      console.log('expand');
+      setScrolledHeaderExpanded(true);
+      objectPageRef.current?.classList.remove(classes.headerCollapsed);
+    }
+  };
 
   const objectPageClasses = StyleClassHelper.of(classes.objectPage, GlobalStyleClasses.sapScrollBar);
   if (className) {
@@ -679,6 +680,9 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   const prevScrollTop = useRef();
   const onObjectPageScroll = useCallback(
     (e) => {
+      if (scrollTimout.current >= performance.now()) {
+        return;
+      }
       scrollEvent.current = e;
       if (typeof props.onScroll === 'function') {
         props.onScroll(e);
@@ -704,6 +708,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
       }
     },
     [
+      scrollTimout.current,
       topHeaderHeight,
       headerPinned,
       props.onScroll,


### PR DESCRIPTION
This PR introduces a timeout to the scroll behavior of 500ms after the user manually expanded/collapsed the header by either clicking on the corresponding button or on the DynamicPageTitle.

Fixes #2119 