### PR TITLE
fix(MessageBox): correct spacing of header items in rtl mode

### DIFF
--- a/packages/main/src/components/MessageBox/MessageBox.jss.ts
+++ b/packages/main/src/components/MessageBox/MessageBox.jss.ts
@@ -17,7 +17,6 @@ const style = {
     color: ThemingParameters.sapContent_LabelColor,
     fontSize: '1rem',
     '& ui5-icon:first-child': {
-      marginRight: '0.5rem',
       width: '1rem',
       height: '1rem'
     },
@@ -55,6 +54,7 @@ const style = {
       '--sapContent_NonInteractiveIconColor': ThemingParameters.sapInformativeElementColor
     }
   },
+  spacer: { width: '0.5rem' },
   content: {
     padding: '1rem'
   },

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`MessageBox Confirm - Cancel 1`] = `
         name="question-mark"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -71,6 +74,9 @@ exports[`MessageBox Confirm 1`] = `
         name="question-mark"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -122,6 +128,9 @@ exports[`MessageBox Custom Action Text 1`] = `
       <ui5-icon
         name="question-mark"
         ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
       />
       <ui5-title
         level="H2"
@@ -217,6 +226,9 @@ exports[`MessageBox Error 1`] = `
         name="message-error"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -262,6 +274,9 @@ exports[`MessageBox Highlight 1`] = `
       <ui5-icon
         name="hint"
         ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
       />
       <ui5-title
         level="H2"
@@ -309,6 +324,9 @@ exports[`MessageBox Information 1`] = `
         name="message-information"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -354,6 +372,9 @@ exports[`MessageBox No Title 1`] = `
       <ui5-icon
         name="question-mark"
         ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
       />
       <ui5-title
         level="H2"
@@ -407,6 +428,9 @@ exports[`MessageBox Not open 1`] = `
         name="message-success"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -452,6 +476,9 @@ exports[`MessageBox Show 1`] = `
       <ui5-icon
         name="question-mark"
         ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
       />
       <ui5-title
         level="H2"
@@ -507,6 +534,9 @@ exports[`MessageBox Success 1`] = `
         name="message-success"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -553,6 +583,9 @@ exports[`MessageBox Success w/ custom title 1`] = `
         name="add"
         ui5-icon=""
       />
+      <span
+        class="MessageBox-spacer"
+      />
       <ui5-title
         level="H2"
         ui5-title=""
@@ -598,6 +631,9 @@ exports[`MessageBox Warning 1`] = `
       <ui5-icon
         name="message-warning"
         ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
       />
       <ui5-title
         level="H2"

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -65,7 +65,8 @@ const deprecatedActions = new Set<MessageBoxAction>([
   MessageBoxActions.YES
 ]);
 
-export interface MessageBoxPropTypes extends Omit<DialogPropTypes, 'children' | 'footer' | 'headerText' | 'onAfterClose'> {
+export interface MessageBoxPropTypes
+  extends Omit<DialogPropTypes, 'children' | 'footer' | 'headerText' | 'onAfterClose'> {
   /**
    * Flag whether the Message Box should be opened or closed
    */
@@ -353,6 +354,7 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<Ui5DialogDom
       {!props.header && (
         <header slot="header" className={classes.header} data-type={type}>
           {iconToRender}
+          {iconToRender && <span className={classes.spacer} />}
           <Title level={TitleLevel.H2}>{titleToRender()}</Title>
         </header>
       )}


### PR DESCRIPTION
This PR adds a spacer between the icon and the header title to support RTL.