### PR TITLE
feat(RadialChart): introduce `chartConfig` & `displayValueStyle` prop, adjust default margin of internal chart

### DIFF
--- a/packages/charts/src/components/RadialChart/RadialChart.stories.mdx
+++ b/packages/charts/src/components/RadialChart/RadialChart.stories.mdx
@@ -2,6 +2,11 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { DocsHeader } from '@docs/DocsHeader';
 import { Footer } from '@docs/Footer';
 import { RadialChart } from '@ui5/webcomponents-react-charts/dist/RadialChart';
+import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
+import { FlexBoxAlignItems } from '@ui5/webcomponents-react/dist/FlexBoxAlignItems';
+import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJustifyContent';
+import { Text } from '@ui5/webcomponents-react/dist/Text';
+import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingParameters';
 
 <Meta
   title="Charts /  RadialChart"
@@ -35,6 +40,43 @@ import { RadialChart } from '@ui5/webcomponents-react-charts/dist/RadialChart';
 <Canvas>
   <Story name="With Custom Color" args={{ color: '#f0ab00' }}>
     {(props) => <RadialChart {...props} />}
+  </Story>
+</Canvas>
+
+### Micro RadialCharts
+
+<Canvas>
+  <Story name="Micro RadialCharts">
+    {() => (
+      <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween} alignItems={FlexBoxAlignItems.Center}>
+        <RadialChart
+          value={50}
+          style={{ height: '50px', width: '50px' }}
+          chartConfig={{ innerRadius: '75%', margin: { top: 0, right: 0, bottom: 0, left: 0 } }}
+          displayValue={'50%'}
+          displayValueStyle={{
+            fontSize: ThemingParameters.sapFontSmallSize,
+            fill: ThemingParameters.sapChart_OrderedColor_1
+          }}
+        />
+        <FlexBox alignItems={FlexBoxAlignItems.Center}>
+          <RadialChart
+            value={50}
+            style={{ width: '25px', height: '25px' }}
+            chartConfig={{ innerRadius: '70%', margin: { top: 0, right: 0, bottom: 0, left: 0 } }}
+          />
+          <Text>50%</Text>
+        </FlexBox>
+        <FlexBox alignItems={FlexBoxAlignItems.Center}>
+          <RadialChart
+            value={50}
+            style={{ height: '16px', width: '16px' }}
+            chartConfig={{ innerRadius: '75%', margin: { top: 0, right: 0, bottom: 0, left: 0 } }}
+          />
+          <Text style={{ fontSize: ThemingParameters.sapFontSmallSize }}>50%</Text>
+        </FlexBox>
+      </FlexBox>
+    )}
   </Story>
 </Canvas>
 

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -3,9 +3,8 @@ import { enrichEventWithDetails } from '@ui5/webcomponents-react-base/dist/Utils
 import { ChartContainer } from '@ui5/webcomponents-react-charts/dist/components/ChartContainer';
 import { PieChartPlaceholder } from '@ui5/webcomponents-react-charts/dist/PieChartPlaceholder';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
+import React, { CSSProperties, FC, forwardRef, Ref } from 'react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
-import { AxisDomain } from 'recharts/types/util/types';
 import { useOnClickInternal } from '../../hooks/useOnClickInternal';
 
 export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'children' | 'onLegendClick'> {
@@ -40,6 +39,12 @@ export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'childre
    * `noAnimation` disables all chart animations when set to `true`.
    */
   noAnimation?: boolean;
+  /**
+   * Defines possible configurations of the chart.
+   *
+   * __Note:__ It is possible to overwrite internally used props. Please use use with caution!
+   */
+  chartConfig?: RadialChartProps;
 }
 
 const radialChartMargin = { right: 30, left: 30, top: 30, bottom: 30 };
@@ -63,29 +68,24 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     tooltip,
     slot,
     noAnimation,
+    chartConfig,
     ...rest
   } = props;
 
-  const range = useMemo<AxisDomain>(() => {
-    return [0, maxValue];
-  }, [maxValue]);
+  const range = [0, maxValue];
+  const dataset = [{ value }];
 
-  const dataset = useMemo(() => [{ value }], [value]);
-
-  const onDataPointClickInternal = useCallback(
-    (payload, i, event) => {
-      if (payload && onDataPointClick) {
-        onDataPointClick(
-          enrichEventWithDetails(event, {
-            value: payload.value,
-            payload: payload.payload,
-            dataIndex: i
-          })
-        );
-      }
-    },
-    [onDataPointClick]
-  );
+  const onDataPointClickInternal = (payload, i, event) => {
+    if (payload && onDataPointClick) {
+      onDataPointClick(
+        enrichEventWithDetails(event, {
+          value: payload.value,
+          payload: payload.payload,
+          dataIndex: i
+        })
+      );
+    }
+  };
 
   const onClickInternal = useOnClickInternal(onClick);
 
@@ -94,11 +94,11 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
       dataset={dataset}
       ref={ref}
       Placeholder={PieChartPlaceholder}
-      style={style}
       className={className}
       tooltip={tooltip}
       slot={slot}
       resizeDebounce={250}
+      style={style}
       {...rest}
     >
       <RadialBarChart
@@ -112,15 +112,14 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
         cy="50%"
         startAngle={90}
         endAngle={-270}
+        {...chartConfig}
       >
         <PolarAngleAxis type="number" domain={range} tick={false} />
         <RadialBar
           isAnimationActive={noAnimation === false}
           background={radialBarBackground}
           dataKey="value"
-          cornerRadius="50%"
           fill={color ?? ThemingParameters.sapChart_OrderedColor_1}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           onClick={onDataPointClickInternal}
         />

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -16,7 +16,7 @@ export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'childre
   /**
    * The maximum value of the ring. If `value` >= `maxValue`, the ring will be filled to 100%.
    *
-   * Defaults to `100`.
+   * __Default:__ `100`.
    */
   maxValue?: number;
   /**
@@ -24,34 +24,58 @@ export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'childre
    */
   displayValue?: number | string;
   /**
+   * Font size of the `displayValue`.
+   *
+   * __Default values:__
+   *
+   * - fontSize: `1.25rem`
+   * - fill: `ThemingParameters.sapTextColor`
+   */
+  displayValueStyle?: CSSProperties;
+  /**
    * A custom color you want to apply to the ring fill. This props accepts any valid CSS color or CSS variable.
    */
   color?: CSSProperties['color'];
   /**
    * `onDataPointClick` fires when the user clicks on the filled part of the ring.
-   * @param event
    */
-  onDataPointClick?: (event: CustomEvent<{ value: unknown; payload: unknown; dataIndex: number }>) => void;
+  onDataPointClick?: (event: CustomEvent<{ value: number; payload: unknown; dataIndex: number }>) => void;
   /**
    * Fired when clicked anywhere in the chart.
    */
-  onClick?: (event: CustomEvent<{ payload: unknown; activePayloads: Record<string, unknown>[] }>) => void;
+  onClick?: (
+    event: CustomEvent<{
+      payload: unknown;
+      activePayloads: Record<string, unknown>[];
+      dataIndex: number;
+      value: number;
+    }>
+  ) => void;
   /**
    * `noAnimation` disables all chart animations when set to `true`.
    */
   noAnimation?: boolean;
   /**
-   * Defines possible configurations of the chart.
+   * Defines possible configurations of the internally used [RadialBarChart](https://recharts.org/en-US/api/RadialBarChart).
    *
-   * __Note:__ It is possible to overwrite internally used props. Please use use with caution!
+   * __Note:__ It is possible to overwrite internally used props. Please use with caution!
+   *
+   * __Default values:__
+   *
+   * - margin: `{ top: 5, right: 5, bottom: 5, left: 5 }`
+   * - innerRadius: `"90%"`
+   * - outerRadius: `"100%"`
    */
-  chartConfig?: RadialChartProps;
+  chartConfig?: typeof RadialBarChart;
 }
 
-const radialChartMargin = { right: 30, left: 30, top: 30, bottom: 30 };
 const radialBarBackground = { fill: ThemingParameters.sapContent_ImagePlaceholderBackground };
-const radialBarLabelStyle = { fontSize: ThemingParameters.sapFontHeader3Size, fill: ThemingParameters.sapTextColor };
 
+const defaultDisplayValueStyles = {
+  fontSize: '1.25rem',
+  fill: ThemingParameters.sapTextColor,
+  fontFamily: ThemingParameters.sapFontFamily
+};
 /**
  * Displays a ring chart highlighting a current status.
  * The status can be emphasized by using the `color` prop.
@@ -70,6 +94,7 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     slot,
     noAnimation,
     chartConfig,
+    displayValueStyle,
     ...rest
   } = props;
 
@@ -106,7 +131,6 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     >
       <RadialBarChart
         onClick={onClickInternal}
-        margin={radialChartMargin}
         innerRadius="90%"
         outerRadius="100%"
         barSize={10}
@@ -123,19 +147,20 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
           background={radialBarBackground}
           dataKey="value"
           fill={color ?? ThemingParameters.sapChart_OrderedColor_1}
-          // @ts-ignore
           onClick={onDataPointClickInternal}
         />
-        <text
-          x="50%"
-          y="50%"
-          textAnchor="middle"
-          dominantBaseline="middle"
-          className="progress-label"
-          style={radialBarLabelStyle}
-        >
-          {displayValue}
-        </text>
+        {displayValue && (
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="progress-label"
+            style={{ ...defaultDisplayValueStyles, ...displayValueStyle }}
+          >
+            {displayValue}
+          </text>
+        )}
       </RadialBarChart>
     </ChartContainer>
   );
@@ -143,7 +168,8 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
 
 RadialChart.defaultProps = {
   maxValue: 100,
-  noAnimation: false
+  noAnimation: false,
+  displayValueStyle: defaultDisplayValueStyles
 };
 
 RadialChart.displayName = 'RadialChart';

--- a/packages/charts/src/components/RadialChart/__snapshots__/RadialChart.test.tsx.snap
+++ b/packages/charts/src/components/RadialChart/__snapshots__/RadialChart.test.tsx.snap
@@ -27,10 +27,10 @@ exports[`RadialChart Check onClick events 1`] = `
               id="recharts3-clip"
             >
               <rect
-                height="340"
-                width="340"
-                x="30"
-                y="30"
+                height="390"
+                width="390"
+                x="5"
+                y="5"
               />
             </clippath>
           </defs>
@@ -41,10 +41,10 @@ exports[`RadialChart Check onClick events 1`] = `
               class="recharts-polygon angleAxis"
               cx="200"
               cy="200"
-              d="M200,30L299.9234928897204,62.46711095625892L361.67960777017606,147.46711095625895L361.67960777017606,252.53288904374108L299.9234928897204,337.5328890437411L200,370L100.07650711027958,337.5328890437411L38.32039222982391,252.53288904374108L38.32039222982388,147.46711095625898L100.07650711027955,62.46711095625895L199.99999999999997,30L200,30Z"
+              d="M200,5L314.6181241970323,42.241686096885246L385.45602067755493,139.74168609688525L385.45602067755493,260.25831390311475L314.6181241970323,357.75831390311475L200,395L85.38187580296776,357.75831390311475L14.543979322445068,260.25831390311475L14.54397932244504,139.74168609688527L85.38187580296771,42.241686096885275L199.99999999999997,5L200,5Z"
               fill="none"
               orientation="outer"
-              radius="170"
+              radius="195"
               type="number"
             />
             <g
@@ -59,12 +59,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="200"
                   x2="200"
-                  y1="30"
-                  y2="22"
+                  y1="5"
+                  y2="-3"
                 />
               </g>
               <g
@@ -76,12 +76,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="299.9234928897204"
-                  x2="304.62577490806024"
-                  y1="62.46711095625892"
-                  y2="55.99497500125935"
+                  x1="314.6181241970323"
+                  x2="319.32040621537203"
+                  y1="42.241686096885246"
+                  y2="35.769550141885674"
                 />
               </g>
               <g
@@ -93,12 +93,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="361.67960777017606"
-                  x2="369.2880599005373"
-                  y1="147.46711095625895"
-                  y2="144.99497500125938"
+                  x1="385.45602067755493"
+                  x2="393.06447280791616"
+                  y1="139.74168609688525"
+                  y2="137.26955014188567"
                 />
               </g>
               <g
@@ -110,12 +110,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="361.67960777017606"
-                  x2="369.2880599005373"
-                  y1="252.53288904374108"
-                  y2="255.00502499874065"
+                  x1="385.45602067755493"
+                  x2="393.06447280791616"
+                  y1="260.25831390311475"
+                  y2="262.73044985811435"
                 />
               </g>
               <g
@@ -127,12 +127,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="299.9234928897204"
-                  x2="304.62577490806024"
-                  y1="337.5328890437411"
-                  y2="344.0050249987406"
+                  x1="314.6181241970323"
+                  x2="319.32040621537203"
+                  y1="357.75831390311475"
+                  y2="364.2304498581143"
                 />
               </g>
               <g
@@ -144,12 +144,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="200"
                   x2="200"
-                  y1="370"
-                  y2="378"
+                  y1="395"
+                  y2="403"
                 />
               </g>
               <g
@@ -161,12 +161,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="100.07650711027958"
-                  x2="95.3742250919398"
-                  y1="337.5328890437411"
-                  y2="344.0050249987406"
+                  x1="85.38187580296776"
+                  x2="80.67959378462798"
+                  y1="357.75831390311475"
+                  y2="364.2304498581143"
                 />
               </g>
               <g
@@ -178,12 +178,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="38.32039222982391"
-                  x2="30.71194009946268"
-                  y1="252.53288904374108"
-                  y2="255.00502499874065"
+                  x1="14.543979322445068"
+                  x2="6.935527192083839"
+                  y1="260.25831390311475"
+                  y2="262.73044985811435"
                 />
               </g>
               <g
@@ -195,12 +195,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="38.32039222982388"
-                  x2="30.71194009946265"
-                  y1="147.46711095625898"
-                  y2="144.99497500125938"
+                  x1="14.54397932244504"
+                  x2="6.935527192083811"
+                  y1="139.74168609688527"
+                  y2="137.2695501418857"
                 />
               </g>
               <g
@@ -212,12 +212,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="100.07650711027955"
-                  x2="95.37422509193976"
-                  y1="62.46711095625895"
-                  y2="55.99497500125938"
+                  x1="85.38187580296771"
+                  x2="80.67959378462793"
+                  y1="42.241686096885275"
+                  y2="35.7695501418857"
                 />
               </g>
               <g
@@ -229,12 +229,12 @@ exports[`RadialChart Check onClick events 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="199.99999999999997"
                   x2="199.99999999999997"
-                  y1="30"
-                  y2="22"
+                  y1="5"
+                  y2="-3"
                 />
               </g>
             </g>
@@ -249,14 +249,14 @@ exports[`RadialChart Check onClick events 1`] = `
                 class="recharts-sector recharts-radial-bar-background-sector"
                 cx="200"
                 cy="200"
-                d="M 200,42.5
-    A 157.5,157.5,0,
+                d="M 200,20.25
+    A 179.75,179.75,0,
     1,1,
-    199.99725110642825,42.50000002398863
-  L 199.99742563935345,52.50000002246554
-            A 147.5,147.5,0,
+    199.9968627706697,20.250000027377496
+  L 199.9970373035949,30.250000025854405
+            A 169.75,169.75,0,
             1,0,
-            200,52.5 Z"
+            200,30.25 Z"
                 fill="var(--sapContent_ImagePlaceholderBackground)"
               />
             </g>
@@ -271,7 +271,7 @@ exports[`RadialChart Check onClick events 1`] = `
           <text
             class="progress-label"
             dominant-baseline="middle"
-            style="fill: var(--sapTextColor);"
+            style="font-size: 1.25rem; fill: var(--sapTextColor); font-family: var(--sapFontFamily);"
             text-anchor="middle"
             x="50%"
             y="50%"
@@ -312,10 +312,10 @@ exports[`RadialChart Render chart with data 1`] = `
               id="recharts1-clip"
             >
               <rect
-                height="340"
-                width="340"
-                x="30"
-                y="30"
+                height="390"
+                width="390"
+                x="5"
+                y="5"
               />
             </clippath>
           </defs>
@@ -326,10 +326,10 @@ exports[`RadialChart Render chart with data 1`] = `
               class="recharts-polygon angleAxis"
               cx="200"
               cy="200"
-              d="M200,30L299.9234928897204,62.46711095625892L361.67960777017606,147.46711095625895L361.67960777017606,252.53288904374108L299.9234928897204,337.5328890437411L200,370L100.07650711027958,337.5328890437411L38.32039222982391,252.53288904374108L38.32039222982388,147.46711095625898L100.07650711027955,62.46711095625895L199.99999999999997,30L200,30Z"
+              d="M200,5L314.6181241970323,42.241686096885246L385.45602067755493,139.74168609688525L385.45602067755493,260.25831390311475L314.6181241970323,357.75831390311475L200,395L85.38187580296776,357.75831390311475L14.543979322445068,260.25831390311475L14.54397932244504,139.74168609688527L85.38187580296771,42.241686096885275L199.99999999999997,5L200,5Z"
               fill="none"
               orientation="outer"
-              radius="170"
+              radius="195"
               type="number"
             />
             <g
@@ -344,12 +344,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="200"
                   x2="200"
-                  y1="30"
-                  y2="22"
+                  y1="5"
+                  y2="-3"
                 />
               </g>
               <g
@@ -361,12 +361,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="299.9234928897204"
-                  x2="304.62577490806024"
-                  y1="62.46711095625892"
-                  y2="55.99497500125935"
+                  x1="314.6181241970323"
+                  x2="319.32040621537203"
+                  y1="42.241686096885246"
+                  y2="35.769550141885674"
                 />
               </g>
               <g
@@ -378,12 +378,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="361.67960777017606"
-                  x2="369.2880599005373"
-                  y1="147.46711095625895"
-                  y2="144.99497500125938"
+                  x1="385.45602067755493"
+                  x2="393.06447280791616"
+                  y1="139.74168609688525"
+                  y2="137.26955014188567"
                 />
               </g>
               <g
@@ -395,12 +395,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="361.67960777017606"
-                  x2="369.2880599005373"
-                  y1="252.53288904374108"
-                  y2="255.00502499874065"
+                  x1="385.45602067755493"
+                  x2="393.06447280791616"
+                  y1="260.25831390311475"
+                  y2="262.73044985811435"
                 />
               </g>
               <g
@@ -412,12 +412,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="299.9234928897204"
-                  x2="304.62577490806024"
-                  y1="337.5328890437411"
-                  y2="344.0050249987406"
+                  x1="314.6181241970323"
+                  x2="319.32040621537203"
+                  y1="357.75831390311475"
+                  y2="364.2304498581143"
                 />
               </g>
               <g
@@ -429,12 +429,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="200"
                   x2="200"
-                  y1="370"
-                  y2="378"
+                  y1="395"
+                  y2="403"
                 />
               </g>
               <g
@@ -446,12 +446,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="100.07650711027958"
-                  x2="95.3742250919398"
-                  y1="337.5328890437411"
-                  y2="344.0050249987406"
+                  x1="85.38187580296776"
+                  x2="80.67959378462798"
+                  y1="357.75831390311475"
+                  y2="364.2304498581143"
                 />
               </g>
               <g
@@ -463,12 +463,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="38.32039222982391"
-                  x2="30.71194009946268"
-                  y1="252.53288904374108"
-                  y2="255.00502499874065"
+                  x1="14.543979322445068"
+                  x2="6.935527192083839"
+                  y1="260.25831390311475"
+                  y2="262.73044985811435"
                 />
               </g>
               <g
@@ -480,12 +480,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="38.32039222982388"
-                  x2="30.71194009946265"
-                  y1="147.46711095625898"
-                  y2="144.99497500125938"
+                  x1="14.54397932244504"
+                  x2="6.935527192083811"
+                  y1="139.74168609688527"
+                  y2="137.2695501418857"
                 />
               </g>
               <g
@@ -497,12 +497,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
-                  x1="100.07650711027955"
-                  x2="95.37422509193976"
-                  y1="62.46711095625895"
-                  y2="55.99497500125938"
+                  x1="85.38187580296771"
+                  x2="80.67959378462793"
+                  y1="42.241686096885275"
+                  y2="35.7695501418857"
                 />
               </g>
               <g
@@ -514,12 +514,12 @@ exports[`RadialChart Render chart with data 1`] = `
                   cy="200"
                   fill="none"
                   orientation="outer"
-                  radius="170"
+                  radius="195"
                   type="number"
                   x1="199.99999999999997"
                   x2="199.99999999999997"
-                  y1="30"
-                  y2="22"
+                  y1="5"
+                  y2="-3"
                 />
               </g>
             </g>
@@ -534,14 +534,14 @@ exports[`RadialChart Render chart with data 1`] = `
                 class="recharts-sector recharts-radial-bar-background-sector"
                 cx="200"
                 cy="200"
-                d="M 200,42.5
-    A 157.5,157.5,0,
+                d="M 200,20.25
+    A 179.75,179.75,0,
     1,1,
-    199.99725110642825,42.50000002398863
-  L 199.99742563935345,52.50000002246554
-            A 147.5,147.5,0,
+    199.9968627706697,20.250000027377496
+  L 199.9970373035949,30.250000025854405
+            A 169.75,169.75,0,
             1,0,
-            200,52.5 Z"
+            200,30.25 Z"
                 fill="var(--sapContent_ImagePlaceholderBackground)"
               />
             </g>
@@ -556,7 +556,7 @@ exports[`RadialChart Render chart with data 1`] = `
           <text
             class="progress-label"
             dominant-baseline="middle"
-            style="fill: var(--sapTextColor);"
+            style="font-size: 1.25rem; fill: var(--sapTextColor); font-family: var(--sapFontFamily);"
             text-anchor="middle"
             x="50%"
             y="50%"

--- a/packages/charts/src/internal/ChartContainer.tsx
+++ b/packages/charts/src/internal/ChartContainer.tsx
@@ -75,17 +75,15 @@ const ChartContainer: FC<ContainerProps> = forwardRef((props: ContainerProps, re
   } = props;
   useStyles();
 
-  const internalStyles: CSSProperties = useMemo(() => {
-    return {
-      fontSize: ThemingParameters.sapFontSmallSize,
-      color: ThemingParameters.sapTextColor,
-      fontFamily: ThemingParameters.sapFontFamily,
-      width: '100%',
-      height: '400px',
-      position: 'relative',
-      ...(style ?? {})
-    };
-  }, [style]);
+  const internalStyles: CSSProperties = {
+    fontSize: ThemingParameters.sapFontSmallSize,
+    color: ThemingParameters.sapTextColor,
+    fontFamily: ThemingParameters.sapFontFamily,
+    width: '100%',
+    height: '400px',
+    position: 'relative',
+    ...(style ?? {})
+  };
 
   return (
     <div ref={ref} style={internalStyles} className={className} title={tooltip} slot={slot} {...rest}>


### PR DESCRIPTION
We should make the `RadialBarChart` customizable by users.

Before we merge this PR we should discuss:

- [x] Is it sufficient to only make the `RadialBarChart` customizable or should we also consider other components used by the `RadialChart` (e.g. `PolarAngleAxis`, `RadialBar`)?

- [x] Should we introduce the `chartConfig` prop, or use the recharts props directly on the component by inheriting the corresponding types from recharts?

- [x] Currently I removed `cornerRadius="50%"` on the `RadialBar` as this was creating rounded corners around the "filled" part of the chart. Was this added by design? I couldn't find anything in the specs, so I was just wondering.