### PR TITLE
fix(FormItem): remove unnecessary string conversion

### DIFF
--- a/packages/main/src/components/FormItem/index.tsx
+++ b/packages/main/src/components/FormItem/index.tsx
@@ -52,11 +52,7 @@ const useStyles = createUseStyles(
   { name: 'FormItem' }
 );
 
-const renderLabel = (
-  label: string | ReactElement,
-  classes: Record<'label' | 'content', string>,
-  styles: CSSProperties
-) => {
+const renderLabel = (label: ReactNode, classes: Record<'label' | 'content', string>, styles: CSSProperties) => {
   if (typeof label === 'string') {
     return (
       <Label className={classes.label} style={styles} wrappingType={WrappingType.Normal}>
@@ -66,21 +62,20 @@ const renderLabel = (
   }
 
   if (isValidElement(label)) {
+    const { showColon, wrappingType, className, style, children } = label.props;
     return cloneElement<LabelPropTypes>(
       label,
       {
-        wrappingType: (label as ReactElement<LabelPropTypes>).props.wrappingType ?? WrappingType.Normal,
-        className: `${classes.label} ${(label as ReactElement<LabelPropTypes>).props.className ?? ''}`,
+        showColon: showColon ?? true,
+        wrappingType: wrappingType ?? WrappingType.Normal,
+        className: `${classes.label} ${className ?? ''}`,
         style: {
           gridColumnStart: styles.gridColumnStart,
           gridRowStart: styles.gridRowStart,
-          ...((label as ReactElement<LabelPropTypes>).props.style || {})
+          ...(style || {})
         }
       },
-      (label as ReactElement<LabelPropTypes>).props.children
-        ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          `${(label as ReactElement<LabelPropTypes>).props.children}:`
-        : ''
+      children ?? ''
     );
   }
 

--- a/packages/main/src/webComponents/Label/index.tsx
+++ b/packages/main/src/webComponents/Label/index.tsx
@@ -50,8 +50,9 @@ const Label = withWebComponent<LabelPropTypes>('ui5-label', ['for', 'wrappingTyp
 Label.displayName = 'Label';
 
 Label.defaultProps = {
-  required: false,
-  showColon: false
+  required: false
+  // needs to be removed for FormItem
+  // showColon: false
 };
 
 export { Label };


### PR DESCRIPTION
This PR removes an unnecessary string conversion of the children of the `Label` when passed. Also it removes the `showColon` default prop from the static `defaultProps` object. This was necessary, because it makes a difference for the FormItem's `label` prop if `showColon` is `undefined` or `false`.

Closes #2235 