### PR TITLE
refactor: allow all custom props to be passed to components

### DIFF
--- a/docs/2-MigrationGuide.stories.mdx
+++ b/docs/2-MigrationGuide.stories.mdx
@@ -1319,7 +1319,7 @@ export const CheckBoxComponent = () => {
 
 UI5 Web Components for React used to have `renderXYZ` props for adding custom content into components, e.g. `renderCustomHeader`.
 For providing a unified API, these props have been deprecated and corresponding slots have been added.
-Slots can be passed a `ReactNode` and depending on the case also a `ReactNodeArray`.
+Slots can be passed a `ReactNode` and depending on the case also a `ReactNode[]`.
 
 **The `renderXYZ` props are still supported but will be removed with `0.10.0`**
 

--- a/docs/Guidelines.md
+++ b/docs/Guidelines.md
@@ -31,7 +31,7 @@ Please use TypeScript to write your components. A good introduction to TypeScrip
 - All Event handlers **must** start with `on`.<br />
    e.g. `onClick`, `onSelect`, `onSelectionChange`, .etc<br />
    All Events must pass an instance of the `Event`-Class as single parameter.
-- When passing additional elements into a component, a slot should be used. This prop should contain a `ReactNode` or an array of ReactNodes (`ReactNode[]` or `ReactNodeArray`)
+- When passing additional elements into a component, a slot should be used. This prop should contain a `ReactNode` or an array of ReactNodes (`ReactNode[]`)
 
 You must follow the coding style as best you can when submitting code. Take note of naming conventions, separation of concerns, and formatting rules. You can use the code formatter [Prettier](https://prettier.io/) to handle some of this for you automatically.
 

--- a/packages/base/src/hooks/usePassThroughHtmlProps.ts
+++ b/packages/base/src/hooks/usePassThroughHtmlProps.ts
@@ -1,7 +1,20 @@
+import { useEffect } from 'react';
+import { deprecationNotice } from '@ui5/webcomponents-react-base/dist/Utils';
+
 const PROP_INCLUDELIST = /^(aria-|data-|id$|on[A-Z]|slot$|role$)/;
 
+/**
+ * @deprecated please use rest/spread syntax instead. `{ propA, propB, ...rest } = props`
+ */
 export const usePassThroughHtmlProps = (props: Record<string, any>, propExcludeList: string[] = []) => {
   const componentPropExcludelist = new Set(propExcludeList);
+
+  useEffect(() => {
+    deprecationNotice(
+      'usePassThroughHtmlProps',
+      `\`usePassThroughHtmlProps\` is deprecated. Please use rest/spread syntax instead. \`{ propA, propB, ...rest } = props\``
+    );
+  }, []);
 
   const returnVal: Record<string, unknown> = {};
   for (const name in props) {

--- a/packages/charts/src/components/BarChart/BarChart.test.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { complexDataSet } from '../../resources/DemoProps';
 import { BarChart } from './BarChart';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import {
   createChartRenderTest,
   createLoadingPlaceholderTest,
@@ -42,5 +42,5 @@ describe('BarChart', () => {
 
   createOnLegendClickNotCrashTest(BarChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(BarChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(BarChart, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -1,4 +1,4 @@
-import { useSyncRef, useIsRTL, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { BarChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/BarChartPlaceholder';
@@ -7,7 +7,7 @@ import { ChartDataLabel } from '@ui5/webcomponents-react-charts/dist/components/
 import { XAxisTicks } from '@ui5/webcomponents-react-charts/dist/components/XAxisTicks';
 import { YAxisTicks } from '@ui5/webcomponents-react-charts/dist/components/YAxisTicks';
 import { useLegendItemClick } from '@ui5/webcomponents-react-charts/dist/useLegendItemClick';
-import { resolvePrimaryAndSecondaryMeasures, getCellColors } from '@ui5/webcomponents-react-charts/dist/Utils';
+import { getCellColors, resolvePrimaryAndSecondaryMeasures } from '@ui5/webcomponents-react-charts/dist/Utils';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
 import {
   Bar,
@@ -142,7 +142,9 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
     tooltip,
     slot,
     syncId,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -214,11 +216,11 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
   const [width, legendPosition] = useLongestYAxisLabelBar(dataset, dimensions);
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
   const [xAxisHeight] = useObserveXAxisHeights(chartRef, 1);
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
   const isRTL = useIsRTL(chartRef);
 
   const { isMounted, handleBarAnimationStart, handleBarAnimationEnd } = useCancelAnimationFallback(noAnimation);
 
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
   return (
     <ChartContainer
       dataset={dataset}
@@ -230,7 +232,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <BarChartLib
         syncId={syncId}
@@ -375,7 +377,7 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
             height={20}
           />
         )}
-        {props.children}
+        {children}
       </BarChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/BulletChart/BulletChart.test.tsx
+++ b/packages/charts/src/components/BulletChart/BulletChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const dimensions = [
   {
@@ -45,5 +45,5 @@ describe('BulletChart', () => {
 
   createOnLegendClickNotCrashTest(BulletChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(BulletChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(BulletChart, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/BulletChart/BulletChart.tsx
+++ b/packages/charts/src/components/BulletChart/BulletChart.tsx
@@ -1,4 +1,4 @@
-import { useSyncRef, useIsRTL, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { BulletChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/BulletChartPlaceholder';
@@ -137,7 +137,9 @@ const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, r
     tooltip,
     slot,
     syncId,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const [componentRef, chartRef] = useSyncRef<any>(ref);
@@ -250,12 +252,13 @@ const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, r
     interval: 0
   };
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
   const isRTL = useIsRTL(chartRef);
 
   const Placeholder = useCallback(() => {
     return <BulletChartPlaceholder layout={layout} measures={measures} />;
   }, [layout, measures]);
+
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
 
   return (
     <ChartContainer
@@ -268,7 +271,7 @@ const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, r
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <ComposedChartLib
         syncId={syncId}
@@ -494,7 +497,7 @@ const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, r
             height={20}
           />
         )}
-        {props.children}
+        {children}
       </ComposedChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/ColumnChart/ColumnChart.test.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { complexDataSet } from '../../resources/DemoProps';
 import { ColumnChart } from './ColumnChart';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import {
   createChartRenderTest,
   createLoadingPlaceholderTest,
@@ -43,5 +43,5 @@ describe('ColumnChart', () => {
 
   createOnLegendClickNotCrashTest(ColumnChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(ColumnChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(ColumnChart, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -1,4 +1,4 @@
-import { useSyncRef, useIsRTL, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ColumnChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/ColumnChartPlaceholder';
@@ -140,7 +140,9 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
     tooltip,
     slot,
     ChartPlaceholder,
-    syncId
+    syncId,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -213,8 +215,8 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
 
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
   const xAxisHeights = useObserveXAxisHeights(chartRef, props.dimensions.length);
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
   const isRTL = useIsRTL(chartRef);
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
 
   const { isMounted, handleBarAnimationStart, handleBarAnimationEnd } = useCancelAnimationFallback(noAnimation);
 
@@ -229,7 +231,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <ColumnChartLib
         syncId={syncId}
@@ -369,7 +371,7 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
             height={20}
           />
         )}
-        {props.children}
+        {children}
       </ColumnChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.test.tsx
+++ b/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@shared/tests';
 import * as React from 'react';
 import { complexDataSet } from '../../resources/DemoProps';
 import { ColumnChartWithTrend } from './ColumnChartWithTrend';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 enum ComposedChartChildrenQuery {
   'area' = 'g.recharts-area-dots',
@@ -124,5 +124,5 @@ describe('ColumnChart', () => {
     }).not.toThrow();
   });
 
-  createPassThroughPropsTest(ColumnChartWithTrend, { dimensions: [], measures: [] });
+  createCustomPropsTest(ColumnChartWithTrend, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
+++ b/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
@@ -1,8 +1,8 @@
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { ComposedChart } from '@ui5/webcomponents-react-charts/dist//ComposedChart';
 import { ColumnChartWithTrendPlaceholder } from '@ui5/webcomponents-react-charts/dist/ColumnChartWithTrendPlaceholder';
 import React, { CSSProperties, FC, forwardRef, Ref, useMemo } from 'react';
+import { TooltipProps } from 'recharts';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
 import { usePrepareTrendMeasures } from '../../hooks/usePrepareTrendMeasures';
@@ -10,7 +10,6 @@ import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
-import { TooltipProps } from 'recharts';
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -114,10 +113,9 @@ const ColumnChartWithTrend: FC<ColumnChartWithTrendProps> = forwardRef(
       tooltipConfig,
       onDataPointClick,
       onLegendClick,
-      ChartPlaceholder
+      ChartPlaceholder,
+      ...rest
     } = props;
-
-    const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
 
     const chartConfig = useMemo(() => {
       return {
@@ -157,13 +155,15 @@ const ColumnChartWithTrend: FC<ColumnChartWithTrendProps> = forwardRef(
       }
     } as TooltipProps<any, any>;
 
+    const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
+
     return (
       <div
         ref={ref}
         style={{ display: 'flex', flexDirection: 'column', height: style?.height, width: style?.width, ...style }}
         className={className}
         slot={slot}
-        {...passThroughProps}
+        {...propsWithoutOmitted}
       >
         {dataset?.length !== 0 && (
           <ComposedChart

--- a/packages/charts/src/components/ComposedChart/ComposedChart.test.tsx
+++ b/packages/charts/src/components/ComposedChart/ComposedChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 enum ComposedChartChildrenQuery {
   'area' = 'g.recharts-area-dots',
@@ -71,5 +71,5 @@ describe('ComposedChart', () => {
 
   createOnLegendClickNotCrashTest(ComposedChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(ComposedChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(ComposedChart, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -1,4 +1,4 @@
-import { useSyncRef, useIsRTL, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
@@ -150,7 +150,9 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     tooltip,
     slot,
     syncId,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const [componentRef, chartRef] = useSyncRef<any>(ref);
@@ -251,7 +253,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     return <ComposedChartPlaceholder layout={layout} measures={measures} />;
   }, [layout, measures]);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
   const isRTL = useIsRTL(chartRef);
 
   return (
@@ -265,7 +267,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <ComposedChartLib
         syncId={syncId}
@@ -500,7 +502,7 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
             height={20}
           />
         )}
-        {props.children}
+        {children}
       </ComposedChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/DonutChart/DonutChart.test.tsx
+++ b/packages/charts/src/components/DonutChart/DonutChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const dimension = {
   accessor: 'name'
@@ -21,9 +21,9 @@ describe('DonutChart', () => {
 
   createOnClickChartTest(DonutChart, { dimension, measure, dataset: simpleDataSet });
 
-  createLoadingPlaceholderTest(DonutChart, { measures: {}, dimensions: {} });
+  createLoadingPlaceholderTest(DonutChart, { measure: {}, dimension: {} });
 
   createOnLegendClickNotCrashTest(DonutChart, { dataset: simpleDataSet, dimension, measure });
 
-  createPassThroughPropsTest(DonutChart, { dimension: {}, measure: {} });
+  createCustomPropsTest(DonutChart, { dimension: {}, measure: {} });
 });

--- a/packages/charts/src/components/LineChart/LineChart.test.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { complexDataSet } from '../../resources/DemoProps';
 import { LineChart } from './LineChart';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import {
   createChartRenderTest,
   createLoadingPlaceholderTest,
@@ -43,5 +43,5 @@ describe('LineChart', () => {
 
   createOnLegendClickNotCrashTest(LineChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(LineChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(LineChart, { dimensions: [], measures: [] });
 });

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -1,4 +1,4 @@
-import { useIsRTL, usePassThroughHtmlProps, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
@@ -12,14 +12,14 @@ import React, { FC, forwardRef, Ref, useCallback, useMemo, useRef } from 'react'
 import {
   Brush,
   CartesianGrid,
+  Label,
   Legend,
   Line,
   LineChart as LineChartLib,
   ReferenceLine,
   Tooltip,
   XAxis,
-  YAxis,
-  Label
+  YAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLabelFormatter } from '../../hooks/useLabelFormatter';
@@ -119,7 +119,9 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
     tooltip,
     slot,
     syncId,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -197,7 +199,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
   const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset, measures);
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
   const xAxisHeights = useObserveXAxisHeights(chartRef, props.dimensions.length);
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
   const isRTL = useIsRTL(chartRef);
 
   return (
@@ -211,7 +213,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <LineChartLib
         syncId={syncId}
@@ -329,7 +331,7 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
             height={20}
           />
         )}
-        {props.children}
+        {children}
       </LineChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.test.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, screen, fireEvent } from '@shared/tests/index';
 import { MicroBarChart } from '@ui5/webcomponents-react-charts/dist/MicroBarChart';
 import { createChartRenderTest, createLoadingPlaceholderTest, createOnClickChartTest } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const text1 = 'January';
 const text2 = 'February';
@@ -108,7 +108,7 @@ describe('Micro Bar Chart', () => {
 
   createChartRenderTest(MicroBarChart, {
     dataset,
-    measures: {
+    measure: {
       accessor: 'value'
     },
     dimension: {
@@ -119,7 +119,7 @@ describe('Micro Bar Chart', () => {
   createOnClickChartTest(MicroBarChart, {
     dataset,
     noLegend: true,
-    measures: {
+    measure: {
       accessor: 'value'
     },
     dimension: {
@@ -127,7 +127,7 @@ describe('Micro Bar Chart', () => {
     }
   });
 
-  createLoadingPlaceholderTest(MicroBarChart, { dimensions: [], measures: [] });
+  createLoadingPlaceholderTest(MicroBarChart, { dimension: [], measure: [] });
 
-  createPassThroughPropsTest(MicroBarChart, { dimensions: [], measures: [] });
+  createCustomPropsTest(MicroBarChart, { dimension: [], measure: [] });
 });

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -1,16 +1,15 @@
-import { createUseStyles } from 'react-jss';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { BarChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/BarChartPlaceholder';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
+import clsx from 'clsx';
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
+import { createUseStyles } from 'react-jss';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
-import clsx from 'clsx';
 
 interface MeasureConfig extends Omit<IChartMeasure, 'color'> {
   /**
@@ -32,7 +31,7 @@ interface MeasureConfig extends Omit<IChartMeasure, 'color'> {
 export interface MicroBarChartProps
   extends Omit<
     IChartBaseProps,
-    'noLegend' | 'onLegendClick' | 'noAnimation' | 'chartConfig' | 'children' | 'tooltipConfig'
+    'noLegend' | 'onLegendClick' | 'noAnimation' | 'chartConfig' | 'children' | 'tooltipConfig' | 'onClick'
   > {
   /**
    * A object which contains the configuration of the dimension.
@@ -133,7 +132,7 @@ const useStyles = createUseStyles(MicroBarChartStyles, { name: 'MicroBarChart' }
  * The `MicroBarChart` compares different values of the same category to each other by displaying them in a compact way.
  */
 const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartProps, ref: Ref<HTMLDivElement>) => {
-  const { loading, dataset, onDataPointClick, style, className, tooltip, slot, ChartPlaceholder } = props;
+  const { loading, dataset, onDataPointClick, style, className, tooltip, slot, ChartPlaceholder, ...rest } = props;
   const classes = useStyles();
 
   const dimension = useMemo<IChartDimension>(
@@ -177,8 +176,7 @@ const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartPr
     [measure.accessor, onDataPointClick]
   );
   const barContainerClasses = clsx(classes.barContainer, onDataPointClick && classes.barContainerActive);
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick']);
-
+  const { maxValue: _0, dimension: _1, measure: _2, ...propsWithoutOmitted } = rest;
   return (
     <ChartContainer
       dataset={dataset}
@@ -190,7 +188,7 @@ const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartPr
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={250}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <div className={classes.container}>
         {dataset?.map((item, index) => {

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -31,7 +31,15 @@ interface MeasureConfig extends Omit<IChartMeasure, 'color'> {
 export interface MicroBarChartProps
   extends Omit<
     IChartBaseProps,
-    'noLegend' | 'onLegendClick' | 'noAnimation' | 'chartConfig' | 'children' | 'tooltipConfig' | 'onClick'
+    | 'noLegend'
+    | 'onLegendClick'
+    | 'noAnimation'
+    | 'chartConfig'
+    | 'children'
+    | 'tooltipConfig'
+    | 'onClick'
+    | 'measures'
+    | 'dimensions'
   > {
   /**
    * A object which contains the configuration of the dimension.

--- a/packages/charts/src/components/MicroBarChart/__snapshots__/MicroBarChart.test.tsx.snap
+++ b/packages/charts/src/components/MicroBarChart/__snapshots__/MicroBarChart.test.tsx.snap
@@ -28,7 +28,10 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="10"
+            >
+              10
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -36,6 +39,7 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 10%;"
             />
           </div>
         </div>
@@ -53,7 +57,10 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="100"
+            >
+              100
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -61,6 +68,7 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 100%;"
             />
           </div>
         </div>
@@ -78,7 +86,10 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="70"
+            >
+              70
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -86,6 +97,7 @@ exports[`Micro Bar Chart Check onClick events 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 70%;"
             />
           </div>
         </div>
@@ -246,7 +258,10 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="10"
+            >
+              10
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -254,6 +269,7 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 10%;"
             />
           </div>
         </div>
@@ -271,7 +287,10 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="100"
+            >
+              100
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -279,6 +298,7 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 100%;"
             />
           </div>
         </div>
@@ -296,7 +316,10 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
             </span>
             <span
               class="MicroBarChart-text"
-            />
+              title="70"
+            >
+              70
+            </span>
           </div>
           <div
             class="MicroBarChart-valueContainer"
@@ -304,6 +327,7 @@ exports[`Micro Bar Chart Render chart with data 1`] = `
           >
             <div
               class="MicroBarChart-valueBar"
+              style="width: 70%;"
             />
           </div>
         </div>

--- a/packages/charts/src/components/PieChart/PieChart.test.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const dimension = {
   accessor: 'name'
@@ -21,9 +21,9 @@ describe('PieChart', () => {
 
   createOnClickChartTest(PieChart, { dimension, measure, dataset: simpleDataSet });
 
-  createLoadingPlaceholderTest(PieChart, { measures: {}, dimensions: {} });
+  createLoadingPlaceholderTest(PieChart, { measure: {}, dimension: {} });
 
   createOnLegendClickNotCrashTest(PieChart, { dataset: simpleDataSet, dimension, measure });
 
-  createPassThroughPropsTest(PieChart, { dimension: {}, measure: {} });
+  createCustomPropsTest(PieChart, { dimension: {}, measure: {} });
 });

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -1,4 +1,3 @@
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { PieChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/PieChartPlaceholder';
@@ -90,7 +89,9 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     className,
     tooltip,
     slot,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -249,7 +250,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     return null;
   }, [showActiveSegmentDataLabel, chartConfig.activeSegment, chartConfig.legendPosition]);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
+  const { chartConfig: _0, dimension: _1, measure: _2, ...propsWithoutOmitted } = rest;
 
   return (
     <ChartContainer
@@ -262,7 +263,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <PieChartLib
         onClick={onClickInternal}
@@ -317,7 +318,7 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
             wrapperStyle={legendWrapperStyle}
           />
         )}
-        {props.children}
+        {children}
       </PieChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -30,7 +30,7 @@ interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'colo
   hideDataLabel?: boolean | ((chartConfig: any) => boolean);
 }
 
-export interface PieChartProps extends IChartBaseProps<IPolarChartConfig> {
+export interface PieChartProps extends Omit<IChartBaseProps<IPolarChartConfig>, 'dimensions' | 'measures'> {
   /**
    * A label to display in the center of the `PieChart`.
    * If you use this prop to display a text, we recommend to increase `chartConfig.innerRadius` to have some free

--- a/packages/charts/src/components/RadarChart/RadarChart.test.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const dimensions = [
   {
@@ -46,5 +46,5 @@ describe('RadarChart', () => {
 
   createOnClickChartTest(RadarChart, { dataset: complexDataSet, dimensions, measures });
 
-  createPassThroughPropsTest(RadarChart, { dataset: complexDataSet, dimensions, measures });
+  createCustomPropsTest(RadarChart, { dataset: complexDataSet, dimensions, measures });
 });

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -1,5 +1,4 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { ChartDataLabel } from '@ui5/webcomponents-react-charts/dist/components/ChartDataLabel';
@@ -90,7 +89,9 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
     className,
     tooltip,
     slot,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -156,7 +157,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
     [onDataPointClick, preventOnClickCall.current]
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
+  const { chartConfig: _0, dimensions: _1, measures: _2, ...propsWithoutOmitted } = rest;
 
   return (
     <ChartContainer
@@ -169,7 +170,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <RadarChartLib
         onClick={onClickInternal}
@@ -217,7 +218,7 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
             onClick={onItemLegendClick}
           />
         )}
-        {props.children}
+        {children}
       </RadarChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/components/RadialChart/RadialChart.test.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RadialChart } from './RadialChart';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { createChartRenderTest, createOnClickChartTest } from '@shared/tests/chartUtils';
 
 const value = 67;
@@ -12,5 +12,5 @@ describe('RadialChart', () => {
 
   createOnClickChartTest(RadialChart, { value, displayValue, noLegend: true });
 
-  createPassThroughPropsTest(RadialChart, { value, displayValue });
+  createCustomPropsTest(RadialChart, { value, displayValue });
 });

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -1,5 +1,4 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { PieChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/PieChartPlaceholder';
@@ -9,7 +8,7 @@ import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import { AxisDomain } from 'recharts/types/util/types';
 import { useOnClickInternal } from '../../hooks/useOnClickInternal';
 
-export interface RadialChartProps extends Omit<CommonProps, 'onClick'> {
+export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'children' | 'onLegendClick'> {
   /**
    * The actual value which defines how much the ring is filled.
    */
@@ -63,7 +62,8 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     className,
     tooltip,
     slot,
-    noAnimation
+    noAnimation,
+    ...rest
   } = props;
 
   const range = useMemo<AxisDomain>(() => {
@@ -89,8 +89,6 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
 
   const onClickInternal = useOnClickInternal(onClick);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
-
   return (
     <ChartContainer
       dataset={dataset}
@@ -101,7 +99,7 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={250}
-      {...passThroughProps}
+      {...rest}
     >
       <RadialBarChart
         onClick={onClickInternal}

--- a/packages/charts/src/components/ScatterChart/ScatterChart.test.tsx
+++ b/packages/charts/src/components/ScatterChart/ScatterChart.test.tsx
@@ -7,7 +7,7 @@ import {
   createOnClickChartTest,
   createOnLegendClickNotCrashTest
 } from '@shared/tests/chartUtils';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 
 const measures = [
   {
@@ -35,5 +35,5 @@ describe('Scatter Chart', () => {
 
   createLoadingPlaceholderTest(ScatterChart, { measures: [] });
 
-  createPassThroughPropsTest(ScatterChart, { dataset: scatterComplexDataSet, measures });
+  createCustomPropsTest(ScatterChart, { dataset: scatterComplexDataSet, measures });
 });

--- a/packages/charts/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/src/components/ScatterChart/ScatterChart.tsx
@@ -1,4 +1,4 @@
-import { useIsRTL, usePassThroughHtmlProps, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
@@ -9,6 +9,7 @@ import { useLegendItemClick } from '@ui5/webcomponents-react-charts/dist/useLege
 import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo, useRef } from 'react';
 import {
   CartesianGrid,
+  Label,
   Legend,
   ReferenceLine,
   Scatter,
@@ -16,8 +17,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-  ZAxis,
-  Label
+  ZAxis
 } from 'recharts';
 import { useChartMargin } from '../../hooks/useChartMargin';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
@@ -143,7 +143,9 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
     className,
     tooltip,
     slot,
-    ChartPlaceholder
+    ChartPlaceholder,
+    children,
+    ...rest
   } = props;
 
   const chartConfig = useMemo(() => {
@@ -209,7 +211,7 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
   const [yAxisWidth, legendPosition] = useLongestYAxisLabel(dataset?.[0].data, [yMeasure]);
   const xAxisHeights = useObserveXAxisHeights(chartRef, 1);
   const marginChart = useChartMargin(chartConfig.margin, chartConfig.zoomingTool);
-  const passThroughProps = usePassThroughHtmlProps(props, ['onDataPointClick', 'onLegendClick', 'onClick']);
+  const { chartConfig: _0, measures: _1, ...propsWithoutOmitted } = rest;
   const isRTL = useIsRTL(chartRef);
 
   return (
@@ -223,7 +225,7 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={chartConfig.resizeDebounce}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <ScatterChartLib
         onClick={onClickInternal}
@@ -316,7 +318,7 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
           contentStyle={tooltipContentStyle}
           {...tooltipConfig}
         />
-        {props.children}
+        {children}
       </ScatterChartLib>
     </ChartContainer>
   );

--- a/packages/charts/src/interfaces/IChartBaseProps.ts
+++ b/packages/charts/src/interfaces/IChartBaseProps.ts
@@ -1,5 +1,5 @@
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
-import { ComponentType, ReactNode, ReactNodeArray } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { TooltipProps } from 'recharts';
 import { ICartesianChartConfig } from './ICartesianChartConfig';
 
@@ -20,7 +20,7 @@ export interface IChartBaseProps<T = ICartesianChartConfig> extends Omit<CommonP
    * With the help of the `children` prop you can add more svg elements to the chart, e.g. if you want to display
    * a linear gradient.
    */
-  children?: ReactNode | ReactNodeArray;
+  children?: ReactNode | ReactNode[];
 
   /**
    * `noLegend` toggles the visibility of the legend below the chart. If this prop is `true`, no legend will be rendered.

--- a/packages/charts/src/internal/ChartContainer.tsx
+++ b/packages/charts/src/internal/ChartContainer.tsx
@@ -1,5 +1,4 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { Label } from '@ui5/webcomponents-react/dist/Label';
 import { Loader } from '@ui5/webcomponents-react/dist/Loader';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
@@ -62,7 +61,18 @@ class ErrorBoundary extends React.Component<{ children: ReactNode }, { errorCoun
 }
 
 const ChartContainer: FC<ContainerProps> = forwardRef((props: ContainerProps, ref: Ref<any>) => {
-  const { Placeholder, loading = false, dataset, style, className, tooltip, slot, children, resizeDebounce } = props;
+  const {
+    Placeholder,
+    loading = false,
+    dataset,
+    style,
+    className,
+    tooltip,
+    slot,
+    children,
+    resizeDebounce,
+    ...rest
+  } = props;
   useStyles();
 
   const internalStyles: CSSProperties = useMemo(() => {
@@ -77,10 +87,8 @@ const ChartContainer: FC<ContainerProps> = forwardRef((props: ContainerProps, re
     };
   }, [style]);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   return (
-    <div ref={ref} style={internalStyles} className={className} title={tooltip} slot={slot} {...passThroughProps}>
+    <div ref={ref} style={internalStyles} className={className} title={tooltip} slot={slot} {...rest}>
       {dataset?.length > 0 ? (
         <>
           {loading && <Loader style={loaderStyles} />}

--- a/packages/main/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/main/src/components/ActionSheet/ActionSheet.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ActionSheet } from '@ui5/webcomponents-react/dist/ActionSheet';
 import { PopoverDomRef } from '@ui5/webcomponents-react/dist/Popover';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
@@ -66,5 +66,5 @@ describe('ActionSheet', () => {
     expect(container.parentElement).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(ActionSheet);
+  createCustomPropsTest(ActionSheet);
 });

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -2,11 +2,11 @@ import { isPhone } from '@ui5/webcomponents-base/dist/Device.js';
 import { addCustomCSS } from '@ui5/webcomponents-base/dist/Theming.js';
 import { useI18nBundle, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { AVAILABLE_ACTIONS, CANCEL, X_OF_Y } from '@ui5/webcomponents-react/dist/assets/i18n/i18n-defaults';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/dist/ButtonDesign';
 import { ResponsivePopover } from '@ui5/webcomponents-react/dist/ResponsivePopover';
+import clsx from 'clsx';
 import React, {
   Children,
   cloneElement,
@@ -21,7 +21,6 @@ import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { ButtonPropTypes } from '../../webComponents/Button';
 import { ResponsivePopoverDomRef, ResponsivePopoverPropTypes } from '../../webComponents/ResponsivePopover';
-import clsx from 'clsx';
 import styles from './ActionSheet.jss';
 
 export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, 'children'> {
@@ -121,7 +120,8 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Resp
     onAfterClose,
     onAfterOpen,
     onBeforeClose,
-    onBeforeOpen
+    onBeforeOpen,
+    ...rest
   } = props;
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const classes = useStyles();
@@ -173,12 +173,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Resp
     });
   };
 
-  const passThroughProps = usePassThroughHtmlProps(props, [
-    'onAfterClose',
-    'onAfterOpen',
-    'onBeforeClose',
-    'onBeforeOpen'
-  ]);
   const handleAfterOpen = useCallback(
     (e) => {
       if (isPhone()) {
@@ -210,7 +204,7 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Resp
       onAfterClose={onAfterClose}
       onBeforeClose={onBeforeClose}
       onBeforeOpen={onBeforeOpen}
-      {...passThroughProps}
+      {...rest}
       onAfterOpen={handleAfterOpen}
       ref={componentRef}
       className={actionSheetClasses}

--- a/packages/main/src/components/AnalyticalCard/AnalyticalCard.test.tsx
+++ b/packages/main/src/components/AnalyticalCard/AnalyticalCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { AnalyticalCard } from '@ui5/webcomponents-react/dist/AnalyticalCard';
 import { AnalyticalCardHeader } from '@ui5/webcomponents-react/dist/AnalyticalCardHeader';
 import { Text } from '@ui5/webcomponents-react/dist/Text';
@@ -40,5 +40,5 @@ describe('Analytical Card', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(AnalyticalCard);
+  createCustomPropsTest(AnalyticalCard);
 });

--- a/packages/main/src/components/AnalyticalCard/index.tsx
+++ b/packages/main/src/components/AnalyticalCard/index.tsx
@@ -1,5 +1,4 @@
 import { createUseStyles } from 'react-jss';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import React, { forwardRef, ReactNode, ReactNodeArray, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
@@ -14,7 +13,7 @@ export interface AnalyticalCardPropTypes extends CommonProps {
   /**
    * The content of the `AnalyticalCard`.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 const useStyles = createUseStyles(styles, { name: 'AnalyticalCard' });
@@ -22,14 +21,12 @@ const useStyles = createUseStyles(styles, { name: 'AnalyticalCard' });
  * The `AnalyticalCard` is mainly used for data visualization. It consists of two areas – a header area and a chart area with a visual representation of the data.<br />
  */
 const AnalyticalCard = forwardRef((props: AnalyticalCardPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { children, style, className, tooltip, header } = props;
+  const { children, style, className, tooltip, header, ...rest } = props;
   const classes = useStyles();
   const classNameString = clsx(classes.card, className);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   return (
-    <div ref={ref} className={classNameString} style={style} title={tooltip} {...passThroughProps}>
+    <div ref={ref} className={classNameString} style={style} title={tooltip} {...rest}>
       {header}
       <div className={classes.content}>{children}</div>
     </div>

--- a/packages/main/src/components/AnalyticalCard/index.tsx
+++ b/packages/main/src/components/AnalyticalCard/index.tsx
@@ -1,5 +1,5 @@
 import { createUseStyles } from 'react-jss';
-import React, { forwardRef, ReactNode, ReactNodeArray, Ref } from 'react';
+import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
 

--- a/packages/main/src/components/AnalyticalCardHeader/AnalyticalCardHeader.test.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/AnalyticalCardHeader.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { AnalyticalCard } from '@ui5/webcomponents-react/dist/AnalyticalCard';
 import { AnalyticalCardHeader } from '@ui5/webcomponents-react/dist/AnalyticalCardHeader';
 import { DeviationIndicator } from '@ui5/webcomponents-react/dist/DeviationIndicator';
@@ -88,5 +88,5 @@ describe('AnalyticalCardHeader', () => {
 
   testFactory();
 
-  createPassThroughPropsTest(AnalyticalCard);
+  createCustomPropsTest(AnalyticalCard);
 });

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -1,4 +1,4 @@
-import { useI18nBundle, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useI18nBundle } from '@ui5/webcomponents-react-base/dist/hooks';
 import { DEVIATION, TARGET } from '@ui5/webcomponents-react/dist/assets/i18n/i18n-defaults';
 import { DeviationIndicator } from '@ui5/webcomponents-react/dist/DeviationIndicator';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
@@ -9,9 +9,9 @@ import { FlexBoxWrap } from '@ui5/webcomponents-react/dist/FlexBoxWrap';
 import { ObjectStatus } from '@ui5/webcomponents-react/dist/ObjectStatus';
 import { ValueState } from '@ui5/webcomponents-react/dist/ValueState';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import clsx from 'clsx';
 import React, { forwardRef, MouseEventHandler, Ref, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
-import clsx from 'clsx';
 import styles from './AnalyticalCardHeader.jss';
 
 export interface AnalyticalCardHeaderPropTypes extends CommonProps {
@@ -103,7 +103,8 @@ export const AnalyticalCardHeader = forwardRef((props: AnalyticalCardHeaderPropT
     currency,
     indicatorState,
     arrowIndicator,
-    style
+    style,
+    ...rest
   } = props;
   const classes = useStyles();
 
@@ -136,12 +137,10 @@ export const AnalyticalCardHeader = forwardRef((props: AnalyticalCardHeaderPropT
 
   const shouldRenderContent = [value, unit, deviation, target].some((v) => !!v);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onHeaderClick']);
-
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
 
   return (
-    <div ref={ref} className={headerClasses} title={tooltip} style={style} {...passThroughProps} onClick={onClick}>
+    <div ref={ref} className={headerClasses} title={tooltip} style={style} {...rest} onClick={onClick}>
       <div className={classes.headerContent}>
         <div className={classes.headerTitles}>
           <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween} wrap={FlexBoxWrap.NoWrap}>

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, getByText, getMouseEvent, render, renderRtl, screen } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { AnalyticalTable } from '@ui5/webcomponents-react/dist/AnalyticalTable';
 import {
   useRowDisableSelection,
@@ -1161,5 +1161,5 @@ describe('AnalyticalTable', () => {
     expect(container.querySelectorAll('ui5-checkbox')[2]).toHaveAttribute('checked', 'true');
   });
 
-  createPassThroughPropsTest(AnalyticalTable);
+  createCustomPropsTest(AnalyticalTable);
 });

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -1,6 +1,5 @@
 import { useIsomorphicLayoutEffect, useIsRTL } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { AnalyticalTableScrollMode } from '@ui5/webcomponents-react/dist/AnalyticalTableScrollMode';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
@@ -10,9 +9,10 @@ import { TableSelectionBehavior } from '@ui5/webcomponents-react/dist/TableSelec
 import { TableSelectionMode } from '@ui5/webcomponents-react/dist/TableSelectionMode';
 import { TableVisibleRowCountMode } from '@ui5/webcomponents-react/dist/TableVisibleRowCountMode';
 import { TextAlign } from '@ui5/webcomponents-react/dist/TextAlign';
-import { VerticalAlign } from '@ui5/webcomponents-react/dist/VerticalAlign';
 import { ValueState } from '@ui5/webcomponents-react/dist/ValueState';
+import { VerticalAlign } from '@ui5/webcomponents-react/dist/VerticalAlign';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import clsx from 'clsx';
 import React, {
   ComponentType,
   CSSProperties,
@@ -65,7 +65,6 @@ import { stateReducer } from './tableReducer/stateReducer';
 import { TitleBar } from './TitleBar';
 import { orderByFn, tagNamesWhichShouldNotSelectARow } from './util';
 import { VerticalResizer } from './VerticalResizer';
-import clsx from 'clsx';
 
 export interface AnalyticalTableColumnDefinition {
   // base properties
@@ -214,6 +213,7 @@ export interface AnalyticalTableColumnDefinition {
    * Defines if the column is reorderable by dragging and dropping columns.
    */
   disableDragAndDrop?: boolean;
+
   // all other custom properties or [React Table](https://react-table.tanstack.com/) column options
   [key: string]: any;
 }
@@ -528,7 +528,8 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     onRowSelected,
     onSort,
     LoadingComponent,
-    NoDataComponent
+    NoDataComponent,
+    ...rest
   } = props;
 
   const classes = useStyles();
@@ -807,15 +808,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     tableInternalColumns
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props, [
-    'onSort',
-    'onGroup',
-    'onRowSelected',
-    'onRowClick',
-    'onRowExpandChange',
-    'onColumnsReordered',
-    'onLoadMore'
-  ]);
+  const { onColumnsReordered: _0, data: _1, ...propsWithoutOmitted } = rest;
 
   const inlineStyle = useMemo(() => {
     const tableStyles = {
@@ -875,7 +868,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
   );
 
   return (
-    <div className={className} style={inlineStyle} title={tooltip} ref={analyticalTableRef} {...passThroughProps}>
+    <div className={className} style={inlineStyle} title={tooltip} ref={analyticalTableRef} {...propsWithoutOmitted}>
       {header && <TitleBar ref={titleBarRef}>{header}</TitleBar>}
       {extension && <div ref={extensionRef}>{extension}</div>}
       <FlexBox>

--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import '@ui5/webcomponents-icons/dist/action.js';
 import '@ui5/webcomponents-icons/dist/decline.js';
 import '@ui5/webcomponents-icons/dist/exit-full-screen.js';
@@ -396,5 +396,5 @@ describe('DynamicPage', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(DynamicPage);
+  createCustomPropsTest(DynamicPage);
 });

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -1,17 +1,16 @@
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
-import { usePassThroughHtmlProps, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useResponsiveContentPadding, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { GlobalStyleClasses } from '@ui5/webcomponents-react/dist/GlobalStyleClasses';
 import { PageBackgroundDesign } from '@ui5/webcomponents-react/dist/PageBackgroundDesign';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import clsx from 'clsx';
 import React, { cloneElement, forwardRef, ReactElement, ReactNode, Ref, useEffect, useRef, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { useObserveHeights } from '../../internal/useObserveHeights';
-import { useResponsiveContentPadding } from '@ui5/webcomponents-react-base/dist/hooks';
 import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
-import clsx from 'clsx';
 import { styles } from './DynamicPage.jss';
 
 export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
@@ -95,9 +94,10 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
     children,
     className,
     footer,
-    a11yConfig
+    a11yConfig,
+    ...rest
   } = props;
-  const passThroughProps = usePassThroughHtmlProps(props, ['onScroll']);
+  const { onScroll: _1, ...propsWithoutOmitted } = rest;
 
   const anchorBarRef = useRef<HTMLDivElement>();
   const [componentRef, dynamicPageRef] = useSyncRef<HTMLDivElement>(ref);
@@ -220,7 +220,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
       className={dynamicPageClasses}
       style={style}
       onScroll={onDynamicPageScroll}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       {headerTitle &&
         cloneElement(headerTitle, {

--- a/packages/main/src/components/DynamicPageHeader/index.tsx
+++ b/packages/main/src/components/DynamicPageHeader/index.tsx
@@ -1,5 +1,4 @@
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { forwardRef, ReactNode, Ref, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
@@ -31,9 +30,7 @@ const useStyles = createUseStyles(DynamicPageHeaderStyles, { name: 'DynamicPageH
  * This component can be collapsed and pinned by the anchorbar.
  */
 const DynamicPageHeader = forwardRef((props: InternalProps, ref: Ref<HTMLDivElement>) => {
-  const { children, headerPinned, topHeaderHeight, tooltip, className, style } = props;
-
-  const passThroughProps = usePassThroughHtmlProps(props);
+  const { children, headerPinned, topHeaderHeight, tooltip, className, style, ...rest } = props;
 
   const headerStyles = useMemo(() => {
     if (headerPinned) {
@@ -53,7 +50,7 @@ const DynamicPageHeader = forwardRef((props: InternalProps, ref: Ref<HTMLDivElem
     <div
       title={tooltip}
       ref={ref}
-      {...passThroughProps}
+      {...rest}
       className={classNames}
       data-component-name="DynamicPageHeader"
       style={headerStyles}

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -1,6 +1,6 @@
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
 import { useIsRTL } from '@ui5/webcomponents-react-base/dist/hooks';
-import { usePassThroughHtmlProps, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { debounce } from '@ui5/webcomponents-react-base/dist/Utils';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignItems';
@@ -95,7 +95,8 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     navigationActions,
     className,
     style,
-    tooltip
+    tooltip,
+    ...rest
   } = props as InternalProps;
 
   const classes = useStyles();
@@ -112,7 +113,7 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     };
   }, [isMounted]);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onToggleHeaderContentVisibility', 'onClick']);
+  const { onClick: _0, ...propsWithoutOmitted } = rest;
 
   const onHeaderClick = useCallback(
     (e) => {
@@ -160,7 +161,7 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
       tooltip={tooltip}
       data-component-name="DynamicPageTitle"
       onClick={onHeaderClick}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       {(breadcrumbs || (navigationActions && showNavigationInTopArea)) && (
         <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween} data-component-name="DynamicPageTitleBreadcrumbs">

--- a/packages/main/src/components/FilterBar/FilterBar.test.tsx
+++ b/packages/main/src/components/FilterBar/FilterBar.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@shared/tests';
-import { createChangeTagNameTest, createPassThroughPropsTest } from '@shared/tests/utils';
+import { createChangeTagNameTest, createCustomPropsTest } from '@shared/tests/utils';
 import { Bar } from '@ui5/webcomponents-react/dist/Bar';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { DatePicker } from '@ui5/webcomponents-react/dist/DatePicker';
@@ -583,5 +583,5 @@ describe('FilterBar', () => {
 
   createChangeTagNameTest(FilterBar);
 
-  createPassThroughPropsTest(FilterBar);
+  createCustomPropsTest(FilterBar);
 });

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -1,5 +1,4 @@
 import { useI18nBundle, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import {
   ADAPT_FILTERS,
@@ -259,7 +258,8 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
     onFiltersDialogSelectionChange,
     onFiltersDialogSearch,
     onGo,
-    onRestore
+    onRestore,
+    ...rest
   } = props;
   const [showFilters, setShowFilters] = useState(useToolbar ? filterBarExpanded : true);
   const [mountFilters, setMountFilters] = useState(true);
@@ -362,20 +362,6 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
       onGo(enrichEventWithDetails(e, { elements: filterRefs.current, ...getFilterElements() }));
     }
   };
-
-  const passThroughProps = usePassThroughHtmlProps(props, [
-    'onToggleFilters',
-    'onFiltersDialogOpen',
-    'onFiltersDialogClose',
-    'onFiltersDialogSave',
-    'onFiltersDialogClear',
-    'onClear',
-    'onFiltersDialogSelectionChange',
-    'onFiltersDialogSearch',
-    'onGo',
-    'onRestore',
-    'onFiltersDialogCancel'
-  ]);
 
   const safeChildren = () => {
     if (Object.keys(toggledFilters).length > 0) {
@@ -649,7 +635,7 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
         style={{ ['--_ui5wcr_filter_group_item_flex_basis']: filterContainerWidth, ...style } as CSSProperties}
         title={tooltip}
         slot={slot}
-        {...passThroughProps}
+        {...rest}
       >
         {loading ? (
           <BusyIndicator active className={classes.loadingContainer} size={BusyIndicatorSize.Large} />

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -1,14 +1,13 @@
 import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
-import { createUseStyles } from 'react-jss';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { BusyIndicator } from '@ui5/webcomponents-react/dist/BusyIndicator';
 import { BusyIndicatorSize } from '@ui5/webcomponents-react/dist/BusyIndicatorSize';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { Label } from '@ui5/webcomponents-react/dist/Label';
-import React, { forwardRef, ReactElement, RefObject } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
-import styles from './FilterGroupItem.jss';
 import clsx from 'clsx';
+import React, { forwardRef, ReactElement, RefObject } from 'react';
+import { createUseStyles } from 'react-jss';
+import styles from './FilterGroupItem.jss';
 
 const useStyles = createUseStyles(styles, { name: 'FilterGroupItem' });
 
@@ -76,9 +75,9 @@ export const FilterGroupItem = forwardRef((props: FilterGroupItemPropTypes, ref:
     loading,
     className,
     tooltip,
-    slot
+    slot,
+    ...rest
   } = props;
-  const passThroughProps = usePassThroughHtmlProps(props);
   const inFB = props['data-in-fb'];
   const [componentRef, filterGroupItemRef] = useSyncRef<HTMLDivElement>(ref);
 
@@ -95,7 +94,7 @@ export const FilterGroupItem = forwardRef((props: FilterGroupItemPropTypes, ref:
       ref={componentRef}
       title={tooltip}
       slot={slot}
-      {...passThroughProps}
+      {...rest}
       className={styleClasses}
       style={inFB ? inlineStyle : emptyObject}
     >

--- a/packages/main/src/components/FlexBox/FlexBox.test.tsx
+++ b/packages/main/src/components/FlexBox/FlexBox.test.tsx
@@ -1,4 +1,4 @@
-import { createChangeTagNameTest, createPassThroughPropsTest } from '@shared/tests/utils';
+import { createChangeTagNameTest, createCustomPropsTest } from '@shared/tests/utils';
 import { render, screen } from '@shared/tests';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJustifyContent';
@@ -45,5 +45,5 @@ describe('FlexBox', () => {
 
   createChangeTagNameTest(FlexBox);
 
-  createPassThroughPropsTest(FlexBox);
+  createCustomPropsTest(FlexBox);
 });

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -1,5 +1,4 @@
 import { createUseStyles } from 'react-jss';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignItems';
 import { FlexBoxDirection } from '@ui5/webcomponents-react/dist/FlexBoxDirection';
 import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJustifyContent';
@@ -68,7 +67,8 @@ const FlexBox = forwardRef((props: FlexBoxPropTypes, ref: Ref<HTMLDivElement>) =
     tooltip,
     fitContainer,
     slot,
-    as
+    as,
+    ...rest
   } = props;
 
   const classes = useStyles();
@@ -83,10 +83,9 @@ const FlexBox = forwardRef((props: FlexBoxPropTypes, ref: Ref<HTMLDivElement>) =
     className
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
   const CustomTag = as as React.ElementType;
   return (
-    <CustomTag ref={ref} className={flexBoxClasses} style={style} title={tooltip} slot={slot} {...passThroughProps}>
+    <CustomTag ref={ref} className={flexBoxClasses} style={style} title={tooltip} slot={slot} {...rest}>
       {children}
     </CustomTag>
   );

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -3,7 +3,7 @@ import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignIte
 import { FlexBoxDirection } from '@ui5/webcomponents-react/dist/FlexBoxDirection';
 import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJustifyContent';
 import { FlexBoxWrap } from '@ui5/webcomponents-react/dist/FlexBoxWrap';
-import React, { forwardRef, ReactNode, ReactNodeArray, Ref } from 'react';
+import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { styles } from './FlexBox.jss';
 import clsx from 'clsx';
@@ -42,7 +42,7 @@ export interface FlexBoxPropTypes extends CommonProps {
   /**
    * Content of the `FlexBox`.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
   /**
    * Sets the components outer HTML tag.
    *

--- a/packages/main/src/components/Form/Form.test.tsx
+++ b/packages/main/src/components/Form/Form.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createChangeTagNameTest, createPassThroughPropsTest } from '@shared/tests/utils';
+import { createChangeTagNameTest, createCustomPropsTest } from '@shared/tests/utils';
 import { Form } from '@ui5/webcomponents-react/dist/Form';
 import { FormGroup } from '@ui5/webcomponents-react/dist/FormGroup';
 import { FormItem } from '@ui5/webcomponents-react/dist/FormItem';
@@ -76,7 +76,7 @@ describe('Create a Form', () => {
 
   createChangeTagNameTest(Form);
 
-  createPassThroughPropsTest(Form, {
+  createCustomPropsTest(Form, {
     children: (
       <FormItem>
         <Input type={InputType.Text} />

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -1,10 +1,11 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/dist/CssSizeVariables';
-import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { createUseStyles } from 'react-jss';
 import { getCurrentRange } from '@ui5/webcomponents-react-base/dist/Device';
-import { useSyncRef, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
+import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 import { Title } from '@ui5/webcomponents-react/dist/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/dist/TitleLevel';
+import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import clsx from 'clsx';
 import React, {
   Children,
   cloneElement,
@@ -17,9 +18,8 @@ import React, {
   useRef,
   useState
 } from 'react';
-import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { createUseStyles } from 'react-jss';
 import { styles } from './Form.jss';
-import clsx from 'clsx';
 
 export interface FormPropTypes extends CommonProps {
   /**
@@ -122,7 +122,8 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
     labelSpanM,
     labelSpanL,
     labelSpanXL,
-    as
+    as,
+    ...rest
   } = props;
 
   const columnsMap = new Map();
@@ -262,7 +263,6 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
 
     return [computedFormGroups, titleText];
   }, [children, currentRange, titleText, currentNumberOfColumns, currentLabelSpan]);
-  const passThroughProps = usePassThroughHtmlProps(props);
 
   const formClassNames = clsx(classes.form, classes[`labelSpan${((currentLabelSpan - 1) % 12) + 1}`], className);
 
@@ -275,7 +275,7 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
       title={tooltip}
       style={style}
       data-columns={currentNumberOfColumns}
-      {...passThroughProps}
+      {...rest}
     >
       {updatedTitle && (
         <Title level={TitleLevel.H3} className={classes.formTitle}>

--- a/packages/main/src/components/FormGroup/index.tsx
+++ b/packages/main/src/components/FormGroup/index.tsx
@@ -1,6 +1,6 @@
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/dist/CssSizeVariables';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import React, { FC, ReactNode, ReactNodeArray } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { createUseStyles } from 'react-jss';
 
 export interface FormGroupPropTypes {
@@ -11,7 +11,7 @@ export interface FormGroupPropTypes {
   /**
    * Contents of the FormGroup. Please use only `FormItem` to keep the intended design.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 const useStyles = createUseStyles(

--- a/packages/main/src/components/FormItem/index.tsx
+++ b/packages/main/src/components/FormItem/index.tsx
@@ -3,7 +3,7 @@ import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignIte
 import { FlexBoxDirection } from '@ui5/webcomponents-react/dist/FlexBoxDirection';
 import { Label, LabelPropTypes } from '@ui5/webcomponents-react/dist/Label';
 import { WrappingType } from '@ui5/webcomponents-react/dist/WrappingType';
-import React, { cloneElement, CSSProperties, FC, isValidElement, ReactElement, ReactNode, ReactNodeArray } from 'react';
+import React, { cloneElement, CSSProperties, FC, isValidElement, ReactElement, ReactNode } from 'react';
 import { createUseStyles } from 'react-jss';
 import { addCustomCSS } from '@ui5/webcomponents-base/dist/Theming.js';
 
@@ -15,7 +15,7 @@ export interface FormItemPropTypes {
   /**
    * Content of the FormItem. Can be an arbitrary React Node.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 //TODO: remove this when ui5-webcomponents adjusted this in their repo

--- a/packages/main/src/components/Grid/Grid.test.tsx
+++ b/packages/main/src/components/Grid/Grid.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Grid } from '@ui5/webcomponents-react/dist/Grid';
 import React from 'react';
 import { GridPosition } from '@ui5/webcomponents-react/dist/GridPosition';
@@ -97,5 +97,5 @@ describe('Grid', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(Grid);
+  createCustomPropsTest(Grid);
 });

--- a/packages/main/src/components/Grid/index.tsx
+++ b/packages/main/src/components/Grid/index.tsx
@@ -1,5 +1,4 @@
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { useViewportRange } from '@ui5/webcomponents-react-base/dist/useViewportRange';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { GridPosition } from '@ui5/webcomponents-react/dist/GridPosition';
@@ -10,7 +9,6 @@ import React, {
   forwardRef,
   ReactElement,
   ReactNode,
-  ReactNodeArray,
   Ref,
   useCallback
 } from 'react';
@@ -50,7 +48,7 @@ export interface GridPropTypes extends CommonProps {
   /**
    * Components that are placed into Grid layout.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 const INDENT_PATTERN =
@@ -100,7 +98,19 @@ const useStyles = createUseStyles(styles, { name: 'Grid' });
  * A layout container component used for aligning items with various sizes in a simple grid.
  */
 const Grid = forwardRef((props: GridPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { position, children, hSpacing, vSpacing, style, className, tooltip, slot, defaultIndent, defaultSpan } = props;
+  const {
+    position,
+    children,
+    hSpacing,
+    vSpacing,
+    style,
+    className,
+    tooltip,
+    slot,
+    defaultIndent,
+    defaultSpan,
+    ...rest
+  } = props;
   const classes = useStyles();
   const currentRange = useViewportRange();
   const gridClasses = clsx(
@@ -145,8 +155,6 @@ const Grid = forwardRef((props: GridPropTypes, ref: Ref<HTMLDivElement>) => {
     [currentRange, defaultSpan, defaultIndent, classes, vSpacing, hSpacing]
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   return (
     <div
       ref={ref}
@@ -154,7 +162,7 @@ const Grid = forwardRef((props: GridPropTypes, ref: Ref<HTMLDivElement>) => {
       style={{ gridRowGap: vSpacing, gridColumnGap: hSpacing, ...style }}
       title={tooltip}
       slot={slot}
-      {...passThroughProps}
+      {...rest}
     >
       {Children.map(children, renderGridElements)}
     </div>

--- a/packages/main/src/components/Loader/Loader.test.tsx
+++ b/packages/main/src/components/Loader/Loader.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Loader } from '@ui5/webcomponents-react/dist/Loader';
 import { LoaderType } from '@ui5/webcomponents-react/dist/LoaderType';
 import React from 'react';
@@ -35,5 +35,5 @@ describe('Loader', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(Loader);
+  createCustomPropsTest(Loader);
 });

--- a/packages/main/src/components/Loader/index.tsx
+++ b/packages/main/src/components/Loader/index.tsx
@@ -1,12 +1,11 @@
-import { createUseStyles } from 'react-jss';
 import { useI18nBundle } from '@ui5/webcomponents-react-base/dist/hooks';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { PLEASE_WAIT } from '@ui5/webcomponents-react/dist/assets/i18n/i18n-defaults';
 import { LoaderType } from '@ui5/webcomponents-react/dist/LoaderType';
-import React, { CSSProperties, forwardRef, RefObject, useEffect, useMemo, useState } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
-import { styles } from './Loader.jss';
 import clsx from 'clsx';
+import React, { CSSProperties, forwardRef, RefObject, useEffect, useMemo, useState } from 'react';
+import { createUseStyles } from 'react-jss';
+import { styles } from './Loader.jss';
 
 export interface LoaderPropTypes extends CommonProps {
   /**
@@ -31,7 +30,7 @@ const useStyles = createUseStyles(styles, { name: 'Loader' });
  * It can be used to signal a data update on an already existing dataset, or where an expansion will happen.
  */
 const Loader = forwardRef((props: LoaderPropTypes, ref: RefObject<HTMLDivElement>) => {
-  const { className, type, progress, tooltip, slot, style, delay } = props;
+  const { className, type, progress, tooltip, slot, style, delay, ...rest } = props;
   const classes = useStyles();
   const [isVisible, setIsVisible] = useState(delay === 0);
 
@@ -57,8 +56,6 @@ const Loader = forwardRef((props: LoaderPropTypes, ref: RefObject<HTMLDivElement
     };
   }, []);
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
 
   if (!isVisible) {
@@ -75,7 +72,7 @@ const Loader = forwardRef((props: LoaderPropTypes, ref: RefObject<HTMLDivElement
       title={tooltip || i18nBundle.getText(PLEASE_WAIT)}
       slot={slot}
       style={inlineStyles}
-      {...passThroughProps}
+      {...rest}
     />
   );
 });

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -34,17 +34,7 @@ import { Title } from '@ui5/webcomponents-react/dist/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/dist/TitleLevel';
 import { Ui5CustomEvent } from '@ui5/webcomponents-react/interfaces/Ui5CustomEvent';
 import clsx from 'clsx';
-import React, {
-  forwardRef,
-  isValidElement,
-  ReactNode,
-  ReactNodeArray,
-  Ref,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import React, { forwardRef, isValidElement, ReactNode, Ref, useCallback, useEffect, useMemo, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { stopPropagation } from '../../internal/stopPropagation';
 import styles from './MessageBox.jss';
@@ -66,7 +56,7 @@ export interface MessageBoxPropTypes
    *
    * **Note:** Although this prop accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design and a11y capabilities.
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
   /**
    * Array of actions of the MessageBox. Those actions will be transformed into buttons in the `MessageBox` footer.
    */

--- a/packages/main/src/components/MessageView/MessageItem.tsx
+++ b/packages/main/src/components/MessageView/MessageItem.tsx
@@ -11,7 +11,7 @@ import { MessageViewContext } from '@ui5/webcomponents-react/dist/MessageViewCon
 import { ValueState } from '@ui5/webcomponents-react/dist/ValueState';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { Ui5DomRef } from '@ui5/webcomponents-react/interfaces/Ui5DomRef';
-import React, { forwardRef, ReactNode, ReactNodeArray, Ref, useContext } from 'react';
+import React, { forwardRef, ReactNode, Ref, useContext } from 'react';
 import { createUseStyles } from 'react-jss';
 import { getIconNameForType } from './utils';
 import clsx from 'clsx';
@@ -45,7 +45,7 @@ export interface MessageItemPropTypes extends CommonProps {
   /**
    * Specifies detailed description of the message
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 const useStyles = createUseStyles(

--- a/packages/main/src/components/MessageView/MessageView.test.tsx
+++ b/packages/main/src/components/MessageView/MessageView.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { MessageView, MessageViewDomRef } from '@ui5/webcomponents-react/dist/MessageView';
 import { MessageItem } from '@ui5/webcomponents-react/dist/MessageItem';
 import React, { createRef, forwardRef } from 'react';
@@ -63,5 +63,5 @@ describe('MessageView', () => {
     expect(screen.queryAllByText('Error')).toHaveLength(1); // list
   });
 
-  createPassThroughPropsTest(MessageView);
+  createCustomPropsTest(MessageView);
 });

--- a/packages/main/src/components/MessageView/index.tsx
+++ b/packages/main/src/components/MessageView/index.tsx
@@ -29,7 +29,6 @@ import React, {
   Fragment,
   ReactElement,
   ReactNode,
-  ReactNodeArray,
   Ref,
   useCallback,
   useEffect,

--- a/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Avatar } from '@ui5/webcomponents-react/dist/Avatar';
 import { Bar } from '@ui5/webcomponents-react/dist/Bar';
 import { BarDesign } from '@ui5/webcomponents-react/dist/BarDesign';
@@ -247,5 +247,5 @@ describe('ObjectPage', () => {
     expect(container.querySelector("[data-component-name='ObjectPageTabContainer']")).toBeInTheDocument();
   });
 
-  createPassThroughPropsTest(ObjectPage);
+  createCustomPropsTest(ObjectPage);
 });

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -1,7 +1,6 @@
 import { addCustomCSS } from '@ui5/webcomponents-base/dist/Theming.js';
 import { useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { AvatarPropTypes } from '@ui5/webcomponents-react/dist/Avatar';
 import { AvatarSize } from '@ui5/webcomponents-react/dist/AvatarSize';
@@ -181,7 +180,8 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     headerContentPinnable,
     a11yConfig,
     placeholder,
-    portalContainer
+    portalContainer,
+    ...rest
   } = props;
 
   const classes = useStyles();
@@ -491,11 +491,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     mode === ObjectPageMode.IconTabBar && classes.iconTabBarMode
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props, [
-    'onSelectedSectionChange',
-    'onSelectedSectionChanged',
-    'onScroll'
-  ]);
+  const { onScroll: _0, selectedSubSectionId: _1, ...propsWithoutOmitted } = rest;
 
   useEffect(() => {
     const sections = objectPageRef.current?.querySelectorAll('section[data-component-name="ObjectPageSection"]');
@@ -734,7 +730,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
       ref={componentRef}
       title={tooltip}
       onScroll={onObjectPageScroll}
-      {...passThroughProps}
+      {...propsWithoutOmitted}
     >
       <header
         onMouseOver={onHoverToggleButton}

--- a/packages/main/src/components/ObjectPageSection/ObjectPageSection.test.tsx
+++ b/packages/main/src/components/ObjectPageSection/ObjectPageSection.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ObjectPageSection } from '@ui5/webcomponents-react/dist/ObjectPageSection';
 import React from 'react';
 
@@ -27,5 +27,5 @@ describe('ObjectPageSection', () => {
     expect(renderer).toThrow();
   });
 
-  createPassThroughPropsTest(ObjectPageSection);
+  createCustomPropsTest(ObjectPageSection);
 });

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -1,4 +1,3 @@
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import React, { forwardRef, ReactNode, RefObject } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
@@ -31,7 +30,7 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSection' });
  * Top-level information container of an `ObjectPage`.
  */
 const ObjectPageSection = forwardRef((props: ObjectPageSectionPropTypes, ref: RefObject<HTMLElement>) => {
-  const { titleText, id, children, titleTextUppercase, className, style, tooltip } = props;
+  const { titleText, id, children, titleTextUppercase, className, style, tooltip, ...rest } = props;
   const classes = useStyles();
 
   if (!id) {
@@ -41,7 +40,6 @@ const ObjectPageSection = forwardRef((props: ObjectPageSectionPropTypes, ref: Re
 
   const titleClasses = clsx(classes.title, titleTextUppercase && classes.uppercase);
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['id']);
   return (
     <section
       ref={ref}
@@ -49,7 +47,7 @@ const ObjectPageSection = forwardRef((props: ObjectPageSectionPropTypes, ref: Re
       className={className}
       style={style}
       title={tooltip}
-      {...passThroughProps}
+      {...rest}
       id={htmlId}
       data-component-name="ObjectPageSection"
     >

--- a/packages/main/src/components/ObjectPageSubSection/ObjectPageSubSection.test.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/ObjectPageSubSection.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ObjectPageSubSection } from '@ui5/webcomponents-react/dist/ObjectPageSubSection';
 import React from 'react';
 
@@ -14,5 +14,5 @@ describe('ObjectPageSubSection', () => {
     expect(renderer).toThrow();
   });
 
-  createPassThroughPropsTest(ObjectPageSubSection);
+  createCustomPropsTest(ObjectPageSubSection);
 });

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -1,5 +1,4 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import React, { forwardRef, ReactNode, RefObject } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
@@ -44,7 +43,7 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSubSection' });
  * __Note:__ This component should only be used inside an `ObjectPageSection` component.
  */
 const ObjectPageSubSection = forwardRef((props: ObjectPageSubSectionPropTypes, ref: RefObject<HTMLDivElement>) => {
-  const { children, id, titleText, className, style, tooltip } = props;
+  const { children, id, titleText, className, style, tooltip, ...rest } = props;
 
   if (!id) {
     throw new EmptyIdPropException('ObjectPageSubSection requires a unique ID property!');
@@ -54,7 +53,6 @@ const ObjectPageSubSection = forwardRef((props: ObjectPageSubSectionPropTypes, r
 
   const classes = useStyles();
   const subSectionClassName = clsx(classes.objectPageSubSection, className);
-  const passThroughProps = usePassThroughHtmlProps(props, ['id']);
 
   return (
     <div
@@ -63,7 +61,7 @@ const ObjectPageSubSection = forwardRef((props: ObjectPageSubSectionPropTypes, r
       style={style}
       title={tooltip}
       tabIndex={-1}
-      {...passThroughProps}
+      {...rest}
       className={subSectionClassName}
       id={htmlId}
     >

--- a/packages/main/src/components/ObjectStatus/ObjectStatus.test.tsx
+++ b/packages/main/src/components/ObjectStatus/ObjectStatus.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ObjectStatus } from '@ui5/webcomponents-react/dist/ObjectStatus';
 import { ValueState } from '@ui5/webcomponents-react/dist/ValueState';
 import { IndicationColor } from '@ui5/webcomponents-react/dist/IndicationColor';
@@ -11,5 +11,5 @@ describe('ObjectStatus', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(ObjectStatus);
+  createCustomPropsTest(ObjectStatus);
 });

--- a/packages/main/src/components/ObjectStatus/index.tsx
+++ b/packages/main/src/components/ObjectStatus/index.tsx
@@ -2,7 +2,6 @@ import '@ui5/webcomponents-icons/dist/hint.js';
 import '@ui5/webcomponents-icons/dist/status-critical.js';
 import '@ui5/webcomponents-icons/dist/status-negative.js';
 import '@ui5/webcomponents-icons/dist/status-positive.js';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { Icon } from '@ui5/webcomponents-react/dist/Icon';
 import { ValueState } from '@ui5/webcomponents-react/dist/ValueState';
 import { IndicationColor } from '@ui5/webcomponents-react/dist/IndicationColor';
@@ -83,7 +82,8 @@ const useStyles = createUseStyles(styles, { name: 'ObjectStatus' });
  * Status information that can be either text with a value state, or an icon.
  */
 const ObjectStatus = forwardRef((props: ObjectStatusPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { state, showDefaultIcon, children, icon, className, style, tooltip, active, inverted, onClick } = props;
+  const { state, showDefaultIcon, children, icon, className, style, tooltip, active, inverted, onClick, ...rest } =
+    props;
 
   const iconToRender = (() => {
     if (icon) {
@@ -104,8 +104,6 @@ const ObjectStatus = forwardRef((props: ObjectStatusPropTypes, ref: Ref<HTMLDivE
     className
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   return (
     <div
       ref={ref}
@@ -113,7 +111,7 @@ const ObjectStatus = forwardRef((props: ObjectStatusPropTypes, ref: Ref<HTMLDivE
       style={style}
       title={tooltip}
       onClick={active ? onClick : undefined}
-      {...passThroughProps}
+      {...rest}
     >
       {iconToRender && <span className={classes.icon}>{iconToRender}</span>}
       {children && <span className={classes.text}>{children}</span>}

--- a/packages/main/src/components/ResponsiveGridLayout/ResponsiveGridLayout.test.tsx
+++ b/packages/main/src/components/ResponsiveGridLayout/ResponsiveGridLayout.test.tsx
@@ -1,5 +1,5 @@
 import { screen, render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ResponsiveGridLayout } from '@ui5/webcomponents-react/dist/ResponsiveGridLayout';
 import React from 'react';
 
@@ -34,5 +34,5 @@ describe('ResponsiveGridLayout', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  createPassThroughPropsTest(ResponsiveGridLayout);
+  createCustomPropsTest(ResponsiveGridLayout);
 });

--- a/packages/main/src/components/ResponsiveGridLayout/index.tsx
+++ b/packages/main/src/components/ResponsiveGridLayout/index.tsx
@@ -1,6 +1,5 @@
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
-import React, { CSSProperties, forwardRef, ReactNode, ReactNodeArray, Ref } from 'react';
+import React, { CSSProperties, forwardRef, ReactNode, Ref } from 'react';
 import { createUseStyles } from 'react-jss';
 import { ResponsiveGridLayoutStyles } from './ResponsiveGridLayout.jss';
 import clsx from 'clsx';
@@ -59,7 +58,7 @@ export interface ResponsiveGridLayoutPropTypes extends CommonProps {
    * Example: If you want one child to span across 4 columns, you can add this element style to the child element:
    * `style={{ gridColumn: 'span 4' }}`
    */
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
 }
 
 const useStyles = createUseStyles(ResponsiveGridLayoutStyles, { name: 'ResponsiveGridLayout' });
@@ -88,12 +87,11 @@ const ResponsiveGridLayout = forwardRef((props: ResponsiveGridLayoutPropTypes, r
     style,
     className,
     tooltip,
-    title
+    title,
+    ...rest
   } = props;
   const classes = useStyles();
   const finalClassNames = clsx(classes.container, className);
-
-  const passThroughProps = usePassThroughHtmlProps(props);
 
   return (
     <div
@@ -115,7 +113,7 @@ const ResponsiveGridLayout = forwardRef((props: ResponsiveGridLayoutPropTypes, r
           ...style
         } as CSSProperties
       }
-      {...passThroughProps}
+      {...rest}
     >
       {children}
     </div>

--- a/packages/main/src/components/Text/Text.test.tsx
+++ b/packages/main/src/components/Text/Text.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Text } from '@ui5/webcomponents-react/dist/Text';
 import React from 'react';
 
@@ -32,5 +32,5 @@ describe('Text', () => {
     });
   });
 
-  createPassThroughPropsTest(Text);
+  createCustomPropsTest(Text);
 });

--- a/packages/main/src/components/Text/index.tsx
+++ b/packages/main/src/components/Text/index.tsx
@@ -1,5 +1,4 @@
 import { createUseStyles } from 'react-jss';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import { TextStyles } from './Text.jss';
@@ -26,7 +25,7 @@ const useStyles = createUseStyles(TextStyles, { name: 'Text' });
  * <br />__Note:__ Line breaks will always be visualized except when the wrapping property is set to false. In addition, tabs and whitespace can be preserved by setting the renderWhitespace property to true.
  */
 const Text = forwardRef((props: TextPropTypes, ref: Ref<HTMLSpanElement>) => {
-  const { children, renderWhitespace, wrapping, className, style, tooltip, slot } = props;
+  const { children, renderWhitespace, wrapping, className, style, tooltip, slot, ...rest } = props;
   const classes = useStyles();
   const classNameString = clsx(
     classes.text,
@@ -35,10 +34,8 @@ const Text = forwardRef((props: TextPropTypes, ref: Ref<HTMLSpanElement>) => {
     className
   );
 
-  const passThroughProps = usePassThroughHtmlProps(props);
-
   return (
-    <span ref={ref} style={style} className={classNameString} title={tooltip} slot={slot} {...passThroughProps}>
+    <span ref={ref} style={style} className={classNameString} title={tooltip} slot={slot} {...rest}>
       {children}
     </span>
   );

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -12,7 +12,6 @@ import React, {
   ReactElement,
   ReactFragment,
   ReactNode,
-  ReactNodeArray,
   Ref,
   RefObject,
   useCallback,
@@ -31,7 +30,7 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
   /**
    * Defines the content of the `Toolbar`.
    */
-  children?: ReactNode | ReactNodeArray | ReactFragment;
+  children?: ReactNode | ReactNode[] | ReactFragment;
   /**
    * Defines the visual style of the `Toolbar`.<br />
    * <b>Note:</b> The visual styles are theme-dependent.

--- a/packages/main/src/components/ToolbarSeparator/index.tsx
+++ b/packages/main/src/components/ToolbarSeparator/index.tsx
@@ -1,4 +1,4 @@
-import { useI18nBundle, usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
+import { useI18nBundle } from '@ui5/webcomponents-react-base/dist/hooks';
 import { createUseStyles } from 'react-jss';
 import { CssSizeVariables } from '@ui5/webcomponents-react-base/dist/CssSizeVariables';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
@@ -20,20 +20,13 @@ const useStyles = createUseStyles(styles, { name: 'ToolbarSeparator' });
 export type ToolbarSeparatorPropTypes = CommonProps;
 
 const ToolbarSeparator = forwardRef((props: ToolbarSeparatorPropTypes, ref: Ref<HTMLDivElement>) => {
-  const { style, className } = props;
+  const { style, className, ...rest } = props;
   const classes = useStyles();
   const separatorClasses = clsx(classes.separator, className);
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
-  const passThroughProps = usePassThroughHtmlProps(props);
 
   return (
-    <div
-      ref={ref}
-      style={style}
-      className={separatorClasses}
-      aria-label={i18nBundle.getText(SEPARATOR)}
-      {...passThroughProps}
-    />
+    <div ref={ref} style={style} className={separatorClasses} aria-label={i18nBundle.getText(SEPARATOR)} {...rest} />
   );
 });
 ToolbarSeparator.displayName = 'ToolbarSeparator';

--- a/packages/main/src/components/ToolbarSpacer/index.tsx
+++ b/packages/main/src/components/ToolbarSpacer/index.tsx
@@ -1,12 +1,10 @@
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/hooks';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { forwardRef, Ref } from 'react';
 
 export type ToolbarSpacerPropTypes = CommonProps;
 
 const ToolbarSpacer = forwardRef((props: ToolbarSpacerPropTypes, ref: Ref<HTMLSpanElement>) => {
-  const passThroughProps = usePassThroughHtmlProps(props);
-  return <span ref={ref} style={{ flexGrow: 1 }} className="spacer" {...passThroughProps} />;
+  return <span ref={ref} style={{ flexGrow: 1 }} className="spacer" {...props} />;
 });
 
 ToolbarSpacer.displayName = 'ToolbarSpacer';

--- a/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
+++ b/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
@@ -17,16 +17,7 @@ import { ButtonDesign } from '@ui5/webcomponents-react/dist/ButtonDesign';
 import { Dialog, DialogDomRef } from '@ui5/webcomponents-react/dist/Dialog';
 import { Table } from '@ui5/webcomponents-react/dist/Table';
 import { TableColumn } from '@ui5/webcomponents-react/dist/TableColumn';
-import React, {
-  Children,
-  ComponentElement,
-  MouseEventHandler,
-  ReactNode,
-  ReactNodeArray,
-  useEffect,
-  useRef,
-  useState
-} from 'react';
+import React, { Children, ComponentElement, MouseEventHandler, ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ManageViewsTableRows } from './MangeViewsTableRows';
 import { VariantItemPropTypes } from './VariantItem';
@@ -43,7 +34,7 @@ addCustomCSS(
 );
 
 interface ManageViewsDialogPropTypes {
-  children: ReactNode | ReactNodeArray;
+  children: ReactNode | ReactNode[];
   onAfterClose: any;
   handleSaveManageViews: (
     e: MouseEventHandler<HTMLElement>,

--- a/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
+++ b/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, getByText, render, renderWithDefine, screen, waitFor, within } from '@shared/tests';
-import { createPassThroughPropsTest } from '@shared/tests/utils';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { VariantManagement } from '@ui5/webcomponents-react/dist/VariantManagement';
 import React from 'react';
 import { TitleLevel } from '../..';
@@ -487,5 +487,5 @@ describe('VariantManagement', () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
-  createPassThroughPropsTest(VariantManagement);
+  createCustomPropsTest(VariantManagement);
 });

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -39,7 +39,6 @@ import React, {
   forwardRef,
   isValidElement,
   ReactNode,
-  ReactNodeArray,
   Ref,
   useCallback,
   useEffect,
@@ -65,7 +64,7 @@ export interface VariantManagementPropTypes extends Omit<CommonProps, 'onSelect'
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `VariantItem` in order to preserve the intended design.
    */
-  children?: ReactNode | ReactNodeArray;
+  children?: ReactNode | ReactNode[];
   /**
    * Determines on which side the VariantManagement popover is placed at.
    */

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -4,7 +4,6 @@ import '@ui5/webcomponents-icons/dist/navigation-down-arrow.js';
 import '@ui5/webcomponents-icons/dist/search.js';
 import { useI18nBundle } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { usePassThroughHtmlProps } from '@ui5/webcomponents-react-base/dist/usePassThroughHtmlProps';
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import {
   CANCEL,
@@ -245,7 +244,8 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
     dirtyState,
     showCancelButton,
     onSave,
-    portalContainer
+    portalContainer,
+    ...rest
   } = props;
 
   const classes = useStyles();
@@ -441,10 +441,8 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
 
   const showSaveBtn = dirtyState && !selectedVariant?.readOnly;
 
-  const passThroughProps = usePassThroughHtmlProps(props, ['onSelect', 'onSaveAs', 'onSaveManageViews', 'onSave']);
-
   return (
-    <div className={variantManagementClasses} style={style} title={tooltip} {...passThroughProps} ref={ref}>
+    <div className={variantManagementClasses} style={style} title={tooltip} {...rest} ref={ref}>
       <VariantManagementContext.Provider
         value={{
           selectVariantItem: setSelectedVariant

--- a/shared/tests/utils.tsx
+++ b/shared/tests/utils.tsx
@@ -9,7 +9,7 @@ export const modifyObjectProperty = (object: any, attr: string, value: any) => {
   });
 };
 
-export const createPassThroughPropsTest = (Component: ComponentType<any>, props = {}) => {
+export const createCustomPropsTest = (Component: ComponentType<any>, props = {}) => {
   test('Pass Through HTML Standard Props', () => {
     render(
       <Component
@@ -17,9 +17,9 @@ export const createPassThroughPropsTest = (Component: ComponentType<any>, props 
         data-special-test-prop="data-prop"
         aria-labelledby="aria-prop"
         id="element-id"
-        disabled-custom-prop
         className="thisClassIsUsedForTestingPurposesOnly"
         style={{ pointerEvents: 'none' }}
+        customattribute="true"
         {...props}
       />
     );
@@ -35,7 +35,7 @@ export const createPassThroughPropsTest = (Component: ComponentType<any>, props 
     if (Component.displayName !== 'ObjectPageSection' && Component.displayName !== 'ObjectPageSubSection') {
       expect(element.id).toBe('element-id');
     }
-    expect(element.hasAttribute('disabled-custom-prop')).toBeFalsy();
+    expect(element.hasAttribute('customattribute')).toBeTruthy();
   });
 };
 


### PR DESCRIPTION
This PR marks `usePassThroughHtmlProps` as deprecated and replaces it with the spread/rest syntax. Also it replaces `createPassThroughPropsTest` with `createCustomPropsTest`.

Closes #2211
Fixes #2358