### PR TITLE
fix(ActionSheet): only announce aria role once

### DIFF
--- a/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
+++ b/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
@@ -4,12 +4,10 @@ exports[`ActionSheet Render without Crashing 1`] = `
 <body>
   <div />
   <ui5-responsive-popover
-    aria-modal="true"
     class="ActionSheet-actionSheet myCustomClass"
     data-actionsheet="true"
     horizontal-align="Center"
     placement-type="Right"
-    role="dialog"
     ui5-responsive-popover=""
     vertical-align="Center"
   >
@@ -57,12 +55,10 @@ exports[`ActionSheet does not crash with other component 1`] = `
 <body>
   <div />
   <ui5-responsive-popover
-    aria-modal="true"
     class="ActionSheet-actionSheet"
     data-actionsheet="true"
     horizontal-align="Center"
     placement-type="Right"
-    role="dialog"
     ui5-responsive-popover=""
     vertical-align="Center"
   >

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -187,8 +187,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: RefObject<Resp
   const displayHeader = alwaysShowHeader || isPhone();
   return createPortal(
     <ResponsivePopover
-      aria-modal
-      role="dialog"
       style={style}
       slot={slot}
       allowTargetOverlap={allowTargetOverlap}


### PR DESCRIPTION
This PR removes the `role` (already set internally on the web component) and `aria-modal` (wrong for popover as it doesn't prevent the user from interacting with other content) prop from the `ResponsivePopover.