### PR TITLE
feat: add `portalContainer` prop for elements rendered via `createPortal`

### DIFF
--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -54,7 +54,6 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
    * Defines where modals are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
 }

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -28,7 +28,9 @@ import styles from './ActionSheet.jss';
 
 export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, 'children'> {
   /**
-   * Defines the actions of the <code>ActionSheet</code>. <br><b>Note:</b> Although this slot accepts all HTML Elements, it is strongly recommended that you only use `Buttons` in order to preserve the intended design.
+   * Defines the actions of the `ActionSheet`.
+   *
+   * __Note:__ Although this slot accepts all HTML Elements, it is strongly recommended that you only use `Buttons` in order to preserve the intended design.
    */
   children?: ReactElement<ButtonPropTypes> | ReactElement<ButtonPropTypes>[];
   /**
@@ -48,6 +50,13 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
       ariaLabel?: string;
     };
   };
+  /**
+   * Defines where modals are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
 }
 
 const useStyles = createUseStyles(styles, { name: 'ActionSheet' });
@@ -94,27 +103,28 @@ if (isPhone()) {
  */
 const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5ResponsivePopoverDomRef>) => {
   const {
-    children,
-    style,
-    slot,
-    className,
+    a11yConfig,
     allowTargetOverlap,
+    alwaysShowHeader,
+    children,
+    className,
+    footer,
+    header,
     headerText,
+    hideArrow,
     horizontalAlign,
     initialFocus,
     modal,
-    hideArrow,
     placementType,
+    portalContainer,
+    showCancelButton,
+    slot,
+    style,
     verticalAlign,
-    footer,
-    header,
     onAfterClose,
     onAfterOpen,
     onBeforeClose,
-    onBeforeOpen,
-    showCancelButton,
-    alwaysShowHeader,
-    a11yConfig
+    onBeforeOpen
   } = props;
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const classes = useStyles();
@@ -231,13 +241,14 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Ui5R
         )}
       </div>
     </ResponsivePopover>,
-    document.body
+    portalContainer
   );
 });
 
 ActionSheet.defaultProps = {
   showCancelButton: true,
-  alwaysShowHeader: true
+  alwaysShowHeader: true,
+  portalContainer: document.body
 };
 
 ActionSheet.displayName = 'ActionSheet';

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderContainer.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderContainer.tsx
@@ -38,6 +38,7 @@ interface ColumnHeaderContainerProps {
   resizeInfo: Record<string, unknown>;
   reactWindowRef: MutableRefObject<any>;
   isRtl: boolean;
+  portalContainer: Element;
 }
 
 const useStyles = createUseStyles(styles, { name: 'Resizer' });
@@ -59,7 +60,8 @@ export const ColumnHeaderContainer = forwardRef((props: ColumnHeaderContainerPro
     overscanCountHorizontal,
     resizeInfo,
     reactWindowRef,
-    isRtl
+    isRtl,
+    portalContainer
   } = props;
   const columnVirtualizer = useVirtual({
     size: visibleColumnsWidth.length,
@@ -132,6 +134,7 @@ export const ColumnHeaderContainer = forwardRef((props: ColumnHeaderContainerPro
               isDraggable={column.canReorder && !resizeInfo.isResizingColumn}
               virtualColumn={virtualColumn}
               isRtl={isRtl}
+              portalContainer={portalContainer}
             >
               {column.render('Header')}
             </ColumnHeader>

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
@@ -33,6 +33,7 @@ export interface ColumnHeaderModalProperties {
   open: boolean;
   setPopoverOpen: (open: boolean) => void;
   targetRef: RefObject<any>;
+  portalContainer: Element;
 }
 
 const styles = {
@@ -49,7 +50,7 @@ const styles = {
 const useStyles = createUseStyles(styles, { name: 'ColumnHeaderModal' });
 
 export const ColumnHeaderModal = (props: ColumnHeaderModalProperties) => {
-  const { column, onSort, onGroupBy, open, setPopoverOpen, targetRef } = props;
+  const { column, onSort, onGroupBy, open, setPopoverOpen, targetRef, portalContainer } = props;
   const classes = useStyles();
   const showFilter = column.canFilter;
   const showGroup = column.canGroupBy;
@@ -197,7 +198,7 @@ export const ColumnHeaderModal = (props: ColumnHeaderModalProperties) => {
         )}
       </List>
     </Popover>,
-    document.body
+    portalContainer
   );
 };
 ColumnHeaderModal.displayName = 'ColumnHeaderModal';

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -13,9 +13,6 @@ import React, {
   MouseEventHandler,
   KeyboardEventHandler,
   ReactNode,
-  ReactNodeArray,
-  useCallback,
-  useMemo,
   useRef,
   useState
 } from 'react';
@@ -38,7 +35,8 @@ export interface ColumnHeaderProps {
   headerTooltip: string;
   virtualColumn: VirtualItem;
   isRtl: boolean;
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
+  portalContainer: Element;
 
   //getHeaderProps()
   id: string;
@@ -113,7 +111,8 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
     columnIndex,
     visibleColumnIndex,
     onClick,
-    onKeyDown
+    onKeyDown,
+    portalContainer
   } = props;
 
   const isFiltered = column.filterValue && column.filterValue.length > 0;
@@ -238,6 +237,7 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
             targetRef={targetRef}
             open={popoverOpen}
             setPopoverOpen={setPopoverOpen}
+            portalContainer={portalContainer}
           />
         )}
       </div>

--- a/packages/main/src/components/AnalyticalTable/VerticalResizer.tsx
+++ b/packages/main/src/components/AnalyticalTable/VerticalResizer.tsx
@@ -44,6 +44,7 @@ interface VerticalResizerProps {
   internalRowHeight: number;
   hasPopInColumns: boolean;
   popInRowHeight: number;
+  portalContainer: Element;
 }
 
 const isTouchEvent = (e, touchEvent) => {
@@ -54,7 +55,15 @@ const isTouchEvent = (e, touchEvent) => {
 };
 
 export const VerticalResizer = (props: VerticalResizerProps) => {
-  const { analyticalTableRef, dispatch, extensionsHeight, internalRowHeight, hasPopInColumns, popInRowHeight } = props;
+  const {
+    analyticalTableRef,
+    dispatch,
+    extensionsHeight,
+    internalRowHeight,
+    hasPopInColumns,
+    popInRowHeight,
+    portalContainer
+  } = props;
   const classes = useStyles();
   const startY = useRef(null);
   const verticalResizerRef = useRef(null);
@@ -162,7 +171,7 @@ export const VerticalResizer = (props: VerticalResizerProps) => {
             className={classes.resizer}
             style={{ top: resizerPosition.top, left: resizerPosition.left, width: resizerPosition.width }}
           />,
-          document.body
+          portalContainer
         )}
     </div>
   );

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -250,7 +250,6 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    * Defines where modals and other elements which should be mounted outside of the DOM hierarchy are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
 

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -246,6 +246,13 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    * Defines whether a subcomponent should be rendered as expandable container or directly at the bottom of the row.
    */
   alwaysShowSubComponent?: boolean;
+  /**
+   * Defines where modals and other elements which should be mounted outside of the DOM hierarchy are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
 
   // events
   /**
@@ -321,52 +328,53 @@ const useStyles = createUseStyles(styles, { name: 'AnalyticalTable' });
  */
 const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HTMLDivElement>) => {
   const {
-    columns,
-    className,
-    style,
-    tooltip,
-    header,
-    loading,
-    groupBy,
-    selectionMode,
-    selectionBehavior,
-    onRowSelected,
-    onRowClick,
-    onSort,
-    reactTableOptions,
-    tableHooks,
-    subRowsKey,
-    onGroup,
-    rowHeight,
-    selectedRowIds,
-    LoadingComponent,
-    onRowExpandChange,
-    noDataText,
-    NoDataComponent,
-    visibleRows,
-    visibleRowCountMode,
-    minRows,
-    isTreeTable,
     alternateRowColor,
-    overscanCount,
-    overscanCountHorizontal,
-    scaleWidthMode,
-    withRowHighlight,
-    highlightField,
-    withNavigationHighlight,
-    markNavigatedRow,
-    groupable,
-    sortable,
+    alwaysShowSubComponent,
+    className,
+    columnOrder,
+    columns,
+    extension,
     filterable,
+    globalFilterValue,
+    groupBy,
+    groupable,
+    header,
+    highlightField,
     infiniteScroll,
     infiniteScrollThreshold,
-    onLoadMore,
-    extension,
-    columnOrder,
+    isTreeTable,
+    loading,
+    markNavigatedRow,
+    minRows,
+    noDataText,
+    overscanCount,
+    overscanCountHorizontal,
+    portalContainer,
+    reactTableOptions,
     renderRowSubComponent,
-    alwaysShowSubComponent,
-    globalFilterValue,
-    tableInstance
+    rowHeight,
+    scaleWidthMode,
+    selectedRowIds,
+    selectionBehavior,
+    selectionMode,
+    sortable,
+    style,
+    subRowsKey,
+    tableHooks,
+    tableInstance,
+    tooltip,
+    visibleRowCountMode,
+    visibleRows,
+    withNavigationHighlight,
+    withRowHighlight,
+    onGroup,
+    onLoadMore,
+    onRowClick,
+    onRowExpandChange,
+    onRowSelected,
+    onSort,
+    LoadingComponent,
+    NoDataComponent
   } = props;
 
   const classes = useStyles();
@@ -750,6 +758,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
                   onDragEnd={handleOnDragEnd}
                   dragOver={dragOver}
                   isRtl={isRtl}
+                  portalContainer={portalContainer}
                 />
               )
             );
@@ -830,6 +839,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
           dispatch={dispatch}
           extensionsHeight={extensionsHeight}
           internalRowHeight={internalRowHeight}
+          portalContainer={portalContainer}
         />
       )}
     </div>
@@ -867,7 +877,8 @@ AnalyticalTable.defaultProps = {
   alternateRowColor: false,
   overscanCountHorizontal: 5,
   visibleRowCountMode: TableVisibleRowCountMode.Fixed,
-  alwaysShowSubComponent: false
+  alwaysShowSubComponent: false,
+  portalContainer: document.body
 };
 
 export { AnalyticalTable };

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -255,7 +255,7 @@ export const FilterDialog = (props) => {
         );
       });
   };
-  console.log(portalContainer);
+
   return createPortal(
     <Dialog
       ref={dialogRef}

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -55,7 +55,8 @@ export const FilterDialog = (props) => {
     onGo,
     handleSelectionChange,
     handleDialogSearch,
-    handleDialogCancel
+    handleDialogCancel,
+    portalContainer
   } = props;
   const classes = useStyles();
   const [searchString, setSearchString] = useState('');
@@ -254,7 +255,7 @@ export const FilterDialog = (props) => {
         );
       });
   };
-
+  console.log(portalContainer);
   return createPortal(
     <Dialog
       ref={dialogRef}
@@ -281,6 +282,6 @@ export const FilterDialog = (props) => {
         {renderGroups()}
       </div>
     </Dialog>,
-    document.body
+    portalContainer
   );
 };

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -139,6 +139,13 @@ export interface FilterBarPropTypes extends CommonProps {
    */
   as?: keyof HTMLElementTagNameMap;
   /**
+   * Defines where modals are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
+  /**
    * The event is fired when the `FilterBar` is collapsed/expanded.
    */
   onToggleFilters?: (event: CustomEvent<{ visible?: boolean }>) => void;
@@ -223,6 +230,7 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
     search,
     variants,
     as,
+    portalContainer,
 
     onToggleFilters,
     onFiltersDialogOpen,
@@ -599,6 +607,7 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
           showGoButton={showGo}
           handleDialogSearch={onFiltersDialogSearch}
           handleDialogCancel={onFiltersDialogCancel}
+          portalContainer={portalContainer}
         >
           {safeChildren()}
         </FilterDialog>
@@ -666,28 +675,7 @@ FilterBar.defaultProps = {
   filterContainerWidth: '13.125rem',
   useToolbar: true,
   filterBarExpanded: true,
-  showClearOnFB: false,
-  showGo: false,
-  showRestoreOnFB: false,
-  showGoOnFB: false,
-  showFilterConfiguration: false,
-  showClearButton: false,
-  showRestoreButton: false,
-  showSearchOnFiltersDialog: false,
-  hideToggleFiltersButton: false,
-  considerGroupName: false,
-  loading: false,
-  onToggleFilters: null,
-  onFiltersDialogOpen: null,
-  onFiltersDialogCancel: null,
-  onFiltersDialogClose: null,
-  onFiltersDialogSave: null,
-  onFiltersDialogClear: null,
-  onClear: null,
-  onFiltersDialogSelectionChange: null,
-  onFiltersDialogSearch: null,
-  onGo: null,
-  onRestore: null
+  portalContainer: document.body
 };
 
 FilterBar.displayName = 'FilterBar';

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -142,7 +142,6 @@ export interface FilterBarPropTypes extends CommonProps {
    * Defines where modals are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
   /**

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -97,7 +97,6 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    * Defines where modals are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
   /**

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -94,6 +94,13 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    */
   selectedSubSectionId?: string;
   /**
+   * Defines where modals are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
+  /**
    * Fired when the selected section changes.
    */
   onSelectedSectionChange?: (
@@ -175,7 +182,8 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     headerContent,
     headerContentPinnable,
     a11yConfig,
-    placeholder
+    placeholder,
+    portalContainer
   } = props;
 
   const classes = useStyles();
@@ -826,7 +834,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
                   ))}
               </List>
             </Popover>,
-            document.body
+            portalContainer
           )}
         </div>
       )}
@@ -853,7 +861,8 @@ ObjectPage.defaultProps = {
   image: null,
   mode: ObjectPageMode.Default,
   imageShapeCircle: false,
-  showHideHeaderButton: false
+  showHideHeaderButton: false,
+  portalContainer: document.body
 };
 
 export { ObjectPage };

--- a/packages/main/src/components/Toolbar/OverflowPopover.tsx
+++ b/packages/main/src/components/Toolbar/OverflowPopover.tsx
@@ -12,10 +12,11 @@ interface OverflowPopoverProps {
   lastVisibleIndex: number;
   contentClass: string;
   children: ReactNode;
+  portalContainer: Element;
 }
 
 export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopoverProps) => {
-  const { lastVisibleIndex, contentClass, children } = props;
+  const { lastVisibleIndex, contentClass, children, portalContainer } = props;
   const popoverRef = useRef<Ui5PopoverDomRef>();
   const [pressed, setPressed] = useState(false);
 
@@ -82,7 +83,7 @@ export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopover
         <Popover placementType={PopoverPlacementType.Bottom} ref={popoverRef} onAfterClose={handleClose}>
           <div className={contentClass}>{renderChildren()}</div>
         </Popover>,
-        document.body
+        portalContainer
       )}
     </>
   );

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -53,6 +53,13 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
    */
   as?: keyof HTMLElementTagNameMap;
   /**
+   * Defines where modals are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
+  /**
    * Fired when the user clicks on the `Toolbar`, if the `active` prop is set to "true".
    */
   onClick?: (event: CustomEvent) => void;
@@ -65,7 +72,20 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
  * It can be accessed by the user through the overflow button that opens it in a popover.
  */
 const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { children, toolbarStyle, design, active, style, tooltip, className, onClick, slot, as, ...rest } = props;
+  const {
+    children,
+    toolbarStyle,
+    design,
+    active,
+    style,
+    tooltip,
+    className,
+    onClick,
+    slot,
+    as,
+    portalContainer,
+    ...rest
+  } = props;
   const classes = useStyles();
   const outerContainer: RefObject<HTMLDivElement> = useConsolidatedRef(ref);
   const controlMetaData = useRef([]);
@@ -214,7 +234,11 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
           title={i18nBundle.getText(SHOW_MORE)}
           data-component-name="ToolbarOverflowButtonContainer"
         >
-          <OverflowPopover lastVisibleIndex={lastVisibleIndex} contentClass={classes.popoverContent}>
+          <OverflowPopover
+            lastVisibleIndex={lastVisibleIndex}
+            contentClass={classes.popoverContent}
+            portalContainer={portalContainer}
+          >
             {React.Children.toArray(children).map((child) => {
               if ((child as ReactElement).type === React.Fragment) {
                 return (child as ReactElement).props.children;
@@ -232,7 +256,8 @@ Toolbar.defaultProps = {
   as: 'div',
   toolbarStyle: ToolbarStyle.Standard,
   design: ToolbarDesign.Auto,
-  active: false
+  active: false,
+  portalContainer: document.body
 };
 
 Toolbar.displayName = 'Toolbar';

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -56,7 +56,6 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
    * Defines where modals are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
   /**

--- a/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
+++ b/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
@@ -58,6 +58,7 @@ interface ManageViewsDialogPropTypes {
   showApplyAutomatically: boolean;
   showSetAsDefault: boolean;
   variantNames: string[];
+  portalContainer: Element;
 }
 
 export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
@@ -68,7 +69,8 @@ export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
     showShare,
     showApplyAutomatically,
     showSetAsDefault,
-    variantNames
+    variantNames,
+    portalContainer
   } = props;
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const cancelText = i18nBundle.getText(CANCEL);
@@ -211,6 +213,6 @@ export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
         })}
       </Table>
     </Dialog>,
-    document.body
+    portalContainer
   );
 };

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -149,7 +149,6 @@ export interface VariantManagementPropTypes extends Omit<CommonProps, 'onSelect'
    * Defines where modals are rendered into via `React.createPortal`.
    *
    * Defaults to: `document.body`
-   *
    */
   portalContainer?: Element;
   /**

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -146,6 +146,13 @@ export interface VariantManagementPropTypes extends Omit<CommonProps, 'onSelect'
    */
   inErrorState?: boolean;
   /**
+   * Defines where modals are rendered into via `React.createPortal`.
+   *
+   * Defaults to: `document.body`
+   *
+   */
+  portalContainer?: Element;
+  /**
    * The event is fired when the "Save" button is clicked inside the Save View dialog.
    */
   onSaveAs?: (e: CustomEvent<SelectedVariant>) => void;
@@ -239,7 +246,8 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
     dirtyStateText,
     dirtyState,
     showCancelButton,
-    onSave
+    onSave,
+    portalContainer
   } = props;
 
   const classes = useStyles();
@@ -550,7 +558,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
               </List>
             )}
           </ResponsivePopover>,
-          document.body
+          portalContainer
         )}
         {manageViewsDialogOpen && (
           <ManageViewsDialog
@@ -560,6 +568,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
             showApplyAutomatically={!hideApplyAutomatically}
             showSetAsDefault={!hideSetAsDefault}
             variantNames={variantNames}
+            portalContainer={portalContainer}
           >
             {safeChildren}
           </ManageViewsDialog>
@@ -583,7 +592,8 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
 VariantManagement.defaultProps = {
   placement: PopoverPlacementType.Bottom,
   level: TitleLevel.H4,
-  dirtyStateText: '*'
+  dirtyStateText: '*',
+  portalContainer: document.body
 };
 VariantManagement.displayName = 'VariantManagement';
 


### PR DESCRIPTION
This PR adds the `portalContainer` prop to components wich are using `React.createPortal` to render modals or other elements outside of the DOM hierarchy. With `portalContainer` it is possible to change the element the modal is rendered into.