### PR TITLE
fix(DynamicPage): correctly display footer in FCL

### DIFF
--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -1,7 +1,7 @@
 import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
 import { useResponsiveContentPadding, useSyncRef } from '@ui5/webcomponents-react-base/dist/hooks';
 import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
-import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
+import { debounce, enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils';
 import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
 import { GlobalStyleClasses } from '@ui5/webcomponents-react/dist/GlobalStyleClasses';
 import { PageBackgroundDesign } from '@ui5/webcomponents-react/dist/PageBackgroundDesign';
@@ -132,12 +132,12 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([element]) => {
+      debounce(([element]) => {
         setIsOverflowing(!element.isIntersecting);
-      },
+      }, 250),
       {
         root: dynamicPageRef.current,
-        threshold: 1,
+        threshold: 0.98,
         rootMargin: '0px 0px -60px 0px' // negative bottom margin for footer height
       }
     );


### PR DESCRIPTION
In some cases the observed element of the IntersectionObserver was not 100% intersecting (~0.99xxx), to prevent this the threshold was adjusted to `0.98`. Also the intersection observer is now debounced.

Fixes #2200