### PR TITLE
fix: support `title` attribute by all components

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -37,6 +37,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 const dimensionDefaults = {
   formatter: defaultFormatter
@@ -146,6 +147,8 @@ const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<H
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('BarChart', props.tooltip);
 
   const chartConfig = {
     margin: {},

--- a/packages/charts/src/components/BulletChart/BulletChart.tsx
+++ b/packages/charts/src/components/BulletChart/BulletChart.tsx
@@ -34,6 +34,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { ComparisonLine } from './ComparisonLine';
 
 const dimensionDefaults = {
@@ -141,6 +142,8 @@ const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, r
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('BulletChart', props.tooltip);
 
   const [componentRef, chartRef] = useSyncRef<any>(ref);
 

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -37,6 +37,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -144,6 +145,8 @@ const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, r
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('ColumnChart', props.tooltip);
 
   const chartConfig = {
     yAxisVisible: false,

--- a/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
+++ b/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
@@ -10,6 +10,7 @@ import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -116,6 +117,8 @@ const ColumnChartWithTrend: FC<ColumnChartWithTrendProps> = forwardRef(
       ChartPlaceholder,
       ...rest
     } = props;
+
+    useDeprecationNoticeForTooltip('ColumnChartWithTrend', props.tooltip);
 
     const chartConfig = {
       yAxisVisible: false,

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -36,6 +36,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { getCellColors } from '../../internal/Utils';
 
 const dimensionDefaults = {
@@ -154,6 +155,8 @@ const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartPr
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('ComposedChart', props.tooltip);
 
   const [componentRef, chartRef] = useSyncRef<any>(ref);
 

--- a/packages/charts/src/components/DonutChart/DonutChart.tsx
+++ b/packages/charts/src/components/DonutChart/DonutChart.tsx
@@ -1,4 +1,5 @@
 import React, { FC, forwardRef } from 'react';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { PieChart, PieChartProps } from '../PieChart/PieChart';
 
 /**
@@ -13,6 +14,8 @@ const DonutChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref) => 
     innerRadius: '50%',
     ...props.chartConfig
   };
+
+  useDeprecationNoticeForTooltip('DonutChart', props.tooltip);
 
   return <PieChart {...props} ref={ref} chartConfig={chartConfig} />;
 });

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -32,6 +32,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity, xAxisPadding } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -123,6 +124,8 @@ const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Re
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('LineChart', props.tooltip);
 
   const chartConfig = {
     yAxisVisible: false,

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -10,6 +10,7 @@ import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
 import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends Omit<IChartMeasure, 'color'> {
   /**
@@ -141,6 +142,9 @@ const useStyles = createUseStyles(MicroBarChartStyles, { name: 'MicroBarChart' }
  */
 const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartProps, ref: Ref<HTMLDivElement>) => {
   const { loading, dataset, onDataPointClick, style, className, tooltip, slot, ChartPlaceholder, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('MicroBarChart', props.tooltip);
+
   const classes = useStyles();
 
   const dimension = useMemo<IChartDimension>(

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -12,6 +12,7 @@ import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { IPolarChartConfig } from '../../interfaces/IPolarChartConfig';
 import { defaultFormatter } from '../../internal/defaults';
 import { tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends Omit<IChartMeasure, 'accessor' | 'label' | 'color' | 'hideDataLabel'> {
   /**
@@ -93,6 +94,8 @@ const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<H
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('PieChart', props.tooltip);
 
   const chartConfig = {
     margin: { right: 30, left: 30, bottom: 30, top: 30, ...(props.chartConfig?.margin ?? {}) },

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -22,6 +22,7 @@ import { IChartDimension } from '../../interfaces/IChartDimension';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tooltipContentStyle, tooltipFillOpacity } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends IChartMeasure {
   /**
@@ -93,6 +94,8 @@ const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref:
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('RadarChart', props.tooltip);
 
   const chartConfig = {
     legendPosition: 'bottom',

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -7,6 +7,7 @@ import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import { AxisDomain } from 'recharts/types/util/types';
 import { useOnClickInternal } from '../../hooks/useOnClickInternal';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 export interface RadialChartProps extends Omit<CommonProps, 'onClick' | 'children' | 'onLegendClick'> {
   /**
@@ -65,6 +66,8 @@ const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, r
     noAnimation,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('RadialChart', props.tooltip);
 
   const range = useMemo<AxisDomain>(() => {
     return [0, maxValue];

--- a/packages/charts/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/src/components/ScatterChart/ScatterChart.tsx
@@ -29,6 +29,7 @@ import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
 import { IChartMeasure } from '../../interfaces/IChartMeasure';
 import { defaultFormatter } from '../../internal/defaults';
 import { tickLineConfig, tooltipContentStyle, tooltipFillOpacity, xAxisPadding } from '../../internal/staticProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 interface MeasureConfig extends Omit<IChartMeasure, 'color' | 'hideDataLabel' | 'DataLabel'> {
   /**
@@ -147,6 +148,8 @@ const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps
     children,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('ScatterChart', props.tooltip);
 
   const chartConfig = {
     yAxisVisible: false,

--- a/packages/charts/src/internal/useDeprecationNotiveForTooltip.ts
+++ b/packages/charts/src/internal/useDeprecationNotiveForTooltip.ts
@@ -1,0 +1,10 @@
+import { deprecationNotice } from '@ui5/webcomponents-react-base/dist/Utils';
+import { useEffect } from 'react';
+
+export const useDeprecationNoticeForTooltip = (component, tooltip) => {
+  useEffect(() => {
+    if (tooltip) {
+      deprecationNotice(component, '`tooltip` has been deprecated, please use the native `title` attribute instead.');
+    }
+  }, [tooltip]);
+};

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -19,6 +19,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { ButtonPropTypes } from '../../webComponents/Button';
 import { ResponsivePopoverDomRef, ResponsivePopoverPropTypes } from '../../webComponents/ResponsivePopover';
 import styles from './ActionSheet.jss';
@@ -114,6 +115,9 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Resp
     onBeforeOpen,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('ActionSheet', props.tooltip);
+
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const classes = useStyles();
   const [componentRef, popoverRef] = useSyncRef(ref);

--- a/packages/main/src/components/AnalyticalCard/index.tsx
+++ b/packages/main/src/components/AnalyticalCard/index.tsx
@@ -2,6 +2,7 @@ import { createUseStyles } from 'react-jss';
 import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 import styles from './AnalyticalCard.jss';
 
@@ -22,6 +23,7 @@ const useStyles = createUseStyles(styles, { name: 'AnalyticalCard' });
  */
 const AnalyticalCard = forwardRef((props: AnalyticalCardPropTypes, ref: Ref<HTMLDivElement>) => {
   const { children, style, className, tooltip, header, ...rest } = props;
+  useDeprecationNoticeForTooltip('AnalyticalCard', props.tooltip);
   const classes = useStyles();
   const classNameString = clsx(classes.card, className);
 

--- a/packages/main/src/components/AnalyticalCardHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalCardHeader/index.tsx
@@ -12,6 +12,7 @@ import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
 import React, { forwardRef, MouseEventHandler, Ref, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './AnalyticalCardHeader.jss';
 
 export interface AnalyticalCardHeaderPropTypes extends CommonProps {
@@ -107,6 +108,7 @@ export const AnalyticalCardHeader = forwardRef((props: AnalyticalCardHeaderPropT
     ...rest
   } = props;
   const classes = useStyles();
+  useDeprecationNoticeForTooltip('AnalyticalCardHeader', props.tooltip);
 
   const indicatorIcon = useMemo(() => {
     const arrowClasses = clsx(

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -220,7 +220,7 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
         onKeyUp={handleHeaderCellKeyUp}
       >
         <div className={classes.header} data-h-align={column.hAlign}>
-          <Text tooltip={tooltip} wrapping={false} style={textStyle} className={classes.text}>
+          <Text title={tooltip} wrapping={false} style={textStyle} className={classes.text}>
             {children}
           </Text>
           <div className={classes.iconContainer} style={iconContainerDirectionStyles}>

--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -4116,6 +4116,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
                   <ui5-checkbox
                     style="cursor: pointer; vertical-align: middle;"
                     tabindex="-1"
+                    title="Toggle All Rows Selected"
                     ui5-checkbox=""
                     value-state="None"
                   />
@@ -4314,6 +4315,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -4432,6 +4434,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -6513,6 +6516,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                     indeterminate="true"
                     style="cursor: pointer; vertical-align: middle;"
                     tabindex="-1"
+                    title="Toggle All Rows Selected"
                     ui5-checkbox=""
                     value-state="None"
                   />
@@ -6713,6 +6717,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   indeterminate="true"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -6833,6 +6838,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   indeterminate="true"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -6953,6 +6959,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   indeterminate="true"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7073,6 +7080,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7191,6 +7199,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7309,6 +7318,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7417,6 +7427,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7535,6 +7546,7 @@ exports[`AnalyticalTable plugin hook: useIndeterminateRowSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -7999,6 +8011,7 @@ exports[`AnalyticalTable plugin hook: useRowDisableSelection 1`] = `
                   disabled="true"
                   style="vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />
@@ -8097,6 +8110,7 @@ exports[`AnalyticalTable plugin hook: useRowDisableSelection 1`] = `
                   data-name="internal_selection_column"
                   style="cursor: pointer; vertical-align: middle;"
                   tabindex="-1"
+                  title="Toggle Row Selected"
                   ui5-checkbox=""
                   value-state="None"
                 />

--- a/packages/main/src/components/AnalyticalTable/defaults/Column/Cell.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/Column/Cell.tsx
@@ -7,7 +7,7 @@ export const Cell = ({ cell: { value = '', isGrouped }, row }) => {
     cellContent += ` (${row.subRows.length})`;
   }
   return (
-    <Text wrapping={false} tooltip={cellContent}>
+    <Text wrapping={false} title={cellContent}>
       {cellContent}
     </Text>
   );

--- a/packages/main/src/components/AnalyticalTable/defaults/Column/PopIn.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/Column/PopIn.tsx
@@ -63,7 +63,7 @@ export const PopIn = (instance) => {
               const cell = item.column.Cell;
               if (typeof cell === 'string') {
                 return (
-                  <Text wrapping={false} tooltip={cell}>
+                  <Text wrapping={false} title={cell}>
                     {cell}
                   </Text>
                 );
@@ -71,7 +71,7 @@ export const PopIn = (instance) => {
               return makeRenderer({ ...instance, ...popInInstanceProps, isPopIn: true }, item.column)(item.column.Cell);
             }
             return popInInstanceProps?.value ? (
-              <Text wrapping={false} tooltip={popInInstanceProps.value}>
+              <Text wrapping={false} title={popInInstanceProps.value}>
                 {popInInstanceProps.value}
               </Text>
             ) : null;

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -40,6 +40,7 @@ import {
   useSortBy,
   useTable
 } from 'react-table';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './AnayticalTable.jss';
 import { ColumnHeaderContainer } from './ColumnHeader/ColumnHeaderContainer';
 import { DefaultColumn } from './defaults/Column';
@@ -531,6 +532,8 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     NoDataComponent,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('AnalyticalTable', props.tooltip);
 
   const classes = useStyles();
 

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -9,6 +9,7 @@ import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
 import React, { cloneElement, forwardRef, ReactElement, ReactNode, Ref, useEffect, useRef, useState } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { useObserveHeights } from '../../internal/useObserveHeights';
 import { DynamicPageAnchorBar } from '../DynamicPageAnchorBar';
 import { styles } from './DynamicPage.jss';
@@ -98,6 +99,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
     ...rest
   } = props;
   const { onScroll: _1, ...propsWithoutOmitted } = rest;
+  useDeprecationNoticeForTooltip('DynamicPage', props.tooltip);
 
   const anchorBarRef = useRef<HTMLDivElement>();
   const [componentRef, dynamicPageRef] = useSyncRef<HTMLDivElement>(ref);

--- a/packages/main/src/components/DynamicPageAnchorBar/index.tsx
+++ b/packages/main/src/components/DynamicPageAnchorBar/index.tsx
@@ -17,6 +17,7 @@ import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { forwardRef, RefObject, useCallback } from 'react';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 addCustomCSS(
   'ui5-button',
@@ -153,6 +154,7 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
     style,
     a11yConfig
   } = props;
+  useDeprecationNoticeForTooltip('DynamicPageAnchorBar', props.tooltip);
 
   const classes = useStyles();
   const [componentRef, anchorBarRef] = useSyncRef<HTMLElement>(ref);

--- a/packages/main/src/components/DynamicPageAnchorBar/index.tsx
+++ b/packages/main/src/components/DynamicPageAnchorBar/index.tsx
@@ -201,7 +201,7 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
           onClick={onToggleHeaderButtonClick}
           onMouseOver={onHoverToggleButton}
           onMouseLeave={onHoverToggleButton}
-          tooltip={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
+          title={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
           aria-label={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
         />
       )}
@@ -216,7 +216,7 @@ const DynamicPageAnchorBar = forwardRef((props: Props, ref: RefObject<HTMLElemen
           )}
           pressed={headerPinned}
           onClick={onPinHeader}
-          tooltip={i18nBundle.getText(headerPinned ? UNPIN_HEADER : PIN_HEADER)}
+          title={i18nBundle.getText(headerPinned ? UNPIN_HEADER : PIN_HEADER)}
           aria-label={i18nBundle.getText(headerPinned ? UNPIN_HEADER : PIN_HEADER)}
         />
       )}

--- a/packages/main/src/components/DynamicPageHeader/index.tsx
+++ b/packages/main/src/components/DynamicPageHeader/index.tsx
@@ -2,6 +2,7 @@ import { isIE } from '@ui5/webcomponents-react-base/dist/Device';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { forwardRef, ReactNode, Ref, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { DynamicPageHeaderStyles } from './DynamicPageHeader.jss';
 import clsx from 'clsx';
 
@@ -31,6 +32,7 @@ const useStyles = createUseStyles(DynamicPageHeaderStyles, { name: 'DynamicPageH
  */
 const DynamicPageHeader = forwardRef((props: InternalProps, ref: Ref<HTMLDivElement>) => {
   const { children, headerPinned, topHeaderHeight, tooltip, className, style, ...rest } = props;
+  useDeprecationNoticeForTooltip('DynamicPageHeader', props.tooltip);
 
   const headerStyles = useMemo(() => {
     if (headerPinned) {

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -23,6 +23,7 @@ import React, {
 } from 'react';
 import { createUseStyles } from 'react-jss';
 import { stopPropagation } from '../../internal/stopPropagation';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { ActionsSpacer } from './ActionsSpacer';
 import { DynamicPageTitleStyles } from './DynamicPageTitle.jss';
 import clsx from 'clsx';
@@ -108,6 +109,7 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     onToolbarOverflowChange,
     ...rest
   } = props as InternalProps;
+  useDeprecationNoticeForTooltip('DynamicPageTitle', props.tooltip);
 
   const classes = useStyles();
   const containerClasses = clsx(classes.container, className, isIE() && classes.iEClass);

--- a/packages/main/src/components/FilterBar/FilterBar.test.tsx
+++ b/packages/main/src/components/FilterBar/FilterBar.test.tsx
@@ -400,7 +400,7 @@ describe('FilterBar', () => {
     const onRestore = jest.fn();
     const { rerender } = render(
       <FilterBar
-        tooltip="FilterBar-Test"
+        title="FilterBar-Test"
         showFilterConfiguration
         showSearchOnFiltersDialog
         showClearOnFB
@@ -505,7 +505,7 @@ describe('FilterBar', () => {
 
     rerender(
       <FilterBar
-        tooltip="FilterBar-Test"
+        title="FilterBar-Test"
         showFilterConfiguration
         showSearchOnFiltersDialog
         showClearOnFB

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -228,7 +228,7 @@ export const FilterDialog = (props) => {
               <Title
                 level={TitleLevel.H5}
                 className={index === 0 ? classes.groupTitle : ''}
-                tooltip={item === 'default' ? basicText : item}
+                title={item === 'default' ? basicText : item}
               >
                 {item === 'default' ? basicText : item}
               </Title>
@@ -246,7 +246,7 @@ export const FilterDialog = (props) => {
       ref={dialogRef}
       header={
         <FlexBox direction={FlexBoxDirection.Column} alignItems={FlexBoxAlignItems.Center} className={classes.header}>
-          <Title level={TitleLevel.H4} tooltip={filtersTitle}>
+          <Title level={TitleLevel.H4} title={filtersTitle}>
             {filtersTitle}
           </Title>
           {showSearch && (

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -34,6 +34,7 @@ import React, {
 } from 'react';
 import { createUseStyles } from 'react-jss';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './FilterBar.jss';
 import { FilterDialog } from './FilterDialog';
 import { filterValue, renderSearchWithValue, syncRef } from './utils';
@@ -261,6 +262,9 @@ const FilterBar = forwardRef((props: FilterBarPropTypes, ref: RefObject<HTMLDivE
     onRestore,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('FilterBar', props.tooltip);
+
   const [showFilters, setShowFilters] = useState(useToolbar ? filterBarExpanded : true);
   const [mountFilters, setMountFilters] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -7,6 +7,7 @@ import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
 import React, { forwardRef, ReactElement, RefObject } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './FilterGroupItem.jss';
 
 const useStyles = createUseStyles(styles, { name: 'FilterGroupItem' });
@@ -78,6 +79,9 @@ export const FilterGroupItem = forwardRef((props: FilterGroupItemPropTypes, ref:
     slot,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('FilterGroupItem', props.tooltip);
+
   const inFB = props['data-in-fb'];
   const [componentRef, filterGroupItemRef] = useSyncRef<HTMLDivElement>(ref);
 

--- a/packages/main/src/components/FilterGroupItem/index.tsx
+++ b/packages/main/src/components/FilterGroupItem/index.tsx
@@ -104,7 +104,7 @@ export const FilterGroupItem = forwardRef((props: FilterGroupItemPropTypes, ref:
     >
       <div className={inFB ? classes.innerFilterItemContainer : classes.innerFilterItemContainerDialog}>
         <FlexBox>
-          <Label tooltip={labelTooltip ?? label} required={required}>
+          <Label title={labelTooltip ?? label} required={required}>
             {`${considerGroupName && groupName !== 'default' ? `${groupName}: ` : ''}
           ${label}`}
           </Label>

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -5,6 +5,7 @@ import { FlexBoxJustifyContent } from '@ui5/webcomponents-react/dist/FlexBoxJust
 import { FlexBoxWrap } from '@ui5/webcomponents-react/dist/FlexBoxWrap';
 import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { styles } from './FlexBox.jss';
 import clsx from 'clsx';
 
@@ -70,6 +71,8 @@ const FlexBox = forwardRef((props: FlexBoxPropTypes, ref: Ref<HTMLDivElement>) =
     as,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('FlexBox', props.tooltip);
 
   const classes = useStyles();
   const flexBoxClasses = clsx(

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -19,6 +19,7 @@ import React, {
   useState
 } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { styles } from './Form.jss';
 
 export interface FormPropTypes extends CommonProps {
@@ -125,6 +126,8 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
     as,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('Form', props.tooltip);
 
   const columnsMap = new Map();
   columnsMap.set('Phone', columnsS);

--- a/packages/main/src/components/Grid/index.tsx
+++ b/packages/main/src/components/Grid/index.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback
 } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { styles } from './Grid.jss';
 import clsx from 'clsx';
 
@@ -111,6 +112,9 @@ const Grid = forwardRef((props: GridPropTypes, ref: Ref<HTMLDivElement>) => {
     defaultSpan,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('Grid', props.tooltip);
+
   const classes = useStyles();
   const currentRange = useViewportRange();
   const gridClasses = clsx(

--- a/packages/main/src/components/Loader/index.tsx
+++ b/packages/main/src/components/Loader/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
 import React, { CSSProperties, forwardRef, RefObject, useEffect, useMemo, useState } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { styles } from './Loader.jss';
 
 export interface LoaderPropTypes extends CommonProps {
@@ -31,6 +32,9 @@ const useStyles = createUseStyles(styles, { name: 'Loader' });
  */
 const Loader = forwardRef((props: LoaderPropTypes, ref: RefObject<HTMLDivElement>) => {
   const { className, type, progress, tooltip, slot, style, delay, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('Loader', props.tooltip);
+
   const classes = useStyles();
   const [isVisible, setIsVisible] = useState(delay === 0);
 

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -46,6 +46,7 @@ import React, {
 } from 'react';
 import { createUseStyles } from 'react-jss';
 import { stopPropagation } from '../../internal/stopPropagation';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './MessageBox.jss';
 
 type MessageBoxAction = MessageBoxActions | keyof typeof MessageBoxActions | string;
@@ -170,6 +171,9 @@ const MessageBox = forwardRef((props: MessageBoxPropTypes, ref: Ref<DialogDomRef
     accessibleName,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('MessageBox', props.tooltip);
+
   const [componentRef, dialogRef] = useSyncRef<DialogDomRef>(ref);
 
   const classes = useStyles();

--- a/packages/main/src/components/MessageView/index.tsx
+++ b/packages/main/src/components/MessageView/index.tsx
@@ -35,6 +35,7 @@ import React, {
   useState
 } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import type { MessageItemPropTypes } from './MessageItem';
 import { getIconNameForType } from './utils';
 
@@ -156,6 +157,8 @@ const useStyles = createUseStyles(
 
 const MessageView = forwardRef((props: MessageViewPropTypes, ref: Ref<MessageViewDomRef>) => {
   const { children, groupItems, showDetailsPageHeader, className, onItemSelect, tooltip, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('MessageView', props.tooltip);
 
   const [componentRef, internalRef] = useSyncRef<MessageViewDomRef>(ref);
 

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -26,6 +26,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { PopoverHorizontalAlign } from '../../enums/PopoverHorizontalAlign';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { PopoverDomRef } from '../../webComponents/Popover';
 import { stopPropagation } from '../../internal/stopPropagation';
 import { useObserveHeights } from '../../internal/useObserveHeights';
@@ -183,6 +184,8 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
     portalContainer,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('ObjectPage', props.tooltip);
 
   const classes = useStyles();
 

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, ReactNode, RefObject } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { EmptyIdPropException } from '../ObjectPage/EmptyIdPropException';
 import styles from './ObjectPageSection.jss';
 import clsx from 'clsx';
@@ -31,6 +32,9 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSection' });
  */
 const ObjectPageSection = forwardRef((props: ObjectPageSectionPropTypes, ref: RefObject<HTMLElement>) => {
   const { titleText, id, children, titleTextUppercase, className, style, tooltip, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('ObjectPageSection', props.tooltip);
+
   const classes = useStyles();
 
   if (!id) {

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -2,6 +2,7 @@ import { ThemingParameters } from '@ui5/webcomponents-react-base/dist/ThemingPar
 import React, { forwardRef, ReactNode, RefObject } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { EmptyIdPropException } from '../ObjectPage/EmptyIdPropException';
 import clsx from 'clsx';
 
@@ -44,6 +45,8 @@ const useStyles = createUseStyles(styles, { name: 'ObjectPageSubSection' });
  */
 const ObjectPageSubSection = forwardRef((props: ObjectPageSubSectionPropTypes, ref: RefObject<HTMLDivElement>) => {
   const { children, id, titleText, className, style, tooltip, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('ObjectPageSubSection', props.tooltip);
 
   if (!id) {
     throw new EmptyIdPropException('ObjectPageSubSection requires a unique ID property!');

--- a/packages/main/src/components/ObjectStatus/index.tsx
+++ b/packages/main/src/components/ObjectStatus/index.tsx
@@ -8,6 +8,7 @@ import { IndicationColor } from '@ui5/webcomponents-react/dist/IndicationColor';
 import React, { forwardRef, MouseEventHandler, ReactNode, Ref } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import styles from './ObjectStatus.jss';
 import clsx from 'clsx';
 
@@ -84,6 +85,8 @@ const useStyles = createUseStyles(styles, { name: 'ObjectStatus' });
 const ObjectStatus = forwardRef((props: ObjectStatusPropTypes, ref: Ref<HTMLDivElement>) => {
   const { state, showDefaultIcon, children, icon, className, style, tooltip, active, inverted, onClick, ...rest } =
     props;
+
+  useDeprecationNoticeForTooltip('ObjectStatus', props.tooltip);
 
   const iconToRender = (() => {
     if (icon) {

--- a/packages/main/src/components/ResponsiveGridLayout/index.tsx
+++ b/packages/main/src/components/ResponsiveGridLayout/index.tsx
@@ -1,6 +1,7 @@
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { CSSProperties, forwardRef, ReactNode, Ref } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { ResponsiveGridLayoutStyles } from './ResponsiveGridLayout.jss';
 import clsx from 'clsx';
 
@@ -92,6 +93,8 @@ const ResponsiveGridLayout = forwardRef((props: ResponsiveGridLayoutPropTypes, r
   } = props;
   const classes = useStyles();
   const finalClassNames = clsx(classes.container, className);
+
+  useDeprecationNoticeForTooltip('ResponsiveGridLayout', props.tooltip);
 
   return (
     <div

--- a/packages/main/src/components/SelectDialog/index.tsx
+++ b/packages/main/src/components/SelectDialog/index.tsx
@@ -30,6 +30,7 @@ import { Ui5CustomEvent } from '@ui5/webcomponents-react/interfaces/Ui5CustomEve
 import clsx from 'clsx';
 import React, { forwardRef, ReactNode, Ref, useState } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 const useStyles = createUseStyles(
   {
@@ -174,6 +175,9 @@ const SelectDialog = forwardRef((props: SelectDialogPropTypes, ref: Ref<DialogDo
     onSearchReset,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('SelectDialog', props.tooltip);
+
   const classes = useStyles();
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const [searchValue, setSearchValue] = useState('');

--- a/packages/main/src/components/SelectDialog/index.tsx
+++ b/packages/main/src/components/SelectDialog/index.tsx
@@ -309,7 +309,7 @@ const SelectDialog = forwardRef((props: SelectDialogPropTypes, ref: Ref<DialogDo
               {searchValue && (
                 <Icon
                   accessibleName={i18nBundle.getText(RESET)}
-                  tooltip={i18nBundle.getText(RESET)}
+                  title={i18nBundle.getText(RESET)}
                   name="decline"
                   interactive
                   onClick={handleResetSearch}
@@ -321,7 +321,7 @@ const SelectDialog = forwardRef((props: SelectDialogPropTypes, ref: Ref<DialogDo
                 className={classes.inputIcon}
                 onClick={handleSearchSubmit}
                 accessibleName={i18nBundle.getText(SEARCH)}
-                tooltip={i18nBundle.getText(SEARCH)}
+                title={i18nBundle.getText(SEARCH)}
               />
             </>
           }

--- a/packages/main/src/components/Text/index.tsx
+++ b/packages/main/src/components/Text/index.tsx
@@ -1,6 +1,7 @@
 import { createUseStyles } from 'react-jss';
 import React, { forwardRef, ReactNode, Ref } from 'react';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { TextStyles } from './Text.jss';
 import clsx from 'clsx';
 
@@ -26,6 +27,9 @@ const useStyles = createUseStyles(TextStyles, { name: 'Text' });
  */
 const Text = forwardRef((props: TextPropTypes, ref: Ref<HTMLSpanElement>) => {
   const { children, renderWhitespace, wrapping, className, style, tooltip, slot, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('Text', props.tooltip);
+
   const classes = useStyles();
   const classNameString = clsx(
     classes.text,

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -20,6 +20,7 @@ import React, {
   useRef,
   useState
 } from 'react';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { OverflowPopover } from './OverflowPopover';
 import { styles } from './Toolbar.jss';
 import clsx from 'clsx';
@@ -103,6 +104,9 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
     onOverflowChange,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('Toolbar', props.tooltip);
+
   const classes = useStyles();
   const [componentRef, outerContainer] = useSyncRef<HTMLDivElement>(ref);
   const controlMetaData = useRef([]);

--- a/packages/main/src/components/ToolbarSeparator/index.tsx
+++ b/packages/main/src/components/ToolbarSeparator/index.tsx
@@ -6,6 +6,7 @@ import React, { forwardRef, Ref } from 'react';
 import { SEPARATOR } from '@ui5/webcomponents-react/dist/assets/i18n/i18n-defaults';
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import clsx from 'clsx';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 const styles = {
   separator: {
@@ -21,6 +22,9 @@ export type ToolbarSeparatorPropTypes = CommonProps;
 
 const ToolbarSeparator = forwardRef((props: ToolbarSeparatorPropTypes, ref: Ref<HTMLDivElement>) => {
   const { style, className, ...rest } = props;
+
+  useDeprecationNoticeForTooltip('ToolbarSeparator', props.tooltip);
+
   const classes = useStyles();
   const separatorClasses = clsx(classes.separator, className);
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');

--- a/packages/main/src/components/ToolbarSpacer/index.tsx
+++ b/packages/main/src/components/ToolbarSpacer/index.tsx
@@ -1,9 +1,12 @@
 import { CommonProps } from '@ui5/webcomponents-react/interfaces/CommonProps';
 import React, { forwardRef, Ref } from 'react';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 
 export type ToolbarSpacerPropTypes = CommonProps;
 
 const ToolbarSpacer = forwardRef((props: ToolbarSpacerPropTypes, ref: Ref<HTMLSpanElement>) => {
+  useDeprecationNoticeForTooltip('ToolbarSpacer', props.tooltip);
+
   return <span ref={ref} style={{ flexGrow: 1 }} className="spacer" {...props} />;
 });
 

--- a/packages/main/src/components/VariantManagement/MangeViewsTableRows.tsx
+++ b/packages/main/src/components/VariantManagement/MangeViewsTableRows.tsx
@@ -171,7 +171,7 @@ export const ManageViewsTableRows = (props: ManageViewsTableRowsProps) => {
         ) : (
           <Icon
             aria-label={a11yFavoriteText}
-            tooltip={iconName === 'favorite' ? favoriteIconTitleText : unfavoriteIconTitleText}
+            title={iconName === 'favorite' ? favoriteIconTitleText : unfavoriteIconTitleText}
             name={iconName}
             interactive
             style={{ color: ThemingParameters.sapContent_MarkerIconColor, cursor: 'pointer' }}
@@ -205,7 +205,7 @@ export const ManageViewsTableRows = (props: ManageViewsTableRowsProps) => {
       <TableCell>
         {!(hideDelete ?? global) && (
           <Button
-            tooltip={a11yDeleteText}
+            title={a11yDeleteText}
             accessibleName={a11yDeleteText}
             icon="decline"
             design={ButtonDesign.Transparent}

--- a/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
+++ b/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
@@ -208,10 +208,12 @@ describe('VariantManagement', () => {
     const variantItems = [
       <VariantItem key="0">VariantItem 1</VariantItem>,
       <VariantItem key="1">VariantItem 2</VariantItem>,
-      <VariantItem favorite selected>
+      <VariantItem favorite selected key="2">
         Favorite VariantItem
       </VariantItem>,
-      <VariantItem isDefault>Default VariantItem</VariantItem>
+      <VariantItem isDefault key="3">
+        Default VariantItem
+      </VariantItem>
     ];
     const { rerender, queryByText, getAllByText, getByText } = render(
       <VariantManagement showOnlyFavorites>{variantItems}</VariantManagement>
@@ -333,8 +335,10 @@ describe('VariantManagement', () => {
     ];
     const { getByText } = render(
       <VariantManagement>
-        {variantItems.map((item) => (
-          <VariantItem {...item.props}>{item.rowId}</VariantItem>
+        {variantItems.map((item, index) => (
+          <VariantItem key={index} {...item.props}>
+            {item.rowId}
+          </VariantItem>
         ))}
       </VariantManagement>
     );
@@ -397,7 +401,12 @@ describe('VariantManagement', () => {
     const cb = jest.fn((e) => e.detail);
     const { getByText } = await renderWithDefine(
       <VariantManagement onSaveManageViews={cb}>
-        {[...TwoVariantItems, <VariantItem isDefault>VariantItem 3</VariantItem>]}
+        {[
+          ...TwoVariantItems,
+          <VariantItem isDefault key="2">
+            VariantItem 3
+          </VariantItem>
+        ]}
       </VariantManagement>,
       ['ui5-checkbox', 'ui5-radio-button']
     );
@@ -439,7 +448,12 @@ describe('VariantManagement', () => {
     const cb = jest.fn((e) => e.detail);
     const { getByText } = render(
       <VariantManagement onSaveManageViews={cb}>
-        {[...TwoVariantItems, <VariantItem isDefault>VariantItem 3</VariantItem>]}
+        {[
+          ...TwoVariantItems,
+          <VariantItem isDefault key="2">
+            VariantItem 3
+          </VariantItem>
+        ]}
       </VariantManagement>
     );
     const manageBtn = getByText('Manage');
@@ -463,7 +477,12 @@ describe('VariantManagement', () => {
     const cb = jest.fn((e) => e.detail);
     const { getByText } = render(
       <VariantManagement onSaveManageViews={cb}>
-        {[...TwoVariantItems, <VariantItem isDefault>VariantItem 3</VariantItem>]}
+        {[
+          ...TwoVariantItems,
+          <VariantItem isDefault key="2">
+            VariantItem 3
+          </VariantItem>
+        ]}
       </VariantManagement>
     );
     const manageBtn = getByText('Manage');

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -457,7 +457,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
           {dirtyState && <div className={dirtyStateClasses}>{dirtyStateText}</div>}
         </FlexBox>
         <Button
-          tooltip={selectViewText}
+          title={selectViewText}
           aria-label={selectViewText}
           onClick={handleOpenVariantManagement}
           design={ButtonDesign.Transparent}
@@ -537,7 +537,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
                             {filteredChildren && (
                               <Icon
                                 accessibleName={resetIconTitleText}
-                                tooltip={resetIconTitleText}
+                                title={resetIconTitleText}
                                 name="decline"
                                 interactive
                                 onClick={handleResetFilter}

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -49,6 +49,7 @@ import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { stopPropagation } from '../../internal/stopPropagation';
+import { useDeprecationNoticeForTooltip } from '../../internal/useDeprecationNotiveForTooltip';
 import { ManageViewsDialog } from './ManageViewsDialog';
 import { SaveViewDialog } from './SaveViewDialog';
 import { VariantItemPropTypes } from './VariantItem';
@@ -246,6 +247,8 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
     portalContainer,
     ...rest
   } = props;
+
+  useDeprecationNoticeForTooltip('VariantManagement', props.tooltip);
 
   const classes = useStyles();
   const popoverRef = useRef<ResponsivePopoverDomRef>(null);

--- a/packages/main/src/interfaces/CommonProps.ts
+++ b/packages/main/src/interfaces/CommonProps.ts
@@ -12,7 +12,9 @@ export interface CommonProps extends HTMLAttributes<HTMLElement> {
    */
   className?: string;
   /**
-   * A tooltip which will be shown on hover
+   * A tooltip which will be shown on hover.
+   *
+   * @deprecated please use `title` attribute instead.
    */
   tooltip?: string;
   ref?: Ref<any>;

--- a/packages/main/src/interfaces/CommonProps.ts
+++ b/packages/main/src/interfaces/CommonProps.ts
@@ -13,8 +13,9 @@ export interface CommonProps extends HTMLAttributes<HTMLElement> {
   className?: string;
   /**
    * A tooltip which will be shown on hover.
+   * This prop is deprecated as of v0.20.6, please use the native `title` prop instead.
    *
-   * @deprecated please use `title` attribute instead.
+   * @deprecated please use `title` prop instead.
    */
   tooltip?: string;
   ref?: Ref<any>;

--- a/packages/main/src/internal/useDeprecationNotiveForTooltip.ts
+++ b/packages/main/src/internal/useDeprecationNotiveForTooltip.ts
@@ -1,0 +1,10 @@
+import { deprecationNotice } from '@ui5/webcomponents-react-base/dist/Utils';
+import { useEffect } from 'react';
+
+export const useDeprecationNoticeForTooltip = (component, tooltip) => {
+  useEffect(() => {
+    if (tooltip) {
+      deprecationNotice(component, '`tooltip` has been deprecated, please use the native `title` attribute instead.');
+    }
+  }, [tooltip]);
+};

--- a/packages/main/src/webComponents/Avatar/Avatar.test.tsx
+++ b/packages/main/src/webComponents/Avatar/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Avatar } from '@ui5/webcomponents-react/dist/Avatar';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Avatar', () => {
     const { asFragment } = render(<Avatar />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Avatar);
 });

--- a/packages/main/src/webComponents/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/main/src/webComponents/AvatarGroup/AvatarGroup.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { AvatarGroup } from '@ui5/webcomponents-react/dist/AvatarGroup';
 import { Avatar } from '@ui5/webcomponents-react/dist/Avatar';
 import React from 'react';
@@ -12,4 +13,5 @@ describe('AvatarGroup', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(AvatarGroup);
 });

--- a/packages/main/src/webComponents/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/main/src/webComponents/AvatarGroup/AvatarGroup.test.tsx
@@ -13,5 +13,5 @@ describe('AvatarGroup', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
-  createCustomPropsTest(AvatarGroup);
+  createCustomPropsTest(AvatarGroup, { children: <Avatar initials="UI5" /> });
 });

--- a/packages/main/src/webComponents/Badge/Badge.test.tsx
+++ b/packages/main/src/webComponents/Badge/Badge.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Badge } from '@ui5/webcomponents-react/dist/Badge';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Badge', () => {
     const { asFragment } = render(<Badge />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Badge);
 });

--- a/packages/main/src/webComponents/Bar/Bar.test.tsx
+++ b/packages/main/src/webComponents/Bar/Bar.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Bar } from '@ui5/webcomponents-react/dist/Bar';
 import React from 'react';
 
@@ -9,4 +10,5 @@ describe('Bar', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Bar);
 });

--- a/packages/main/src/webComponents/BarcodeScannerDialog/BarcodeScannerDialog.test.tsx
+++ b/packages/main/src/webComponents/BarcodeScannerDialog/BarcodeScannerDialog.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { BarcodeScannerDialog } from '@ui5/webcomponents-react/dist/BarcodeScannerDialog';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('BarcodeScannerDialog', () => {
     const { asFragment } = render(<BarcodeScannerDialog />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(BarcodeScannerDialog);
 });

--- a/packages/main/src/webComponents/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/main/src/webComponents/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Breadcrumbs } from '@ui5/webcomponents-react/dist/Breadcrumbs';
 import { BreadcrumbsItem } from '@ui5/webcomponents-react/dist/BreadcrumbsItem';
 import React from 'react';
@@ -12,4 +13,5 @@ describe('Breadcrumbs', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Breadcrumbs);
 });

--- a/packages/main/src/webComponents/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/main/src/webComponents/Breadcrumbs/Breadcrumbs.test.tsx
@@ -13,5 +13,5 @@ describe('Breadcrumbs', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
-  createCustomPropsTest(Breadcrumbs);
+  createCustomPropsTest(Breadcrumbs, { children: <BreadcrumbsItem>Hello World!</BreadcrumbsItem> });
 });

--- a/packages/main/src/webComponents/BreadcrumbsItem/BreadcrumbsItem.test.tsx
+++ b/packages/main/src/webComponents/BreadcrumbsItem/BreadcrumbsItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { BreadcrumbsItem } from '@ui5/webcomponents-react/dist/BreadcrumbsItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('BreadcrumbsItem', () => {
     const { asFragment } = render(<BreadcrumbsItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(BreadcrumbsItem);
 });

--- a/packages/main/src/webComponents/BusyIndicator/BusyIndicator.test.tsx
+++ b/packages/main/src/webComponents/BusyIndicator/BusyIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { BusyIndicator } from '@ui5/webcomponents-react/dist/BusyIndicator';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('BusyIndicator', () => {
     const { asFragment } = render(<BusyIndicator />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(BusyIndicator);
 });

--- a/packages/main/src/webComponents/Button/Button.test.tsx
+++ b/packages/main/src/webComponents/Button/Button.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Button', () => {
     const { asFragment } = render(<Button />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Button);
 });

--- a/packages/main/src/webComponents/Calendar/Calendar.test.tsx
+++ b/packages/main/src/webComponents/Calendar/Calendar.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Calendar } from '@ui5/webcomponents-react/dist/Calendar';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Calendar', () => {
     const { asFragment } = render(<Calendar />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Calendar);
 });

--- a/packages/main/src/webComponents/CalendarDate/CalendarDate.test.tsx
+++ b/packages/main/src/webComponents/CalendarDate/CalendarDate.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { CalendarDate } from '@ui5/webcomponents-react/dist/CalendarDate';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('CalendarDate', () => {
     const { asFragment } = render(<CalendarDate />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(CalendarDate);
 });

--- a/packages/main/src/webComponents/Card/Card.test.tsx
+++ b/packages/main/src/webComponents/Card/Card.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Card } from '@ui5/webcomponents-react/dist/Card';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Card', () => {
     const { asFragment } = render(<Card />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Card);
 });

--- a/packages/main/src/webComponents/CardHeader/CardHeader.test.tsx
+++ b/packages/main/src/webComponents/CardHeader/CardHeader.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { CardHeader } from '@ui5/webcomponents-react/dist/CardHeader';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('CardHeader', () => {
     const { asFragment } = render(<CardHeader />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(CardHeader);
 });

--- a/packages/main/src/webComponents/Carousel/Carousel.test.tsx
+++ b/packages/main/src/webComponents/Carousel/Carousel.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Carousel } from '@ui5/webcomponents-react/dist/Carousel';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Carousel', () => {
     const { asFragment } = render(<Carousel />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Carousel);
 });

--- a/packages/main/src/webComponents/CheckBox/CheckBox.test.tsx
+++ b/packages/main/src/webComponents/CheckBox/CheckBox.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { CheckBox } from '@ui5/webcomponents-react/dist/CheckBox';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('CheckBox', () => {
     const { asFragment } = render(<CheckBox />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(CheckBox);
 });

--- a/packages/main/src/webComponents/ColorPalette/ColorPalette.test.tsx
+++ b/packages/main/src/webComponents/ColorPalette/ColorPalette.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ColorPalette } from '@ui5/webcomponents-react/dist/ColorPalette';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ColorPalette', () => {
     const { asFragment } = render(<ColorPalette />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ColorPalette);
 });

--- a/packages/main/src/webComponents/ColorPaletteItem/ColorPaletteItem.test.tsx
+++ b/packages/main/src/webComponents/ColorPaletteItem/ColorPaletteItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ColorPaletteItem } from '@ui5/webcomponents-react/dist/ColorPaletteItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ColorPaletteItem', () => {
     const { asFragment } = render(<ColorPaletteItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ColorPaletteItem);
 });

--- a/packages/main/src/webComponents/ColorPalettePopover/ColorPalettePopover.test.tsx
+++ b/packages/main/src/webComponents/ColorPalettePopover/ColorPalettePopover.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ColorPalettePopover } from '@ui5/webcomponents-react/dist/ColorPalettePopover';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ColorPalettePopover', () => {
     const { asFragment } = render(<ColorPalettePopover />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ColorPalettePopover);
 });

--- a/packages/main/src/webComponents/ColorPicker/ColorPicker.test.tsx
+++ b/packages/main/src/webComponents/ColorPicker/ColorPicker.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ColorPicker } from '@ui5/webcomponents-react/dist/ColorPicker';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ColorPicker', () => {
     const { asFragment } = render(<ColorPicker />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ColorPicker);
 });

--- a/packages/main/src/webComponents/ComboBox/ComboBox.test.tsx
+++ b/packages/main/src/webComponents/ComboBox/ComboBox.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ComboBox } from '@ui5/webcomponents-react/dist/ComboBox';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ComboBox', () => {
     const { asFragment } = render(<ComboBox />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ComboBox);
 });

--- a/packages/main/src/webComponents/ComboBoxGroupItem/ComboBoxGroupItem.test.tsx
+++ b/packages/main/src/webComponents/ComboBoxGroupItem/ComboBoxGroupItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ComboBoxGroupItem } from '@ui5/webcomponents-react/dist/ComboBoxGroupItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ComboBoxGroupItem', () => {
     const { asFragment } = render(<ComboBoxGroupItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ComboBoxGroupItem);
 });

--- a/packages/main/src/webComponents/ComboBoxItem/ComboBoxItem.test.tsx
+++ b/packages/main/src/webComponents/ComboBoxItem/ComboBoxItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ComboBoxItem } from '@ui5/webcomponents-react/dist/ComboBoxItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ComboBoxItem', () => {
     const { asFragment } = render(<ComboBoxItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ComboBoxItem);
 });

--- a/packages/main/src/webComponents/CustomListItem/CustomListItem.test.tsx
+++ b/packages/main/src/webComponents/CustomListItem/CustomListItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { CustomListItem } from '@ui5/webcomponents-react/dist/CustomListItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('CustomListItem', () => {
     const { asFragment } = render(<CustomListItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(CustomListItem);
 });

--- a/packages/main/src/webComponents/DatePicker/DatePicker.test.tsx
+++ b/packages/main/src/webComponents/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { DatePicker } from '@ui5/webcomponents-react/dist/DatePicker';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('DatePicker', () => {
     const { asFragment } = render(<DatePicker />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(DatePicker);
 });

--- a/packages/main/src/webComponents/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/main/src/webComponents/DateRangePicker/DateRangePicker.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { DateRangePicker } from '@ui5/webcomponents-react/dist/DateRangePicker';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('DateRangePicker', () => {
     const { asFragment } = render(<DateRangePicker />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(DateRangePicker);
 });

--- a/packages/main/src/webComponents/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/main/src/webComponents/DateTimePicker/DateTimePicker.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { DateTimePicker } from '@ui5/webcomponents-react/dist/DateTimePicker';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('DateTimePicker', () => {
     const { asFragment } = render(<DateTimePicker />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(DateTimePicker);
 });

--- a/packages/main/src/webComponents/Dialog/Dialog.test.tsx
+++ b/packages/main/src/webComponents/Dialog/Dialog.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Dialog } from '@ui5/webcomponents-react/dist/Dialog';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Dialog', () => {
     const { asFragment } = render(<Dialog />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Dialog);
 });

--- a/packages/main/src/webComponents/FileUploader/FileUploader.test.tsx
+++ b/packages/main/src/webComponents/FileUploader/FileUploader.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { FileUploader } from '@ui5/webcomponents-react/dist/FileUploader';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('FileUploader', () => {
     const { asFragment } = render(<FileUploader />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(FileUploader);
 });

--- a/packages/main/src/webComponents/FilterItem/FilterItem.test.tsx
+++ b/packages/main/src/webComponents/FilterItem/FilterItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { FilterItem } from '@ui5/webcomponents-react/dist/FilterItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('FilterItem', () => {
     const { asFragment } = render(<FilterItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(FilterItem);
 });

--- a/packages/main/src/webComponents/FilterItemOption/FilterItemOption.test.tsx
+++ b/packages/main/src/webComponents/FilterItemOption/FilterItemOption.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { FilterItemOption } from '@ui5/webcomponents-react/dist/FilterItemOption';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('FilterItemOption', () => {
     const { asFragment } = render(<FilterItemOption />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(FilterItemOption);
 });

--- a/packages/main/src/webComponents/FlexibleColumnLayout/FlexibleColumnLayout.test.tsx
+++ b/packages/main/src/webComponents/FlexibleColumnLayout/FlexibleColumnLayout.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { FlexibleColumnLayout } from '@ui5/webcomponents-react/dist/FlexibleColumnLayout';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('FlexibleColumnLayout', () => {
     const { asFragment } = render(<FlexibleColumnLayout />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(FlexibleColumnLayout);
 });

--- a/packages/main/src/webComponents/GroupHeaderListItem/GroupHeaderListItem.test.tsx
+++ b/packages/main/src/webComponents/GroupHeaderListItem/GroupHeaderListItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { GroupHeaderListItem } from '@ui5/webcomponents-react/dist/GroupHeaderListItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('GroupHeaderListItem', () => {
     const { asFragment } = render(<GroupHeaderListItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(GroupHeaderListItem);
 });

--- a/packages/main/src/webComponents/Icon/Icon.test.tsx
+++ b/packages/main/src/webComponents/Icon/Icon.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@shared/tests';
 import '@ui5/webcomponents-icons/dist/add.js';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Icon } from '@ui5/webcomponents-react/dist/Icon';
 import React from 'react';
 
@@ -8,4 +9,5 @@ describe('Icon', () => {
     const { asFragment } = render(<Icon name="add" />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Icon);
 });

--- a/packages/main/src/webComponents/IllustratedMessage/IllustratedMessage.test.tsx
+++ b/packages/main/src/webComponents/IllustratedMessage/IllustratedMessage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { IllustratedMessage } from '@ui5/webcomponents-react/dist/IllustratedMessage';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('IllustratedMessage', () => {
     const { asFragment } = render(<IllustratedMessage />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(IllustratedMessage);
 });

--- a/packages/main/src/webComponents/Input/Input.test.tsx
+++ b/packages/main/src/webComponents/Input/Input.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Input } from '@ui5/webcomponents-react/dist/Input';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Input', () => {
     const { asFragment } = render(<Input />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Input);
 });

--- a/packages/main/src/webComponents/Label/Label.test.tsx
+++ b/packages/main/src/webComponents/Label/Label.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Label } from '@ui5/webcomponents-react/dist/Label';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Label', () => {
     const { asFragment } = render(<Label />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Label);
 });

--- a/packages/main/src/webComponents/Link/Link.test.tsx
+++ b/packages/main/src/webComponents/Link/Link.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Link } from '@ui5/webcomponents-react/dist/Link';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Link', () => {
     const { asFragment } = render(<Link />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Link);
 });

--- a/packages/main/src/webComponents/List/List.test.tsx
+++ b/packages/main/src/webComponents/List/List.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { CustomListItem } from '@ui5/webcomponents-react/dist/CustomListItem';
 import { List } from '@ui5/webcomponents-react/dist/List';
@@ -17,4 +18,5 @@ describe('List', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(List);
 });

--- a/packages/main/src/webComponents/MessageStrip/MessageStrip.test.tsx
+++ b/packages/main/src/webComponents/MessageStrip/MessageStrip.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { MessageStrip } from '@ui5/webcomponents-react/dist/MessageStrip';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('MessageStrip', () => {
     const { asFragment } = render(<MessageStrip />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(MessageStrip);
 });

--- a/packages/main/src/webComponents/MultiComboBox/MultiComboBox.test.tsx
+++ b/packages/main/src/webComponents/MultiComboBox/MultiComboBox.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { MultiComboBox } from '@ui5/webcomponents-react/dist/MultiComboBox';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('MultiComboBox', () => {
     const { asFragment } = render(<MultiComboBox />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(MultiComboBox);
 });

--- a/packages/main/src/webComponents/MultiComboBoxItem/MultiComboBoxItem.test.tsx
+++ b/packages/main/src/webComponents/MultiComboBoxItem/MultiComboBoxItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { MultiComboBoxItem } from '@ui5/webcomponents-react/dist/MultiComboBoxItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('MultiComboBoxItem', () => {
     const { asFragment } = render(<MultiComboBoxItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(MultiComboBoxItem);
 });

--- a/packages/main/src/webComponents/MultiInput/MultiInput.test.tsx
+++ b/packages/main/src/webComponents/MultiInput/MultiInput.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { MultiInput } from '@ui5/webcomponents-react/dist/MultiInput';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('MultiInput', () => {
     const { asFragment } = render(<MultiInput />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(MultiInput);
 });

--- a/packages/main/src/webComponents/NotificationAction/NotificationAction.test.tsx
+++ b/packages/main/src/webComponents/NotificationAction/NotificationAction.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { NotificationAction } from '@ui5/webcomponents-react/dist/NotificationAction';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('NotificationAction', () => {
     const { asFragment } = render(<NotificationAction />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(NotificationAction);
 });

--- a/packages/main/src/webComponents/NotificationListGroupItem/NotificationListGroupItem.test.tsx
+++ b/packages/main/src/webComponents/NotificationListGroupItem/NotificationListGroupItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { NotificationListGroupItem } from '@ui5/webcomponents-react/dist/NotificationListGroupItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('NotificationListGroupItem', () => {
     const { asFragment } = render(<NotificationListGroupItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(NotificationListGroupItem);
 });

--- a/packages/main/src/webComponents/NotificationListItem/NotificationListItem.test.tsx
+++ b/packages/main/src/webComponents/NotificationListItem/NotificationListItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { NotificationListItem } from '@ui5/webcomponents-react/dist/NotificationListItem';
 import { NotificationAction } from '@ui5/webcomponents-react/dist/NotificationAction';
 import { Priority } from '@ui5/webcomponents-react/dist/Priority';
@@ -16,4 +17,5 @@ describe('NotificationListItem', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(NotificationListItem);
 });

--- a/packages/main/src/webComponents/Option/Option.test.tsx
+++ b/packages/main/src/webComponents/Option/Option.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Option } from '@ui5/webcomponents-react/dist/Option';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Option', () => {
     const { asFragment } = render(<Option />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Option);
 });

--- a/packages/main/src/webComponents/Page/Page.test.tsx
+++ b/packages/main/src/webComponents/Page/Page.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Page } from '@ui5/webcomponents-react/dist/Page';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Page', () => {
     const { asFragment } = render(<Page />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Page);
 });

--- a/packages/main/src/webComponents/Panel/Panel.test.tsx
+++ b/packages/main/src/webComponents/Panel/Panel.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Panel } from '@ui5/webcomponents-react/dist/Panel';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Panel', () => {
     const { asFragment } = render(<Panel />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Panel);
 });

--- a/packages/main/src/webComponents/Popover/Popover.test.tsx
+++ b/packages/main/src/webComponents/Popover/Popover.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Popover } from '@ui5/webcomponents-react/dist/Popover';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Popover', () => {
     const { asFragment } = render(<Popover />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Popover);
 });

--- a/packages/main/src/webComponents/ProductSwitch/ProductSwitch.test.tsx
+++ b/packages/main/src/webComponents/ProductSwitch/ProductSwitch.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ProductSwitch } from '@ui5/webcomponents-react/dist/ProductSwitch';
 import { ProductSwitchItem } from '@ui5/webcomponents-react/dist/ProductSwitchItem';
 import React from 'react';
@@ -12,4 +13,5 @@ describe('ProductSwitch', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ProductSwitch);
 });

--- a/packages/main/src/webComponents/ProductSwitchItem/ProductSwitchItem.test.tsx
+++ b/packages/main/src/webComponents/ProductSwitchItem/ProductSwitchItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ProductSwitchItem } from '@ui5/webcomponents-react/dist/ProductSwitchItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ProductSwitchItem', () => {
     const { asFragment } = render(<ProductSwitchItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ProductSwitchItem);
 });

--- a/packages/main/src/webComponents/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/main/src/webComponents/ProgressIndicator/ProgressIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ProgressIndicator } from '@ui5/webcomponents-react/dist/ProgressIndicator';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ProgressIndicator', () => {
     const { asFragment } = render(<ProgressIndicator />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ProgressIndicator);
 });

--- a/packages/main/src/webComponents/RadioButton/RadioButton.test.tsx
+++ b/packages/main/src/webComponents/RadioButton/RadioButton.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { RadioButton } from '@ui5/webcomponents-react/dist/RadioButton';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('RadioButton', () => {
     const { asFragment } = render(<RadioButton />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(RadioButton);
 });

--- a/packages/main/src/webComponents/RangeSlider/RangeSlider.test.tsx
+++ b/packages/main/src/webComponents/RangeSlider/RangeSlider.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { RangeSlider } from '@ui5/webcomponents-react/dist/RangeSlider';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('RangeSlider', () => {
     const { asFragment } = render(<RangeSlider />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(RangeSlider);
 });

--- a/packages/main/src/webComponents/RatingIndicator/RatingIndicator.test.tsx
+++ b/packages/main/src/webComponents/RatingIndicator/RatingIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { RatingIndicator } from '@ui5/webcomponents-react/dist/RatingIndicator';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('RatingIndicator', () => {
     const { asFragment } = render(<RatingIndicator />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(RatingIndicator);
 });

--- a/packages/main/src/webComponents/ResponsivePopover/ResponsivePopover.test.tsx
+++ b/packages/main/src/webComponents/ResponsivePopover/ResponsivePopover.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ResponsivePopover } from '@ui5/webcomponents-react/dist/ResponsivePopover';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ResponsivePopover', () => {
     const { asFragment } = render(<ResponsivePopover />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ResponsivePopover);
 });

--- a/packages/main/src/webComponents/SegmentedButton/SegmentedButton.test.tsx
+++ b/packages/main/src/webComponents/SegmentedButton/SegmentedButton.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SegmentedButtonItem } from '@ui5/webcomponents-react/dist/SegmentedButtonItem';
 import { SegmentedButton } from '@ui5/webcomponents-react/dist/SegmentedButton';
 import React from 'react';
@@ -14,4 +15,5 @@ describe('SegmentedButton', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SegmentedButton);
 });

--- a/packages/main/src/webComponents/SegmentedButtonItem/SegmentedButtonItem.test.tsx
+++ b/packages/main/src/webComponents/SegmentedButtonItem/SegmentedButtonItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SegmentedButtonItem } from '@ui5/webcomponents-react/dist/SegmentedButtonItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SegmentedButtonItem', () => {
     const { asFragment } = render(<SegmentedButtonItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SegmentedButtonItem);
 });

--- a/packages/main/src/webComponents/Select/Select.test.tsx
+++ b/packages/main/src/webComponents/Select/Select.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Select } from '@ui5/webcomponents-react/dist/Select';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Select', () => {
     const { asFragment } = render(<Select />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Select);
 });

--- a/packages/main/src/webComponents/ShellBar/ShellBar.test.tsx
+++ b/packages/main/src/webComponents/ShellBar/ShellBar.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ShellBar } from '@ui5/webcomponents-react/dist/ShellBar';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ShellBar', () => {
     const { asFragment } = render(<ShellBar />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ShellBar);
 });

--- a/packages/main/src/webComponents/ShellBarItem/ShellBarItem.test.tsx
+++ b/packages/main/src/webComponents/ShellBarItem/ShellBarItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ShellBarItem } from '@ui5/webcomponents-react/dist/ShellBarItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ShellBarItem', () => {
     const { asFragment } = render(<ShellBarItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ShellBarItem);
 });

--- a/packages/main/src/webComponents/SideNavigation/SideNavigation.test.tsx
+++ b/packages/main/src/webComponents/SideNavigation/SideNavigation.test.tsx
@@ -5,6 +5,7 @@ import '@ui5/webcomponents-icons/dist/group.js';
 import '@ui5/webcomponents-icons/dist/history.js';
 import '@ui5/webcomponents-icons/dist/home.js';
 import '@ui5/webcomponents-icons/dist/locate-me.js';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SideNavigation } from '@ui5/webcomponents-react/dist/SideNavigation';
 import { SideNavigationItem } from '@ui5/webcomponents-react/dist/SideNavigationItem';
 import { SideNavigationSubItem } from '@ui5/webcomponents-react/dist/SideNavigationSubItem';
@@ -35,4 +36,5 @@ describe('SideNavigation', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SideNavigation);
 });

--- a/packages/main/src/webComponents/SideNavigationItem/SideNavigationItem.test.tsx
+++ b/packages/main/src/webComponents/SideNavigationItem/SideNavigationItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SideNavigationItem } from '@ui5/webcomponents-react/dist/SideNavigationItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SideNavigationItem', () => {
     const { asFragment } = render(<SideNavigationItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SideNavigationItem);
 });

--- a/packages/main/src/webComponents/SideNavigationSubItem/SideNavigationSubItem.test.tsx
+++ b/packages/main/src/webComponents/SideNavigationSubItem/SideNavigationSubItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SideNavigationSubItem } from '@ui5/webcomponents-react/dist/SideNavigationSubItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SideNavigationSubItem', () => {
     const { asFragment } = render(<SideNavigationSubItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SideNavigationSubItem);
 });

--- a/packages/main/src/webComponents/Slider/Slider.test.tsx
+++ b/packages/main/src/webComponents/Slider/Slider.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Slider } from '@ui5/webcomponents-react/dist/Slider';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Slider', () => {
     const { asFragment } = render(<Slider />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Slider);
 });

--- a/packages/main/src/webComponents/SortItem/SortItem.test.tsx
+++ b/packages/main/src/webComponents/SortItem/SortItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SortItem } from '@ui5/webcomponents-react/dist/SortItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SortItem', () => {
     const { asFragment } = render(<SortItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SortItem);
 });

--- a/packages/main/src/webComponents/StandardListItem/StandardListItem.test.tsx
+++ b/packages/main/src/webComponents/StandardListItem/StandardListItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { StandardListItem } from '@ui5/webcomponents-react/dist/StandardListItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('StandardListItem', () => {
     const { asFragment } = render(<StandardListItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(StandardListItem);
 });

--- a/packages/main/src/webComponents/StepInput/StepInput.test.tsx
+++ b/packages/main/src/webComponents/StepInput/StepInput.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { StepInput } from '@ui5/webcomponents-react/dist/StepInput';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('StepInput', () => {
     const { asFragment } = render(<StepInput />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(StepInput);
 });

--- a/packages/main/src/webComponents/SuggestionGroupItem/SuggestionGroupItem.test.tsx
+++ b/packages/main/src/webComponents/SuggestionGroupItem/SuggestionGroupItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SuggestionGroupItem } from '@ui5/webcomponents-react/dist/SuggestionGroupItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SuggestionGroupItem', () => {
     const { asFragment } = render(<SuggestionGroupItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SuggestionGroupItem);
 });

--- a/packages/main/src/webComponents/SuggestionItem/SuggestionItem.test.tsx
+++ b/packages/main/src/webComponents/SuggestionItem/SuggestionItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { SuggestionItem } from '@ui5/webcomponents-react/dist/SuggestionItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('SuggestionItem', () => {
     const { asFragment } = render(<SuggestionItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(SuggestionItem);
 });

--- a/packages/main/src/webComponents/Switch/Switch.test.tsx
+++ b/packages/main/src/webComponents/Switch/Switch.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Switch } from '@ui5/webcomponents-react/dist/Switch';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Switch', () => {
     const { asFragment } = render(<Switch />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Switch);
 });

--- a/packages/main/src/webComponents/Tab/Tab.test.tsx
+++ b/packages/main/src/webComponents/Tab/Tab.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Tab } from '@ui5/webcomponents-react/dist/Tab';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Tab', () => {
     const { asFragment } = render(<Tab />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Tab);
 });

--- a/packages/main/src/webComponents/TabContainer/TabContainer.test.tsx
+++ b/packages/main/src/webComponents/TabContainer/TabContainer.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TabContainer } from '@ui5/webcomponents-react/dist/TabContainer';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TabContainer', () => {
     const { asFragment } = render(<TabContainer />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TabContainer);
 });

--- a/packages/main/src/webComponents/TabSeparator/TabSeparator.test.tsx
+++ b/packages/main/src/webComponents/TabSeparator/TabSeparator.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TabSeparator } from '@ui5/webcomponents-react/dist/TabSeparator';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TabSeparator', () => {
     const { asFragment } = render(<TabSeparator />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TabSeparator);
 });

--- a/packages/main/src/webComponents/Table/Table.test.tsx
+++ b/packages/main/src/webComponents/Table/Table.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Table } from '@ui5/webcomponents-react/dist/Table';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Table', () => {
     const { asFragment } = render(<Table />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Table);
 });

--- a/packages/main/src/webComponents/TableCell/TableCell.test.tsx
+++ b/packages/main/src/webComponents/TableCell/TableCell.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TableCell } from '@ui5/webcomponents-react/dist/TableCell';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TableCell', () => {
     const { asFragment } = render(<TableCell />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TableCell);
 });

--- a/packages/main/src/webComponents/TableColumn/TableColumn.test.tsx
+++ b/packages/main/src/webComponents/TableColumn/TableColumn.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TableColumn } from '@ui5/webcomponents-react/dist/TableColumn';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TableColumn', () => {
     const { asFragment } = render(<TableColumn />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TableColumn);
 });

--- a/packages/main/src/webComponents/TableGroupRow/TableGroupRow.test.tsx
+++ b/packages/main/src/webComponents/TableGroupRow/TableGroupRow.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TableGroupRow } from '@ui5/webcomponents-react/dist/TableGroupRow';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TableGroupRow', () => {
     const { asFragment } = render(<TableGroupRow />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TableGroupRow);
 });

--- a/packages/main/src/webComponents/TableRow/TableRow.test.tsx
+++ b/packages/main/src/webComponents/TableRow/TableRow.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TableRow } from '@ui5/webcomponents-react/dist/TableRow';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TableRow', () => {
     const { asFragment } = render(<TableRow />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TableRow);
 });

--- a/packages/main/src/webComponents/TextArea/TextArea.test.tsx
+++ b/packages/main/src/webComponents/TextArea/TextArea.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TextArea } from '@ui5/webcomponents-react/dist/TextArea';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TextArea', () => {
     const { asFragment } = render(<TextArea />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TextArea);
 });

--- a/packages/main/src/webComponents/TimePicker/TimePicker.test.tsx
+++ b/packages/main/src/webComponents/TimePicker/TimePicker.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TimePicker } from '@ui5/webcomponents-react/dist/TimePicker';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TimePicker', () => {
     const { asFragment } = render(<TimePicker />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TimePicker);
 });

--- a/packages/main/src/webComponents/Timeline/Timeline.test.tsx
+++ b/packages/main/src/webComponents/Timeline/Timeline.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Timeline } from '@ui5/webcomponents-react/dist/Timeline';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Timeline', () => {
     const { asFragment } = render(<Timeline />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Timeline);
 });

--- a/packages/main/src/webComponents/TimelineItem/TimelineItem.test.tsx
+++ b/packages/main/src/webComponents/TimelineItem/TimelineItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TimelineItem } from '@ui5/webcomponents-react/dist/TimelineItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TimelineItem', () => {
     const { asFragment } = render(<TimelineItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TimelineItem);
 });

--- a/packages/main/src/webComponents/Title/Title.test.tsx
+++ b/packages/main/src/webComponents/Title/Title.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Title } from '@ui5/webcomponents-react/dist/Title';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Title', () => {
     const { asFragment } = render(<Title />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Title);
 });

--- a/packages/main/src/webComponents/Toast/Toast.test.tsx
+++ b/packages/main/src/webComponents/Toast/Toast.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Toast } from '@ui5/webcomponents-react/dist/Toast';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Toast', () => {
     const { asFragment } = render(<Toast />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Toast);
 });

--- a/packages/main/src/webComponents/ToggleButton/ToggleButton.test.tsx
+++ b/packages/main/src/webComponents/ToggleButton/ToggleButton.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ToggleButton } from '@ui5/webcomponents-react/dist/ToggleButton';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ToggleButton', () => {
     const { asFragment } = render(<ToggleButton />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ToggleButton);
 });

--- a/packages/main/src/webComponents/Token/Token.test.tsx
+++ b/packages/main/src/webComponents/Token/Token.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Token } from '@ui5/webcomponents-react/dist/Token';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Token', () => {
     const { asFragment } = render(<Token />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Token);
 });

--- a/packages/main/src/webComponents/Tree/Tree.test.tsx
+++ b/packages/main/src/webComponents/Tree/Tree.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Tree } from '@ui5/webcomponents-react/dist/Tree';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Tree', () => {
     const { asFragment } = render(<Tree />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Tree);
 });

--- a/packages/main/src/webComponents/TreeItem/TreeItem.test.tsx
+++ b/packages/main/src/webComponents/TreeItem/TreeItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { TreeItem } from '@ui5/webcomponents-react/dist/TreeItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('TreeItem', () => {
     const { asFragment } = render(<TreeItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(TreeItem);
 });

--- a/packages/main/src/webComponents/UploadCollection/UploadCollection.test.tsx
+++ b/packages/main/src/webComponents/UploadCollection/UploadCollection.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { UploadCollection } from '@ui5/webcomponents-react/dist/UploadCollection';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('UploadCollection', () => {
     const { asFragment } = render(<UploadCollection />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(UploadCollection);
 });

--- a/packages/main/src/webComponents/UploadCollectionItem/UploadCollectionItem.test.tsx
+++ b/packages/main/src/webComponents/UploadCollectionItem/UploadCollectionItem.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { UploadCollectionItem } from '@ui5/webcomponents-react/dist/UploadCollectionItem';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('UploadCollectionItem', () => {
     const { asFragment } = render(<UploadCollectionItem />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(UploadCollectionItem);
 });

--- a/packages/main/src/webComponents/ViewSettingsDialog/ViewSettingsDialog.test.tsx
+++ b/packages/main/src/webComponents/ViewSettingsDialog/ViewSettingsDialog.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { ViewSettingsDialog } from '@ui5/webcomponents-react/dist/ViewSettingsDialog';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('ViewSettingsDialog', () => {
     const { asFragment } = render(<ViewSettingsDialog />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(ViewSettingsDialog);
 });

--- a/packages/main/src/webComponents/Wizard/Wizard.test.tsx
+++ b/packages/main/src/webComponents/Wizard/Wizard.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { Wizard } from '@ui5/webcomponents-react/dist/Wizard';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('Wizard', () => {
     const { asFragment } = render(<Wizard />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(Wizard);
 });

--- a/packages/main/src/webComponents/WizardStep/WizardStep.test.tsx
+++ b/packages/main/src/webComponents/WizardStep/WizardStep.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { WizardStep } from '@ui5/webcomponents-react/dist/WizardStep';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('WizardStep', () => {
     const { asFragment } = render(<WizardStep />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest(WizardStep);
 });

--- a/scripts/web-component-wrappers/TestTemplate.hbs
+++ b/scripts/web-component-wrappers/TestTemplate.hbs
@@ -1,4 +1,5 @@
 import { render } from '@shared/tests';
+import { createCustomPropsTest } from '@shared/tests/utils';
 import { {{name}} } from '@ui5/webcomponents-react/dist/{{name}}';
 import React from 'react';
 
@@ -7,4 +8,5 @@ describe('{{name}}', () => {
     const { asFragment } = render(<{{name}} />);
     expect(asFragment()).toMatchSnapshot();
   });
+  createCustomPropsTest({{name}});
 });

--- a/shared/tests/utils.tsx
+++ b/shared/tests/utils.tsx
@@ -11,7 +11,7 @@ export const modifyObjectProperty = (object: any, attr: string, value: any) => {
 
 export const createCustomPropsTest = (Component: ComponentType<any>, props = {}) => {
   test('Pass Through HTML Standard Props', () => {
-    render(
+    const { getByTitle, container } = render(
       <Component
         data-testid={'component-to-be-tested'}
         data-special-test-prop="data-prop"
@@ -19,6 +19,7 @@ export const createCustomPropsTest = (Component: ComponentType<any>, props = {})
         id="element-id"
         className="thisClassIsUsedForTestingPurposesOnly"
         style={{ pointerEvents: 'none' }}
+        title="Tooltip"
         customattribute="true"
         {...props}
       />
@@ -26,6 +27,7 @@ export const createCustomPropsTest = (Component: ComponentType<any>, props = {})
 
     const element = screen.getByTestId('component-to-be-tested');
 
+    expect(getByTitle('Tooltip')).toBeInTheDocument();
     expect(element.classList.contains('thisClassIsUsedForTestingPurposesOnly')).toBeTruthy();
     expect(element.style.pointerEvents).toEqual('none');
 

--- a/shared/tests/utils.tsx
+++ b/shared/tests/utils.tsx
@@ -11,7 +11,7 @@ export const modifyObjectProperty = (object: any, attr: string, value: any) => {
 
 export const createCustomPropsTest = (Component: ComponentType<any>, props = {}) => {
   test('Pass Through HTML Standard Props', () => {
-    const { getByTitle, container } = render(
+    const { getByTitle } = render(
       <Component
         data-testid={'component-to-be-tested'}
         data-special-test-prop="data-prop"


### PR DESCRIPTION
This PR adds the support of the `title` attribute to all ui5-webcomponents. Also the `tooltip` prop is now deprecated and will be removed with the next minor version.

Fixes #2472 