### PR TITLE
feat(SelectDialog): add `numberOfSelectedItems` prop to support `MultiSelect` mode

### DIFF
--- a/packages/main/src/components/SelectDialog/SelectDialog.stories.mdx
+++ b/packages/main/src/components/SelectDialog/SelectDialog.stories.mdx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Button } from '@ui5/webcomponents-react/dist/Button';
 import { StandardListItem } from '@ui5/webcomponents-react/dist/StandardListItem';
@@ -9,6 +10,10 @@ import Laptop1 from '../../../../../.storybook/demoImages/Laptop1.jpg';
 import Laptop2 from '../../../../../.storybook/demoImages/Laptop2.jpg';
 import Pc1 from '../../../../../.storybook/demoImages/PC1.jpg';
 import Pc2 from '../../../../../.storybook/demoImages/PC2.jpg';
+import { ListMode } from '@ui5/webcomponents-react/dist/ListMode';
+import { FlexBox } from '@ui5/webcomponents-react/dist/FlexBox';
+import { Label } from '@ui5/webcomponents-react/dist/Label';
+import { Text } from '@ui5/webcomponents-react/dist/Text';
 
 <Meta
   title="Modals & Popovers / SelectDialog"
@@ -73,5 +78,106 @@ This component exposes public methods. You can invoke them directly on the insta
 | **close**      | &mdash;                                                                                                                                                                              | Hides the block layer (for modal popups only)                                                                             |
 | **isOpen**     | &mdash;                                                                                                                                                                              | Override this method to provide custom logic for the popup's open/closed state. Maps to the "opened" property by default. |
 | **show**       | <dl><dt className="methodText">**preventInitialFocus** _optional_</dt><dd className="methodText">prevents applying the focus inside the popup</dd><dd><code>boolean</code></dd></dl> | Shows the block layer (for modal popups only) and sets the correct z-index for the purpose of popup stacking              |
+
+## More Examples
+
+### SelectDialog in MultiSelect mode with search
+
+<Canvas>
+  <Story name="MultiSelect">
+    {() => {
+      const listItems = [
+        { img: Laptop1, description: 'LT-10', text: 'Gaming Laptop' },
+        { img: Laptop2, description: 'LT-20', text: 'Business Laptop' },
+        { img: Pc2, description: 'HT-10', text: 'Gaming PC' },
+        { img: Pc1, description: 'HT-20', text: 'Business PC' }
+      ];
+      const dialogRef = useRef(null);
+      const onButtonClick = () => {
+        dialogRef.current.show();
+      };
+      const [searchVal, setSearchVal] = useState();
+      // search
+      const handleSearch = (e) => {
+        setSearchVal(e.detail.value);
+      };
+      const handleSearchReset = () => {
+        setSearchVal(undefined);
+      };
+      // predefined selection
+      const selectedProducts = { 'HT-102': true, 'HT-203': true, 'HT-1038': true };
+      // number of selected items
+      const [selectedItems, setSelectedItems] = useState(selectedProducts);
+      const handleItemClick = (e) => {
+        const itemDescription = e.detail.item.dataset.description;
+        setSelectedItems((prev) => {
+          if (prev[itemDescription]) {
+            const { [itemDescription]: omit, ...rest } = prev;
+            return rest;
+          } else {
+            return { ...prev, [itemDescription]: true };
+          }
+        });
+      };
+      // clear selection
+      const handleClear = () => {
+        setSelectedItems({});
+      };
+      // confirm selection
+      const [products, setProducts] = useState(Object.keys(selectedProducts));
+      const handleConfirm = () => {
+        setProducts(Object.keys(selectedItems));
+      };
+      return (
+        <>
+          <Button onClick={onButtonClick}>Open Dialog</Button>
+          <SelectDialog
+            mode={ListMode.MultiSelect}
+            ref={dialogRef}
+            onSearchInput={handleSearch}
+            onSearch={handleSearch}
+            onSearchReset={handleSearchReset}
+            numberOfSelectedItems={Object.keys(selectedItems).length}
+            listProps={{ onItemClick: handleItemClick }}
+            showClearButton
+            onClear={handleClear}
+            onConfirm={handleConfirm}
+          >
+            {new Array(40)
+              .fill('')
+              .map((_, index) => {
+                const currentProduct = listItems[index % 4];
+                const description = `${currentProduct.description}${index}`;
+                const lowerCaseSearchVal = searchVal?.toLowerCase();
+                if (
+                  searchVal &&
+                  !description.toLowerCase().includes(lowerCaseSearchVal) &&
+                  !currentProduct.text.toLowerCase().includes(lowerCaseSearchVal)
+                ) {
+                  return null;
+                }
+                return (
+                  <StandardListItem
+                    image={currentProduct.img}
+                    description={`${currentProduct.description}${index}`}
+                    data-description={`${currentProduct.description}${index}`}
+                    key={`${currentProduct.text}${index}`}
+                    selected={selectedItems[description]}
+                  >
+                    {currentProduct.text}
+                  </StandardListItem>
+                );
+              })
+              .filter(Boolean)}
+          </SelectDialog>
+          <FlexBox>
+            <Label>Selected: </Label>
+            <Text>{products.join(', ')}</Text>
+          </FlexBox>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
 
 <Footer />

--- a/packages/main/src/components/SelectDialog/SelectDialog.test.tsx
+++ b/packages/main/src/components/SelectDialog/SelectDialog.test.tsx
@@ -148,4 +148,9 @@ describe('SelectDialog', () => {
     getByText('Exterminate');
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('numberOfSelectedItems', () => {
+    const { getByText } = render(<SelectDialog mode={ListMode.MultiSelect} numberOfSelectedItems={1337} />);
+    expect(getByText('Selected: 1337')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR adds the `numberOfSelectedItems` prop to support programatically setting the counter in `MultiSelection` mode in combination with searching. It also fixes an issue concerning programatically selected items not being recognized by the component.

Fixes #2492 