### PR TITLE
fix: use fully specified paths for all web component imports

### DIFF
--- a/packages/cra-template-seed/template/src/index.js
+++ b/packages/cra-template-seed/template/src/index.js
@@ -1,7 +1,7 @@
 import '@ui5/webcomponents/dist/Assets.js';
 import '@ui5/webcomponents-fiori/dist/Assets.js';
-import '@ui5/webcomponents-react/dist/Assets';
-import '@ui5/webcomponents/dist/features/InputElementsFormSupport';
+import '@ui5/webcomponents-react/dist/Assets.js';
+import '@ui5/webcomponents/dist/features/InputElementsFormSupport.js';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/cra-template/template/src/index.js
+++ b/packages/cra-template/template/src/index.js
@@ -1,6 +1,6 @@
 import '@ui5/webcomponents/dist/Assets.js';
 import '@ui5/webcomponents-fiori/dist/Assets.js';
-import '@ui5/webcomponents-react/dist/Assets';
+import '@ui5/webcomponents-react/dist/Assets.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
+++ b/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
@@ -1,3 +1,5 @@
+import { isPhone, isTablet } from '@ui5/webcomponents-base/dist/Device.js';
+import { addCustomCSS } from '@ui5/webcomponents-base/dist/Theming.js';
 import '@ui5/webcomponents-icons/dist/decline.js';
 import '@ui5/webcomponents-icons/dist/favorite.js';
 import '@ui5/webcomponents-icons/dist/unfavorite.js';
@@ -21,8 +23,6 @@ import React, { Children, ComponentElement, MouseEventHandler, ReactNode, useEff
 import { createPortal } from 'react-dom';
 import { ManageViewsTableRows } from './MangeViewsTableRows';
 import { VariantItemPropTypes } from './VariantItem';
-import { addCustomCSS } from '@ui5/webcomponents-base/dist/Theming';
-import { isPhone, isTablet } from '@ui5/webcomponents-base/dist/Device';
 
 addCustomCSS(
   'ui5-dialog',


### PR DESCRIPTION
Not using fully specified paths might cause issues in e.g. rollup builds.