### PR TITLE
feat(DynamicPageTitle): add `onToolbarOverflowChange` callback/prop

### DIFF
--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -68,6 +68,15 @@ export interface DynamicPageTitlePropTypes extends CommonProps {
    * Display the `subHeader` on the right instead of below the `header`.
    */
   showSubHeaderRight?: boolean;
+  /**
+   * Fired when the content of the `actions` or `navigationActions` toolbar overflow popover has been changed.
+   */
+  onToolbarOverflowChange?: (event: {
+    toolbarElements: HTMLElement[];
+    overflowElements: HTMLCollection;
+    target: HTMLElement;
+    origin: 'actions' | 'navigationActions';
+  }) => void;
 }
 
 interface InternalProps extends DynamicPageTitlePropTypes {
@@ -86,7 +95,6 @@ const useStyles = createUseStyles(DynamicPageTitleStyles, { name: 'DynamicPageTi
 const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<HTMLDivElement>) => {
   const {
     actions,
-    onToggleHeaderContentVisibility,
     breadcrumbs,
     children,
     header,
@@ -96,6 +104,8 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     className,
     style,
     tooltip,
+    onToggleHeaderContentVisibility,
+    onToolbarOverflowChange,
     ...rest
   } = props as InternalProps;
 
@@ -153,6 +163,16 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
 
   const paddingLeftRtl = isRtl ? 'paddingRight' : 'paddingLeft';
 
+  const handleToolbarsOverflowChange = (e) => {
+    if (typeof onToolbarOverflowChange === 'function') {
+      let origin = 'actions';
+      if (e.target.dataset.componentName === 'DynamicPageTitleNavActions') {
+        origin = 'navigationActions';
+      }
+      onToolbarOverflowChange({ ...e, origin });
+    }
+  };
+
   return (
     <FlexBox
       className={containerClasses}
@@ -178,6 +198,7 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
               className={classes.toolbar}
               onClick={stopPropagation}
               data-component-name="DynamicPageTitleNavActions"
+              onOverflowChange={handleToolbarsOverflowChange}
             >
               <ActionsSpacer onClick={onHeaderClick} noHover={props?.['data-not-clickable']} />
               {navigationActions}
@@ -219,6 +240,7 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
             className={classes.toolbar}
             onClick={stopPropagation}
             data-component-name="DynamicPageTitleActions"
+            onOverflowChange={handleToolbarsOverflowChange}
           >
             <ActionsSpacer onClick={onHeaderClick} noHover={props?.['data-not-clickable']} />
             {actions}

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -64,7 +64,11 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
   /**
    * Fired when the content of the overflow popover has changed.
    */
-  onOverflowChange?: (event: { toolbarElements: HTMLElement[]; overflowElements: HTMLCollection }) => void;
+  onOverflowChange?: (event: {
+    toolbarElements: HTMLElement[];
+    overflowElements: HTMLCollection;
+    target: HTMLElement;
+  }) => void;
 }
 
 /**
@@ -220,9 +224,13 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
       if (toolbarChildren?.length > 0) {
         toolbarElements = Array.from(toolbarChildren).filter((item, index) => index <= lastVisibleIndex);
       }
-      onOverflowChange({ toolbarElements: toolbarElements, overflowElements: overflowElements });
+      onOverflowChange({
+        toolbarElements: toolbarElements,
+        overflowElements: overflowElements,
+        target: outerContainer.current
+      });
     }
-  }, [lastVisibleIndex, onOverflowChange]);
+  }, [lastVisibleIndex]);
 
   const CustomTag = as as React.ElementType;
   return (


### PR DESCRIPTION
This PR adds the `onToolbarOverflowChange` callback to the `DynamicPageTitle` component. The callback is fired when the content  of one of the toolbars overflow popover changes. All properties of `onOverflowChange` are inherited and `origin`, which can be used to easily identify which toolbar has fired the corresponding event, is added.

Additionally the `target` property has been incorporated in the `onOverflowChange` event of the `Toolbar`.

Closes #2375