### PR TITLE
feat(MessageBox): allow passing `Button`s as actions

### DIFF
--- a/packages/main/src/components/MessageBox/MessageBox.stories.mdx
+++ b/packages/main/src/components/MessageBox/MessageBox.stories.mdx
@@ -169,7 +169,12 @@ const MessageBoxComponent = () => {
 ## MessageBox with custom actions
 
 <Canvas>
-  <Story name="With Custom Action">
+  <Story
+    name="With Custom Action"
+    args={{
+      actions: [MessageBoxActions.OK, 'Custom Action', MessageBoxActions.Cancel, <Button>Custom Button</Button>]
+    }}
+  >
     {(args) => {
       const [open, setOpen] = useState(false);
       const onButtonClick = () => {
@@ -185,12 +190,7 @@ const MessageBoxComponent = () => {
       return (
         <>
           <Button onClick={onButtonClick}>Open Messagebox</Button>
-          <MessageBox
-            {...args}
-            open={open}
-            onClose={handleClose}
-            actions={[MessageBoxActions.OK, 'Custom Action', MessageBoxActions.Cancel]}
-          />
+          <MessageBox {...args} open={open} onClose={handleClose} />
         </>
       );
     }}

--- a/packages/main/src/components/MessageBox/MessageBox.test.tsx
+++ b/packages/main/src/components/MessageBox/MessageBox.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@shared/tests';
 import '@ui5/webcomponents-icons/dist/add.js';
 import { Icon } from '@ui5/webcomponents-react/dist/Icon';
 import { MessageBox } from '@ui5/webcomponents-react/dist/MessageBox';
+import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { MessageBoxActions } from '@ui5/webcomponents-react/dist/MessageBoxActions';
 import { MessageBoxTypes } from '@ui5/webcomponents-react/dist/MessageBoxTypes';
 import React from 'react';
@@ -34,6 +35,56 @@ describe('MessageBox', () => {
 
     expect(callback.mock.calls[0][0].detail.action).toEqual(buttonText);
     unmount();
+  });
+
+  test('Custom Button', () => {
+    const click = jest.fn();
+    const close = jest.fn();
+    const { asFragment, getByText, container, rerender, getByTestId } = render(
+      <MessageBox
+        open
+        onClose={close}
+        actions={[
+          <Button onClick={click} key="0">
+            Custom
+          </Button>
+        ]}
+      >
+        My Message Box Content
+      </MessageBox>
+    );
+    mockActionIds(container);
+    expect(asFragment()).toMatchSnapshot();
+
+    fireEvent.click(getByText('Custom'));
+    expect(close.mock.calls[0][0].detail.action).toEqual('0: custom action');
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MessageBox
+        open
+        onClose={close}
+        actions={[
+          MessageBoxActions.Cancel,
+          <Button onClick={click} key="0">
+            Custom
+          </Button>,
+          'Custom Text Action',
+          MessageBoxActions.OK
+        ]}
+      >
+        My Message Box Content
+      </MessageBox>
+    );
+
+    getByText('Cancel');
+    getByText('Custom Text Action');
+    getByText('OK');
+    fireEvent.click(getByText('Custom'));
+    expect(close.mock.calls[1][0].detail.action).toEqual('1: custom action');
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(click).toHaveBeenCalledTimes(2);
   });
 
   test('Confirm - Cancel', () => {
@@ -187,6 +238,7 @@ describe('MessageBox', () => {
 
     expect(dialogInitialFocus).toEqual(cancelBtnId);
   });
+
   test('display custom header', () => {
     const { getByText, queryByText } = render(
       <MessageBox open header={<div>Custom Header</div>}>

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MessageBox Confirm - Cancel 1`] = `
     accessible-name="Confirmation Confirm"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 128; display: flex; top: 384px; left: 512px;"
+    style="z-index: 132; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header
@@ -178,7 +178,7 @@ exports[`MessageBox Custom Button 1`] = `
     accessible-name="Confirmation My Message Box Content"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 104; display: flex; top: 384px; left: 512px;"
+    style="z-index: 128; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header
@@ -228,7 +228,7 @@ exports[`MessageBox Don't crash on unknown type 1`] = `
     accessible-name=" Unknown Type!"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 144; display: flex; top: 384px; left: 512px;"
+    style="z-index: 148; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header
@@ -419,7 +419,7 @@ exports[`MessageBox No Title 1`] = `
     accessible-name="Confirmation No Title"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 140; display: flex; top: 384px; left: 512px;"
+    style="z-index: 144; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header
@@ -525,7 +525,7 @@ exports[`MessageBox Show 1`] = `
     accessible-name="Custom Custom"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 132; display: flex; top: 384px; left: 512px;"
+    style="z-index: 136; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header
@@ -633,7 +633,7 @@ exports[`MessageBox Success w/ custom title 1`] = `
     accessible-name="Custom Success Custom Success"
     class="MessageBox-messageBox"
     opened=""
-    style="z-index: 136; display: flex; top: 384px; left: 512px;"
+    style="z-index: 140; display: flex; top: 384px; left: 512px;"
     ui5-dialog=""
   >
     <header

--- a/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
+++ b/packages/main/src/components/MessageBox/__snapshots__/MessageBox.test.tsx.snap
@@ -172,6 +172,56 @@ exports[`MessageBox Custom Action Text 1`] = `
 </DocumentFragment>
 `;
 
+exports[`MessageBox Custom Button 1`] = `
+<DocumentFragment>
+  <ui5-dialog
+    accessible-name="Confirmation My Message Box Content"
+    class="MessageBox-messageBox"
+    opened=""
+    style="z-index: 104; display: flex; top: 384px; left: 512px;"
+    ui5-dialog=""
+  >
+    <header
+      class="MessageBox-header"
+      data-type="Confirm"
+      slot="header"
+    >
+      <ui5-icon
+        name="question-mark"
+        ui5-icon=""
+      />
+      <span
+        class="MessageBox-spacer"
+      />
+      <ui5-title
+        level="H2"
+        ui5-title=""
+      >
+        Confirmation
+      </ui5-title>
+    </header>
+    <span
+      class="Text-text MessageBox-content"
+    >
+      My Message Box Content
+    </span>
+    <footer
+      class="MessageBox-footer"
+      slot="footer"
+    >
+      <ui5-button
+        data-action="0: custom action"
+        design="Default"
+        id="0"
+        ui5-button=""
+      >
+        Custom
+      </ui5-button>
+    </footer>
+  </ui5-dialog>
+</DocumentFragment>
+`;
+
 exports[`MessageBox Don't crash on unknown type 1`] = `
 <DocumentFragment>
   <ui5-dialog

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -49,7 +49,6 @@ import { stopPropagation } from '../../internal/stopPropagation';
 import styles from './MessageBox.jss';
 
 type MessageBoxAction = MessageBoxActions | keyof typeof MessageBoxActions | string;
-type MessageBoxActionWithComponent = MessageBoxAction | ReactNode;
 
 export interface MessageBoxPropTypes
   extends Omit<DialogPropTypes, 'children' | 'footer' | 'headerText' | 'onAfterClose'> {
@@ -72,7 +71,7 @@ export interface MessageBoxPropTypes
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `MessageBoxAction`s (text) or the `Button` component in order to preserve the intended.
    */
-  actions?: MessageBoxActionWithComponent[];
+  actions?: (MessageBoxAction | ReactNode)[];
   /**
    * Specifies which action of the created dialog will be emphasized.
    *

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -23,7 +23,7 @@ import {
   WARNING,
   YES
 } from '@ui5/webcomponents-react/dist/assets/i18n/i18n-defaults';
-import { Button } from '@ui5/webcomponents-react/dist/Button';
+import { Button, ButtonPropTypes } from '@ui5/webcomponents-react/dist/Button';
 import { ButtonDesign } from '@ui5/webcomponents-react/dist/ButtonDesign';
 import { Dialog, DialogPropTypes, DialogDomRef } from '@ui5/webcomponents-react/dist/Dialog';
 import { Icon } from '@ui5/webcomponents-react/dist/Icon';
@@ -34,12 +34,22 @@ import { Title } from '@ui5/webcomponents-react/dist/Title';
 import { TitleLevel } from '@ui5/webcomponents-react/dist/TitleLevel';
 import { Ui5CustomEvent } from '@ui5/webcomponents-react/interfaces/Ui5CustomEvent';
 import clsx from 'clsx';
-import React, { forwardRef, isValidElement, ReactNode, Ref, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  Ref,
+  useEffect,
+  useState
+} from 'react';
 import { createUseStyles } from 'react-jss';
 import { stopPropagation } from '../../internal/stopPropagation';
 import styles from './MessageBox.jss';
 
 type MessageBoxAction = MessageBoxActions | keyof typeof MessageBoxActions | string;
+type MessageBoxActionWithComponent = MessageBoxAction | ReactNode;
 
 export interface MessageBoxPropTypes
   extends Omit<DialogPropTypes, 'children' | 'footer' | 'headerText' | 'onAfterClose'> {
@@ -59,8 +69,10 @@ export interface MessageBoxPropTypes
   children: ReactNode | ReactNode[];
   /**
    * Array of actions of the MessageBox. Those actions will be transformed into buttons in the `MessageBox` footer.
+   *
+   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `MessageBoxAction`s (text) or the `Button` component in order to preserve the intended.
    */
-  actions?: MessageBoxAction[];
+  actions?: MessageBoxActionWithComponent[];
   /**
    * Specifies which action of the created dialog will be emphasized.
    *
@@ -95,8 +107,47 @@ export interface MessageBoxPropTypes
 
 const useStyles = createUseStyles(styles, { name: 'MessageBox' });
 
-const createUniqueIds = (internalActions) =>
-  internalActions.map((_) => `${performance.now() + Math.random()}`.split('.')[1]);
+const createUniqueIds = (internalActions) => {
+  return internalActions.map((action) => {
+    if (typeof action === 'string') {
+      return `${performance.now() + Math.random()}`.split('.')[1];
+    }
+    return null;
+  });
+};
+
+const getIcon = (icon, type) => {
+  if (isValidElement(icon)) return icon;
+  switch (type) {
+    case MessageBoxTypes.Confirm:
+      return <Icon name="question-mark" />;
+    case MessageBoxTypes.Error:
+      return <Icon name="message-error" />;
+    case MessageBoxTypes.Information:
+      return <Icon name="message-information" />;
+    case MessageBoxTypes.Success:
+      return <Icon name="message-success" />;
+    case MessageBoxTypes.Warning:
+      return <Icon name="message-warning" />;
+    case MessageBoxTypes.Highlight:
+      return <Icon name="hint" />;
+    default:
+      return null;
+  }
+};
+
+const getActions = (actions, type) => {
+  if (actions && actions.length > 0) {
+    return actions;
+  }
+  if (type === MessageBoxTypes.Confirm) {
+    return [MessageBoxActions.OK, MessageBoxActions.Cancel];
+  }
+  if (type === MessageBoxTypes.Error) {
+    return [MessageBoxActions.Close];
+  }
+  return [MessageBoxActions.OK];
+};
 
 /**
  * The `MessageBox` component provides easier methods to create a `Dialog`, such as standard alerts, confirmation dialogs, or arbitrary message dialogs.
@@ -123,26 +174,6 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
   const [componentRef, dialogRef] = useSyncRef<DialogDomRef>(ref);
 
   const classes = useStyles();
-
-  const iconToRender = useMemo(() => {
-    if (isValidElement(icon)) return icon;
-    switch (type) {
-      case MessageBoxTypes.Confirm:
-        return <Icon name="question-mark" />;
-      case MessageBoxTypes.Error:
-        return <Icon name="message-error" />;
-      case MessageBoxTypes.Information:
-        return <Icon name="message-information" />;
-      case MessageBoxTypes.Success:
-        return <Icon name="message-success" />;
-      case MessageBoxTypes.Warning:
-        return <Icon name="message-warning" />;
-      case MessageBoxTypes.Highlight:
-        return <Icon name="hint" />;
-      default:
-        return null;
-    }
-  }, [icon, type]);
 
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
 
@@ -180,27 +211,11 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
     }
   };
 
-  const getActions = () => {
-    if (actions && actions.length > 0) {
-      return actions;
-    }
-    if (type === MessageBoxTypes.Confirm) {
-      return [MessageBoxActions.OK, MessageBoxActions.Cancel];
-    }
-    if (type === MessageBoxTypes.Error) {
-      return [MessageBoxActions.Close];
-    }
-    return [MessageBoxActions.OK];
+  const handleOnClose = (e) => {
+    const { action } = e.target.dataset;
+    stopPropagation(e);
+    onClose(enrichEventWithDetails(e, { action }));
   };
-
-  const handleOnClose = useCallback(
-    (e) => {
-      const { action } = e.target.dataset;
-      stopPropagation(e);
-      onClose(enrichEventWithDetails(e, { action }));
-    },
-    [onClose]
-  );
 
   useEffect(() => {
     if (dialogRef.current) {
@@ -213,7 +228,7 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
   }, [dialogRef.current, open]);
 
   const messageBoxClassNames = clsx(classes.messageBox, className);
-  const internalActions = getActions();
+  const internalActions = getActions(actions, type);
 
   const [uniqueIds, setUniqueIds] = useState(() => createUniqueIds(internalActions));
   useIsomorphicLayoutEffect(() => {
@@ -222,11 +237,13 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
 
   const getInitialFocus = () => {
     const indexOfInitialFocus = internalActions.indexOf(initialFocus);
-    if (~indexOfInitialFocus) {
+    if (~indexOfInitialFocus && typeof internalActions[indexOfInitialFocus] === 'string') {
       return `${internalActions[indexOfInitialFocus]}-${uniqueIds[indexOfInitialFocus]}`;
     }
     return initialFocus;
   };
+
+  const iconToRender = getIcon(icon, type);
 
   // @ts-ignore
   const { footer, headerText, title, onAfterClose, ...restWithoutOmitted } = rest;
@@ -252,17 +269,30 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
       )}
       <Text className={classes.content}>{children}</Text>
       <footer slot="footer" className={classes.footer}>
-        {internalActions.map((action, index) => (
-          <Button
-            id={`${action}-${uniqueIds[index]}`}
-            key={`${action}-${index}`}
-            design={emphasizedAction === action ? ButtonDesign.Emphasized : ButtonDesign.Transparent}
-            onClick={handleOnClose}
-            data-action={action}
-          >
-            {actionTranslations[action] ?? action}
-          </Button>
-        ))}
+        {internalActions.map((action, index) => {
+          if (typeof action !== 'string' && isValidElement(action)) {
+            return cloneElement<ButtonPropTypes | { 'data-action': string }>(action, {
+              onClick: (action as ReactElement<ButtonPropTypes>)?.props?.onClick
+                ? (e) => {
+                    (action as ReactElement<ButtonPropTypes>)?.props?.onClick(e);
+                    handleOnClose(e);
+                  }
+                : handleOnClose,
+              'data-action': action?.props?.['data-action'] ?? `${index}: custom action`
+            });
+          }
+          return (
+            <Button
+              id={`${action}-${uniqueIds[index]}`}
+              key={`${action}-${index}`}
+              design={emphasizedAction === action ? ButtonDesign.Emphasized : ButtonDesign.Transparent}
+              onClick={handleOnClose}
+              data-action={action}
+            >
+              {actionTranslations[action] ?? action}
+            </Button>
+          );
+        })}
       </footer>
     </Dialog>
   );


### PR DESCRIPTION
This PR enhances the MessageBox by allowing `Button` components to be passed to the "actions" array. 

Closes #2424 