### PR TITLE
feat: add `waitForDefine` prop to all components with web component base

### DIFF
--- a/packages/main/scripts/create-web-components-wrapper.mjs
+++ b/packages/main/scripts/create-web-components-wrapper.mjs
@@ -293,16 +293,23 @@ const createWebComponentWrapper = async (
     }.js';`
   ];
 
+  const waitForDefineType = `/**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;`;
+
   return await renderComponentWrapper({
     name: componentSpec.module,
     imports,
     propTypesExtends: tsExtendsStatement,
     domRefExtends,
     attributes,
-    slotsAndEvents,
+    slotsAndEvents: [...slotsAndEvents, waitForDefineType],
     description: componentDescription,
     tagName: componentSpec.tagname,
-    regularProps,
+    regularProps: [...regularProps, 'waitForDefine'],
     booleanProps,
     slotProps: slotProps.filter((name) => name !== 'children'),
     eventProps,

--- a/packages/main/src/webComponents/Avatar/index.tsx
+++ b/packages/main/src/webComponents/Avatar/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Avatar.js';
 import { ReactNode } from 'react';
 import { AvatarColorScheme, AvatarShape, AvatarSize } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Avatar.js';
 
 interface AvatarAttributes {
   /**
@@ -84,6 +83,12 @@ export interface AvatarPropTypes extends AvatarAttributes, CommonProps {
    * `Avatar:not(:defined) {  visibility: hidden;   }   `
    */
   children?: ReactNode;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -93,7 +98,7 @@ export interface AvatarPropTypes extends AvatarAttributes, CommonProps {
  */
 const Avatar = withWebComponent<AvatarPropTypes, AvatarDomRef>(
   'ui5-avatar',
-  ['accessibleName', 'colorScheme', 'icon', 'initials', 'shape', 'size'],
+  ['accessibleName', 'colorScheme', 'icon', 'initials', 'shape', 'size', 'waitForDefine'],
   ['interactive'],
   [],
   []

--- a/packages/main/src/webComponents/AvatarGroup/index.tsx
+++ b/packages/main/src/webComponents/AvatarGroup/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/AvatarGroup.js';
 import { ReactNode } from 'react';
 import { AvatarColorScheme, AvatarGroupType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/AvatarGroup.js';
 
 interface AvatarGroupAttributes {
   /**
@@ -54,6 +53,12 @@ export interface AvatarGroupPropTypes extends AvatarGroupAttributes, Omit<Common
    * Fired when the count of visible `Avatar` elements in the component has changed
    */
   onOverflow?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -66,7 +71,7 @@ export interface AvatarGroupPropTypes extends AvatarGroupAttributes, Omit<Common
  */
 const AvatarGroup = withWebComponent<AvatarGroupPropTypes, AvatarGroupDomRef>(
   'ui5-avatar-group',
-  ['type'],
+  ['type', 'waitForDefine'],
   [],
   ['overflowButton'],
   ['click', 'overflow']

--- a/packages/main/src/webComponents/Badge/index.tsx
+++ b/packages/main/src/webComponents/Badge/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/Badge.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Badge.js';
 
 interface BadgeAttributes {
   /**
@@ -29,6 +28,12 @@ export interface BadgePropTypes extends BadgeAttributes, CommonProps {
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   icon?: ReactNode;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -36,7 +41,13 @@ export interface BadgePropTypes extends BadgeAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Badge" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Badge = withWebComponent<BadgePropTypes, BadgeDomRef>('ui5-badge', ['colorScheme'], [], ['icon'], []);
+const Badge = withWebComponent<BadgePropTypes, BadgeDomRef>(
+  'ui5-badge',
+  ['colorScheme', 'waitForDefine'],
+  [],
+  ['icon'],
+  []
+);
 
 Badge.displayName = 'Badge';
 

--- a/packages/main/src/webComponents/Bar/index.tsx
+++ b/packages/main/src/webComponents/Bar/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/Bar.js';
 import { ReactNode } from 'react';
 import { BarDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/Bar.js';
 
 interface BarAttributes {
   /**
@@ -41,6 +40,12 @@ export interface BarPropTypes extends BarAttributes, CommonProps {
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   startContent?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -48,7 +53,13 @@ export interface BarPropTypes extends BarAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Bar" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Bar = withWebComponent<BarPropTypes, BarDomRef>('ui5-bar', ['design'], [], ['endContent', 'startContent'], []);
+const Bar = withWebComponent<BarPropTypes, BarDomRef>(
+  'ui5-bar',
+  ['design', 'waitForDefine'],
+  [],
+  ['endContent', 'startContent'],
+  []
+);
 
 Bar.displayName = 'Bar';
 

--- a/packages/main/src/webComponents/BarcodeScannerDialog/index.tsx
+++ b/packages/main/src/webComponents/BarcodeScannerDialog/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/BarcodeScannerDialog.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/BarcodeScannerDialog.js';
 
 interface BarcodeScannerDialogAttributes {}
 
@@ -29,6 +28,12 @@ export interface BarcodeScannerDialogPropTypes extends BarcodeScannerDialogAttri
    * Fires when the scan is completed successfuuly.
    */
   onScanSuccess?: (event: Ui5CustomEvent<HTMLElement, { text: string; rawBytes: Record<string, unknown> }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -42,7 +47,7 @@ export interface BarcodeScannerDialogPropTypes extends BarcodeScannerDialogAttri
  */
 const BarcodeScannerDialog = withWebComponent<BarcodeScannerDialogPropTypes, BarcodeScannerDialogDomRef>(
   'ui5-barcode-scanner-dialog',
-  [],
+  ['waitForDefine'],
   [],
   [],
   ['scan-error', 'scan-success']

--- a/packages/main/src/webComponents/Breadcrumbs/index.tsx
+++ b/packages/main/src/webComponents/Breadcrumbs/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Breadcrumbs.js';
 import { ReactNode } from 'react';
 import { BreadcrumbsDesign, BreadcrumbsSeparatorStyle } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Breadcrumbs.js';
 
 interface BreadcrumbsAttributes {
   /**
@@ -42,6 +41,12 @@ export interface BreadcrumbsPropTypes extends BreadcrumbsAttributes, CommonProps
    * Fires when a `BreadcrumbsItem` is clicked.
    */
   onItemClick?: (event: Ui5CustomEvent<HTMLElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -55,7 +60,7 @@ export interface BreadcrumbsPropTypes extends BreadcrumbsAttributes, CommonProps
  */
 const Breadcrumbs = withWebComponent<BreadcrumbsPropTypes, BreadcrumbsDomRef>(
   'ui5-breadcrumbs',
-  ['design', 'separatorStyle'],
+  ['design', 'separatorStyle', 'waitForDefine'],
   [],
   [],
   ['item-click']

--- a/packages/main/src/webComponents/BreadcrumbsItem/index.tsx
+++ b/packages/main/src/webComponents/BreadcrumbsItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/BreadcrumbsItem.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/BreadcrumbsItem.js';
 
 interface BreadcrumbsItemAttributes {
   /**
@@ -43,6 +42,12 @@ export interface BreadcrumbsItemPropTypes extends BreadcrumbsItemAttributes, Com
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -52,7 +57,7 @@ export interface BreadcrumbsItemPropTypes extends BreadcrumbsItemAttributes, Com
  */
 const BreadcrumbsItem = withWebComponent<BreadcrumbsItemPropTypes, BreadcrumbsItemDomRef>(
   'ui5-breadcrumbs-item',
-  ['accessibleName', 'href', 'target'],
+  ['accessibleName', 'href', 'target', 'waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/BusyIndicator/index.tsx
+++ b/packages/main/src/webComponents/BusyIndicator/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/BusyIndicator.js';
 import { ReactNode } from 'react';
 import { BusyIndicatorSize } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/BusyIndicator.js';
 
 interface BusyIndicatorAttributes {
   /**
@@ -38,6 +37,12 @@ export interface BusyIndicatorPropTypes extends BusyIndicatorAttributes, CommonP
    * Determines the content over which the component will appear.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -47,7 +52,7 @@ export interface BusyIndicatorPropTypes extends BusyIndicatorAttributes, CommonP
  */
 const BusyIndicator = withWebComponent<BusyIndicatorPropTypes, BusyIndicatorDomRef>(
   'ui5-busy-indicator',
-  ['delay', 'size', 'text'],
+  ['delay', 'size', 'text', 'waitForDefine'],
   ['active'],
   [],
   []

--- a/packages/main/src/webComponents/Button/index.tsx
+++ b/packages/main/src/webComponents/Button/index.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import '@ui5/webcomponents/dist/Button.js';
+import { MouseEventHandler, ReactNode } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Button.js';
 
 interface ButtonAttributes {
   /**
@@ -65,6 +64,12 @@ export interface ButtonPropTypes extends ButtonAttributes, Omit<CommonProps, 'on
    * **Note:** The event will not be fired if the `disabled` property is set to `true`.
    */
   onClick?: MouseEventHandler<HTMLElement>;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -74,7 +79,7 @@ export interface ButtonPropTypes extends ButtonAttributes, Omit<CommonProps, 'on
  */
 const Button = withWebComponent<ButtonPropTypes, ButtonDomRef>(
   'ui5-button',
-  ['accessibleName', 'accessibleNameRef', 'design', 'icon'],
+  ['accessibleName', 'accessibleNameRef', 'design', 'icon', 'waitForDefine'],
   ['disabled', 'iconEnd', 'submits'],
   [],
   ['click']

--- a/packages/main/src/webComponents/Calendar/index.tsx
+++ b/packages/main/src/webComponents/Calendar/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Calendar.js';
 import { ReactNode } from 'react';
 import { CalendarSelectionMode, CalendarType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Calendar.js';
 
 interface CalendarAttributes {
   /**
@@ -55,6 +54,12 @@ export interface CalendarPropTypes extends CalendarAttributes, CommonProps {
    * Fired when the selected dates change. **Note:** If you call `preventDefault()` for this event, the component will not create instances of `CalendarDate` for the newly selected dates. In that case you should do this manually.
    */
   onSelectedDatesChange?: (event: Ui5CustomEvent<HTMLElement, { values: unknown[]; dates: unknown[] }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -66,7 +71,15 @@ export interface CalendarPropTypes extends CalendarAttributes, CommonProps {
  */
 const Calendar = withWebComponent<CalendarPropTypes, CalendarDomRef>(
   'ui5-calendar',
-  ['selectionMode', 'formatPattern', 'maxDate', 'minDate', 'primaryCalendarType', 'secondaryCalendarType'],
+  [
+    'selectionMode',
+    'formatPattern',
+    'maxDate',
+    'minDate',
+    'primaryCalendarType',
+    'secondaryCalendarType',
+    'waitForDefine'
+  ],
   ['hideWeekNumbers'],
   [],
   ['selected-dates-change']

--- a/packages/main/src/webComponents/CalendarDate/index.tsx
+++ b/packages/main/src/webComponents/CalendarDate/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/CalendarDate.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/CalendarDate.js';
 
 interface CalendarDateAttributes {
   /**
@@ -13,14 +12,27 @@ interface CalendarDateAttributes {
 
 export interface CalendarDateDomRef extends CalendarDateAttributes, Ui5DomRef {}
 
-export interface CalendarDatePropTypes extends CalendarDateAttributes, CommonProps {}
+export interface CalendarDatePropTypes extends CalendarDateAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `CalendarDate` component defines a calendar date to be used inside `Calendar`
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/CalendarDate" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const CalendarDate = withWebComponent<CalendarDatePropTypes, CalendarDateDomRef>('ui5-date', ['value'], [], [], []);
+const CalendarDate = withWebComponent<CalendarDatePropTypes, CalendarDateDomRef>(
+  'ui5-date',
+  ['value', 'waitForDefine'],
+  [],
+  [],
+  []
+);
 
 CalendarDate.displayName = 'CalendarDate';
 

--- a/packages/main/src/webComponents/Card/index.tsx
+++ b/packages/main/src/webComponents/Card/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/Card.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Card.js';
 
 interface CardAttributes {
   /**
@@ -32,6 +31,12 @@ export interface CardPropTypes extends CardAttributes, CommonProps {
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   header?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -41,7 +46,7 @@ export interface CardPropTypes extends CardAttributes, CommonProps {
  */
 const Card = withWebComponent<CardPropTypes, CardDomRef>(
   'ui5-card',
-  ['accessibleName', 'accessibleNameRef'],
+  ['accessibleName', 'accessibleNameRef', 'waitForDefine'],
   [],
   ['header'],
   []

--- a/packages/main/src/webComponents/CardHeader/index.tsx
+++ b/packages/main/src/webComponents/CardHeader/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/CardHeader.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/CardHeader.js';
 
 interface CardHeaderAttributes {
   /**
@@ -52,6 +51,12 @@ export interface CardHeaderPropTypes extends CardHeaderAttributes, Omit<CommonPr
    * **Note:** The event would be fired only if the `interactive` property is set to true.
    */
   onClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -61,7 +66,7 @@ export interface CardHeaderPropTypes extends CardHeaderAttributes, Omit<CommonPr
  */
 const CardHeader = withWebComponent<CardHeaderPropTypes, CardHeaderDomRef>(
   'ui5-card-header',
-  ['status', 'subtitleText', 'titleText'],
+  ['status', 'subtitleText', 'titleText', 'waitForDefine'],
   ['interactive'],
   ['action', 'avatar'],
   ['click']

--- a/packages/main/src/webComponents/Carousel/index.tsx
+++ b/packages/main/src/webComponents/Carousel/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Carousel.js';
 import { ReactNode } from 'react';
 import { CarouselArrowsPlacement } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Carousel.js';
 
 interface CarouselAttributes {
   /**
@@ -66,6 +65,12 @@ export interface CarouselPropTypes extends CarouselAttributes, CommonProps {
    * Fired whenever the page changes due to user interaction, when the user clicks on the navigation arrows or while resizing, based on the `items-per-page-l`, `items-per-page-m` and `items-per-page-s` properties.
    */
   onNavigate?: (event: Ui5CustomEvent<HTMLElement, { selectedIndex: number }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -79,7 +84,7 @@ export interface CarouselPropTypes extends CarouselAttributes, CommonProps {
  */
 const Carousel = withWebComponent<CarouselPropTypes, CarouselDomRef>(
   'ui5-carousel',
-  ['arrowsPlacement', 'itemsPerPageL', 'itemsPerPageM', 'itemsPerPageS'],
+  ['arrowsPlacement', 'itemsPerPageL', 'itemsPerPageM', 'itemsPerPageS', 'waitForDefine'],
   ['cyclic', 'hideNavigationArrows', 'hidePageIndicator'],
   [],
   ['navigate']

--- a/packages/main/src/webComponents/CheckBox/index.tsx
+++ b/packages/main/src/webComponents/CheckBox/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/CheckBox.js';
 import { ValueState, WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/CheckBox.js';
 
 interface CheckBoxAttributes {
   /**
@@ -85,6 +84,12 @@ export interface CheckBoxPropTypes extends CheckBoxAttributes, Omit<CommonProps,
    * Fired when the component checked state changes.
    */
   onChange?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -98,7 +103,7 @@ export interface CheckBoxPropTypes extends CheckBoxAttributes, Omit<CommonProps,
  */
 const CheckBox = withWebComponent<CheckBoxPropTypes, CheckBoxDomRef>(
   'ui5-checkbox',
-  ['accessibleName', 'accessibleNameRef', 'name', 'text', 'valueState', 'wrappingType'],
+  ['accessibleName', 'accessibleNameRef', 'name', 'text', 'valueState', 'wrappingType', 'waitForDefine'],
   ['checked', 'disabled', 'indeterminate', 'readonly'],
   [],
   ['change']

--- a/packages/main/src/webComponents/ColorPalette/index.tsx
+++ b/packages/main/src/webComponents/ColorPalette/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/ColorPalette.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ColorPalette.js';
 
 interface ColorPaletteAttributes {}
 
@@ -19,6 +18,12 @@ export interface ColorPalettePropTypes extends ColorPaletteAttributes, CommonPro
    * Fired when the user selects a color.
    */
   onItemClick?: (event: Ui5CustomEvent<HTMLElement, { color: string }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -28,7 +33,7 @@ export interface ColorPalettePropTypes extends ColorPaletteAttributes, CommonPro
  */
 const ColorPalette = withWebComponent<ColorPalettePropTypes, ColorPaletteDomRef>(
   'ui5-color-palette',
-  [],
+  ['waitForDefine'],
   [],
   [],
   ['item-click']

--- a/packages/main/src/webComponents/ColorPaletteItem/index.tsx
+++ b/packages/main/src/webComponents/ColorPaletteItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/ColorPaletteItem.js';
 import { CSSProperties } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ColorPaletteItem.js';
 
 interface ColorPaletteItemAttributes {
   /**
@@ -16,7 +15,14 @@ interface ColorPaletteItemAttributes {
 
 export interface ColorPaletteItemDomRef extends ColorPaletteItemAttributes, Ui5DomRef {}
 
-export interface ColorPaletteItemPropTypes extends ColorPaletteItemAttributes, CommonProps {}
+export interface ColorPaletteItemPropTypes extends ColorPaletteItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `ColorPaletteItem` component represents a color in the the `ColorPalette`
@@ -25,7 +31,7 @@ export interface ColorPaletteItemPropTypes extends ColorPaletteItemAttributes, C
  */
 const ColorPaletteItem = withWebComponent<ColorPaletteItemPropTypes, ColorPaletteItemDomRef>(
   'ui5-color-palette-item',
-  ['value'],
+  ['value', 'waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/ColorPalettePopover/index.tsx
+++ b/packages/main/src/webComponents/ColorPalettePopover/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/ColorPalettePopover.js';
 import { CSSProperties, ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ColorPalettePopover.js';
 
 interface ColorPalettePopoverAttributes {
   /**
@@ -48,6 +47,12 @@ export interface ColorPalettePopoverPropTypes extends ColorPalettePopoverAttribu
    * Fired when the user selects a color.
    */
   onItemClick?: (event: Ui5CustomEvent<HTMLElement, { color: string }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -57,7 +62,7 @@ export interface ColorPalettePopoverPropTypes extends ColorPalettePopoverAttribu
  */
 const ColorPalettePopover = withWebComponent<ColorPalettePopoverPropTypes, ColorPalettePopoverDomRef>(
   'ui5-color-palette-popover',
-  ['defaultColor'],
+  ['defaultColor', 'waitForDefine'],
   ['showDefaultColor', 'showMoreColors', 'showRecentColors'],
   [],
   ['item-click']

--- a/packages/main/src/webComponents/ColorPicker/index.tsx
+++ b/packages/main/src/webComponents/ColorPicker/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/ColorPicker.js';
 import { CSSProperties } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ColorPicker.js';
 
 interface ColorPickerAttributes {
   /**
@@ -22,6 +21,12 @@ export interface ColorPickerPropTypes extends ColorPickerAttributes, Omit<Common
    * Fired when the the selected color is changed
    */
   onChange?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -31,7 +36,7 @@ export interface ColorPickerPropTypes extends ColorPickerAttributes, Omit<Common
  */
 const ColorPicker = withWebComponent<ColorPickerPropTypes, ColorPickerDomRef>(
   'ui5-color-picker',
-  ['color'],
+  ['color', 'waitForDefine'],
   [],
   [],
   ['change']

--- a/packages/main/src/webComponents/ComboBox/index.tsx
+++ b/packages/main/src/webComponents/ComboBox/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/ComboBox.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ComboBox.js';
 
 interface ComboBoxAttributes {
   /**
@@ -100,6 +99,12 @@ export interface ComboBoxPropTypes extends ComboBoxAttributes, Omit<CommonProps,
    * Fired when selection is changed by user interaction
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLInputElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -109,7 +114,7 @@ export interface ComboBoxPropTypes extends ComboBoxAttributes, Omit<CommonProps,
  */
 const ComboBox = withWebComponent<ComboBoxPropTypes, ComboBoxDomRef>(
   'ui5-combobox',
-  ['accessibleName', 'accessibleNameRef', 'filter', 'placeholder', 'value', 'valueState'],
+  ['accessibleName', 'accessibleNameRef', 'filter', 'placeholder', 'value', 'valueState', 'waitForDefine'],
   ['disabled', 'loading', 'readonly', 'required'],
   ['icon', 'valueStateMessage'],
   ['change', 'input', 'selection-change']

--- a/packages/main/src/webComponents/ComboBoxGroupItem/index.tsx
+++ b/packages/main/src/webComponents/ComboBoxGroupItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/ComboBoxGroupItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ComboBoxGroupItem.js';
 
 interface ComboBoxGroupItemAttributes {
   /**
@@ -13,7 +12,14 @@ interface ComboBoxGroupItemAttributes {
 
 export interface ComboBoxGroupItemDomRef extends ComboBoxGroupItemAttributes, Ui5DomRef {}
 
-export interface ComboBoxGroupItemPropTypes extends ComboBoxGroupItemAttributes, CommonProps {}
+export interface ComboBoxGroupItemPropTypes extends ComboBoxGroupItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `undefined` is type of suggestion item, that can be used to split the `ComboBox` suggestions into groups
@@ -22,7 +28,7 @@ export interface ComboBoxGroupItemPropTypes extends ComboBoxGroupItemAttributes,
  */
 const ComboBoxGroupItem = withWebComponent<ComboBoxGroupItemPropTypes, ComboBoxGroupItemDomRef>(
   'ui5-cb-group-item',
-  ['text'],
+  ['text', 'waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/ComboBoxItem/index.tsx
+++ b/packages/main/src/webComponents/ComboBoxItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/ComboBoxItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ComboBoxItem.js';
 
 interface ComboBoxItemAttributes {
   /**
@@ -17,7 +16,14 @@ interface ComboBoxItemAttributes {
 
 export interface ComboBoxItemDomRef extends ComboBoxItemAttributes, Ui5DomRef {}
 
-export interface ComboBoxItemPropTypes extends ComboBoxItemAttributes, CommonProps {}
+export interface ComboBoxItemPropTypes extends ComboBoxItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `ComboBoxItem` represents the item for a `ComboBox`
@@ -26,7 +32,7 @@ export interface ComboBoxItemPropTypes extends ComboBoxItemAttributes, CommonPro
  */
 const ComboBoxItem = withWebComponent<ComboBoxItemPropTypes, ComboBoxItemDomRef>(
   'ui5-cb-item',
-  ['additionalText', 'text'],
+  ['additionalText', 'text', 'waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/CustomListItem/index.tsx
+++ b/packages/main/src/webComponents/CustomListItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/CustomListItem.js';
 import { ReactNode } from 'react';
 import { ListItemType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/CustomListItem.js';
 
 interface CustomListItemAttributes {
   /**
@@ -35,6 +34,12 @@ export interface CustomListItemPropTypes extends CustomListItemAttributes, Commo
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
   onDetailClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -44,7 +49,7 @@ export interface CustomListItemPropTypes extends CustomListItemAttributes, Commo
  */
 const CustomListItem = withWebComponent<CustomListItemPropTypes, CustomListItemDomRef>(
   'ui5-li-custom',
-  ['accessibleName', 'type'],
+  ['accessibleName', 'type', 'waitForDefine'],
   ['selected'],
   [],
   ['detail-click']

--- a/packages/main/src/webComponents/DatePicker/index.tsx
+++ b/packages/main/src/webComponents/DatePicker/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/DatePicker.js';
 import { ReactNode } from 'react';
-import { ValueState, CalendarType } from '../../enums';
+import { CalendarType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/DatePicker.js';
 
 interface DatePickerAttributes {
   /**
@@ -142,6 +141,12 @@ export interface DatePickerPropTypes extends DatePickerAttributes, Omit<CommonPr
    * Fired when the value of the component is changed at each key stroke.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement, { value: string; valid: boolean }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -162,7 +167,8 @@ const DatePicker = withWebComponent<DatePickerPropTypes, DatePickerDomRef>(
     'maxDate',
     'minDate',
     'primaryCalendarType',
-    'secondaryCalendarType'
+    'secondaryCalendarType',
+    'waitForDefine'
   ],
   ['disabled', 'hideWeekNumbers', 'readonly', 'required'],
   ['valueStateMessage'],

--- a/packages/main/src/webComponents/DateRangePicker/index.tsx
+++ b/packages/main/src/webComponents/DateRangePicker/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/DateRangePicker.js';
 import { ReactNode } from 'react';
-import { ValueState, CalendarType } from '../../enums';
+import { CalendarType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/DateRangePicker.js';
 
 interface DateRangePickerAttributes {
   /**
@@ -150,6 +149,12 @@ export interface DateRangePickerPropTypes extends DateRangePickerAttributes, Omi
    * Fired when the value of the component is changed at each key stroke.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement, { value: string; valid: boolean }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -171,7 +176,8 @@ const DateRangePicker = withWebComponent<DateRangePickerPropTypes, DateRangePick
     'maxDate',
     'minDate',
     'primaryCalendarType',
-    'secondaryCalendarType'
+    'secondaryCalendarType',
+    'waitForDefine'
   ],
   ['disabled', 'hideWeekNumbers', 'readonly', 'required'],
   ['valueStateMessage'],

--- a/packages/main/src/webComponents/DateTimePicker/index.tsx
+++ b/packages/main/src/webComponents/DateTimePicker/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/DateTimePicker.js';
 import { ReactNode } from 'react';
-import { ValueState, CalendarType } from '../../enums';
+import { CalendarType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/DateTimePicker.js';
 
 interface DateTimePickerAttributes {
   /**
@@ -142,6 +141,12 @@ export interface DateTimePickerPropTypes extends DateTimePickerAttributes, Omit<
    * Fired when the value of the component is changed at each key stroke.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement, { value: string; valid: boolean }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -162,7 +167,8 @@ const DateTimePicker = withWebComponent<DateTimePickerPropTypes, DateTimePickerD
     'maxDate',
     'minDate',
     'primaryCalendarType',
-    'secondaryCalendarType'
+    'secondaryCalendarType',
+    'waitForDefine'
   ],
   ['disabled', 'hideWeekNumbers', 'readonly', 'required'],
   ['valueStateMessage'],

--- a/packages/main/src/webComponents/Dialog/index.tsx
+++ b/packages/main/src/webComponents/Dialog/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Dialog.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Dialog.js';
 
 interface DialogAttributes {
   /**
@@ -110,6 +109,12 @@ export interface DialogPropTypes extends DialogAttributes, Omit<CommonProps, 'dr
    * Fired before the component is opened. This event can be cancelled, which will prevent the popup from opening. **This event does not bubble.**
    */
   onBeforeOpen?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -121,7 +126,7 @@ export interface DialogPropTypes extends DialogAttributes, Omit<CommonProps, 'dr
  */
 const Dialog = withWebComponent<DialogPropTypes, DialogDomRef>(
   'ui5-dialog',
-  ['headerText', 'accessibleName', 'accessibleNameRef', 'initialFocus'],
+  ['headerText', 'accessibleName', 'accessibleNameRef', 'initialFocus', 'waitForDefine'],
   ['draggable', 'resizable', 'stretch', 'preventFocusRestore'],
   ['footer', 'header'],
   ['after-close', 'after-open', 'before-close', 'before-open']

--- a/packages/main/src/webComponents/DynamicSideContent/index.tsx
+++ b/packages/main/src/webComponents/DynamicSideContent/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/DynamicSideContent.js';
 import { ReactNode } from 'react';
 import { SideContentFallDown, SideContentPosition, SideContentVisibility } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/DynamicSideContent.js';
 
 interface DynamicSideContentAttributes {
   /**
@@ -88,6 +87,12 @@ export interface DynamicSideContentPropTypes extends DynamicSideContentAttribute
       }
     >
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -97,7 +102,7 @@ export interface DynamicSideContentPropTypes extends DynamicSideContentAttribute
  */
 const DynamicSideContent = withWebComponent<DynamicSideContentPropTypes, DynamicSideContentDomRef>(
   'ui5-dynamic-side-content',
-  ['sideContentFallDown', 'sideContentPosition', 'sideContentVisibility'],
+  ['sideContentFallDown', 'sideContentPosition', 'sideContentVisibility', 'waitForDefine'],
   ['equalSplit', 'hideMainContent', 'hideSideContent'],
   ['sideContent'],
   ['layout-change']

--- a/packages/main/src/webComponents/FileUploader/index.tsx
+++ b/packages/main/src/webComponents/FileUploader/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/FileUploader.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/FileUploader.js';
 
 interface FileUploaderAttributes {
   /**
@@ -84,6 +83,12 @@ export interface FileUploaderPropTypes extends FileUploaderAttributes, Omit<Comm
    * Event is fired when the value of the file path has been changed. **Note:** Keep in mind that because of the HTML input element of type file, the event is also fired in Chrome browser when the Cancel button of the uploads window is pressed.
    */
   onChange?: (event: Ui5CustomEvent<HTMLElement, { files: FileList }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -95,7 +100,7 @@ export interface FileUploaderPropTypes extends FileUploaderAttributes, Omit<Comm
  */
 const FileUploader = withWebComponent<FileUploaderPropTypes, FileUploaderDomRef>(
   'ui5-file-uploader',
-  ['accept', 'name', 'placeholder', 'value', 'valueState'],
+  ['accept', 'name', 'placeholder', 'value', 'valueState', 'waitForDefine'],
   ['disabled', 'hideInput', 'multiple'],
   ['valueStateMessage'],
   ['change']

--- a/packages/main/src/webComponents/FilterItem/index.tsx
+++ b/packages/main/src/webComponents/FilterItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/FilterItem.js';
 import { ReactNode } from 'react';
 import { ListItemType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/FilterItem.js';
 
 interface FilterItemAttributes {
   /**
@@ -38,6 +37,12 @@ export interface FilterItemPropTypes extends FilterItemAttributes, CommonProps {
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
   onDetailClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -47,7 +52,7 @@ export interface FilterItemPropTypes extends FilterItemAttributes, CommonProps {
  */
 const FilterItem = withWebComponent<FilterItemPropTypes, FilterItemDomRef>(
   'ui5-filter-item',
-  ['text', 'type'],
+  ['text', 'type', 'waitForDefine'],
   ['selected'],
   ['values'],
   ['detail-click']

--- a/packages/main/src/webComponents/FilterItemOption/index.tsx
+++ b/packages/main/src/webComponents/FilterItemOption/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents-fiori/dist/FilterItemOption.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/FilterItemOption.js';
 
 interface FilterItemOptionAttributes {
   /**
@@ -17,7 +16,14 @@ interface FilterItemOptionAttributes {
 
 export interface FilterItemOptionDomRef extends FilterItemOptionAttributes, Ui5DomRef {}
 
-export interface FilterItemOptionPropTypes extends FilterItemOptionAttributes, CommonProps {}
+export interface FilterItemOptionPropTypes extends FilterItemOptionAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  *
@@ -26,7 +32,7 @@ export interface FilterItemOptionPropTypes extends FilterItemOptionAttributes, C
  */
 const FilterItemOption = withWebComponent<FilterItemOptionPropTypes, FilterItemOptionDomRef>(
   'ui5-filter-item-option',
-  ['text'],
+  ['text', 'waitForDefine'],
   ['selected'],
   [],
   []

--- a/packages/main/src/webComponents/FlexibleColumnLayout/index.tsx
+++ b/packages/main/src/webComponents/FlexibleColumnLayout/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/FlexibleColumnLayout.js';
 import { ReactNode } from 'react';
 import { FCLLayout } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/FlexibleColumnLayout.js';
 
 interface FlexibleColumnLayoutAttributes {
   /**
@@ -122,6 +121,12 @@ export interface FlexibleColumnLayoutPropTypes extends FlexibleColumnLayoutAttri
       }
     >
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -131,7 +136,7 @@ export interface FlexibleColumnLayoutPropTypes extends FlexibleColumnLayoutAttri
  */
 const FlexibleColumnLayout = withWebComponent<FlexibleColumnLayoutPropTypes, FlexibleColumnLayoutDomRef>(
   'ui5-flexible-column-layout',
-  ['accessibilityRoles', 'accessibilityTexts', 'layout'],
+  ['accessibilityRoles', 'accessibilityTexts', 'layout', 'waitForDefine'],
   ['hideArrows'],
   ['endColumn', 'midColumn', 'startColumn'],
   ['layout-change']

--- a/packages/main/src/webComponents/GroupHeaderListItem/index.tsx
+++ b/packages/main/src/webComponents/GroupHeaderListItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/GroupHeaderListItem.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/GroupHeaderListItem.js';
 
 interface GroupHeaderListItemAttributes {
   /**
@@ -24,6 +23,12 @@ export interface GroupHeaderListItemPropTypes extends GroupHeaderListItemAttribu
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -33,7 +38,7 @@ export interface GroupHeaderListItemPropTypes extends GroupHeaderListItemAttribu
  */
 const GroupHeaderListItem = withWebComponent<GroupHeaderListItemPropTypes, GroupHeaderListItemDomRef>(
   'ui5-li-groupheader',
-  ['accessibleName'],
+  ['accessibleName', 'waitForDefine'],
   ['selected'],
   [],
   []

--- a/packages/main/src/webComponents/Icon/index.tsx
+++ b/packages/main/src/webComponents/Icon/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/Icon.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Icon.js';
 
 interface IconAttributes {
   /**
@@ -38,7 +37,14 @@ interface IconAttributes {
 
 export interface IconDomRef extends IconAttributes, Ui5DomRef {}
 
-export interface IconPropTypes extends IconAttributes, CommonProps {}
+export interface IconPropTypes extends IconAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `Icon` component represents an SVG icon. There are two main scenarios how the `Icon` component is used: as a purely decorative element; or as a visually appealing clickable area in the form of an icon button.
@@ -53,7 +59,7 @@ export interface IconPropTypes extends IconAttributes, CommonProps {}
  */
 const Icon = withWebComponent<IconPropTypes, IconDomRef>(
   'ui5-icon',
-  ['accessibleName', 'accessibleRole', 'name'],
+  ['accessibleName', 'accessibleRole', 'name', 'waitForDefine'],
   ['interactive', 'showTooltip'],
   [],
   []

--- a/packages/main/src/webComponents/IllustratedMessage/index.tsx
+++ b/packages/main/src/webComponents/IllustratedMessage/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/IllustratedMessage.js';
 import { ReactNode } from 'react';
 import { IllustrationMessageType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/IllustratedMessage.js';
 
 interface IllustratedMessageAttributes {
   /**
@@ -125,6 +124,12 @@ export interface IllustratedMessagePropTypes extends IllustratedMessageAttribute
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   subtitle?: ReactNode;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -137,7 +142,7 @@ export interface IllustratedMessagePropTypes extends IllustratedMessageAttribute
  */
 const IllustratedMessage = withWebComponent<IllustratedMessagePropTypes, IllustratedMessageDomRef>(
   'ui5-illustrated-message',
-  ['name', 'subtitleText', 'titleText'],
+  ['name', 'subtitleText', 'titleText', 'waitForDefine'],
   [],
   ['subtitle'],
   []

--- a/packages/main/src/webComponents/Input/index.tsx
+++ b/packages/main/src/webComponents/Input/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Input.js';
 import { ReactNode } from 'react';
 import { InputType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Input.js';
 
 interface InputAttributes {
   /**
@@ -153,6 +152,12 @@ export interface InputPropTypes extends InputAttributes, Omit<CommonProps, 'onCh
    * Fired when a suggestion item, that is displayed in the suggestion popup, is selected.
    */
   onSuggestionItemSelect?: (event: Ui5CustomEvent<HTMLInputElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -167,7 +172,17 @@ export interface InputPropTypes extends InputAttributes, Omit<CommonProps, 'onCh
  */
 const Input = withWebComponent<InputPropTypes, InputDomRef>(
   'ui5-input',
-  ['accessibleName', 'accessibleNameRef', 'maxlength', 'name', 'placeholder', 'type', 'value', 'valueState'],
+  [
+    'accessibleName',
+    'accessibleNameRef',
+    'maxlength',
+    'name',
+    'placeholder',
+    'type',
+    'value',
+    'valueState',
+    'waitForDefine'
+  ],
   ['disabled', 'readonly', 'required', 'showSuggestions'],
   ['icon', 'valueStateMessage'],
   ['change', 'input', 'suggestion-item-preview', 'suggestion-item-select']

--- a/packages/main/src/webComponents/Label/index.tsx
+++ b/packages/main/src/webComponents/Label/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Label.js';
 import { ReactNode } from 'react';
 import { WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Label.js';
 
 interface LabelAttributes {
   /**
@@ -42,6 +41,12 @@ export interface LabelPropTypes extends LabelAttributes, CommonProps {
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -53,7 +58,7 @@ export interface LabelPropTypes extends LabelAttributes, CommonProps {
  */
 const Label = withWebComponent<LabelPropTypes, LabelDomRef>(
   'ui5-label',
-  ['for', 'wrappingType'],
+  ['for', 'wrappingType', 'waitForDefine'],
   ['required', 'showColon'],
   [],
   []

--- a/packages/main/src/webComponents/Link/index.tsx
+++ b/packages/main/src/webComponents/Link/index.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import '@ui5/webcomponents/dist/Link.js';
+import { MouseEventHandler, ReactNode } from 'react';
 import { LinkDesign, WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Link.js';
 
 interface LinkAttributes {
   /**
@@ -79,6 +78,12 @@ export interface LinkPropTypes extends LinkAttributes, Omit<CommonProps, 'onClic
    * Fired when the component is triggered either with a mouse/tap or by using the Enter key.
    */
   onClick?: MouseEventHandler<HTMLElement>;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -88,7 +93,7 @@ export interface LinkPropTypes extends LinkAttributes, Omit<CommonProps, 'onClic
  */
 const Link = withWebComponent<LinkPropTypes, LinkDomRef>(
   'ui5-link',
-  ['accessibilityAttributes', 'accessibleNameRef', 'design', 'href', 'target', 'wrappingType'],
+  ['accessibilityAttributes', 'accessibleNameRef', 'design', 'href', 'target', 'wrappingType', 'waitForDefine'],
   ['disabled'],
   [],
   ['click']

--- a/packages/main/src/webComponents/List/index.tsx
+++ b/packages/main/src/webComponents/List/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/List.js';
 import { ReactNode } from 'react';
 import { ListGrowingMode, ListMode, ListSeparators } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/List.js';
 
 interface ListAttributes {
   /**
@@ -128,6 +127,12 @@ export interface ListPropTypes extends ListAttributes, CommonProps {
   onSelectionChange?: (
     event: Ui5CustomEvent<HTMLElement, { selectedItems: unknown[]; previouslySelectedItems: unknown[] }>
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -159,7 +164,8 @@ const List = withWebComponent<ListPropTypes, ListDomRef>(
     'headerText',
     'mode',
     'noDataText',
-    'separators'
+    'separators',
+    'waitForDefine'
   ],
   ['busy', 'indent'],
   ['header'],

--- a/packages/main/src/webComponents/MediaGallery/index.tsx
+++ b/packages/main/src/webComponents/MediaGallery/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/MediaGallery.js';
 import { ReactNode } from 'react';
 import { MediaGalleryLayout, MediaGalleryMenuHorizontalAlign, MediaGalleryMenuVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/MediaGallery.js';
 
 interface MediaGalleryAttributes {
   /**
@@ -71,6 +70,12 @@ export interface MediaGalleryPropTypes extends MediaGalleryAttributes, CommonPro
    * Fired when selection is changed by user interaction.
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -81,7 +86,7 @@ export interface MediaGalleryPropTypes extends MediaGalleryAttributes, CommonPro
  */
 const MediaGallery = withWebComponent<MediaGalleryPropTypes, MediaGalleryDomRef>(
   'ui5-media-gallery',
-  ['layout', 'menuHorizontalAlign', 'menuVerticalAlign'],
+  ['layout', 'menuHorizontalAlign', 'menuVerticalAlign', 'waitForDefine'],
   ['interactiveDisplayArea', 'showAllThumbnails'],
   [],
   ['display-area-click', 'overflow-click', 'selection-change']

--- a/packages/main/src/webComponents/MediaGalleryItem/index.tsx
+++ b/packages/main/src/webComponents/MediaGalleryItem/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/MediaGalleryItem.js';
 import { ReactNode } from 'react';
 import { MediaGalleryItemLayout } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/MediaGalleryItem.js';
 
 interface MediaGalleryItemAttributes {
   /**
@@ -40,6 +39,12 @@ export interface MediaGalleryItemPropTypes extends MediaGalleryItemAttributes, C
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   thumbnail?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -51,7 +56,7 @@ export interface MediaGalleryItemPropTypes extends MediaGalleryItemAttributes, C
  */
 const MediaGalleryItem = withWebComponent<MediaGalleryItemPropTypes, MediaGalleryItemDomRef>(
   'ui5-media-gallery-item',
-  ['layout'],
+  ['layout', 'waitForDefine'],
   ['disabled', 'selected'],
   ['thumbnail'],
   []

--- a/packages/main/src/webComponents/MessageStrip/index.tsx
+++ b/packages/main/src/webComponents/MessageStrip/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/MessageStrip.js';
 import { ReactNode } from 'react';
 import { MessageStripDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/MessageStrip.js';
 
 interface MessageStripAttributes {
   /**
@@ -48,6 +47,12 @@ export interface MessageStripPropTypes extends MessageStripAttributes, CommonPro
    * Fired when the close button is pressed either with a click/tap or by using the Enter or Space key.
    */
   onClose?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -57,7 +62,7 @@ export interface MessageStripPropTypes extends MessageStripAttributes, CommonPro
  */
 const MessageStrip = withWebComponent<MessageStripPropTypes, MessageStripDomRef>(
   'ui5-message-strip',
-  ['design'],
+  ['design', 'waitForDefine'],
   ['hideCloseButton', 'hideIcon'],
   ['icon'],
   ['close']

--- a/packages/main/src/webComponents/MultiComboBox/index.tsx
+++ b/packages/main/src/webComponents/MultiComboBox/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/MultiComboBox.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/MultiComboBox.js';
 
 interface MultiComboBoxAttributes {
   /**
@@ -101,6 +100,12 @@ export interface MultiComboBoxPropTypes extends MultiComboBoxAttributes, Omit<Co
    * Fired when selection is changed by user interaction in `SingleSelect` and `MultiSelect` modes.
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLInputElement, { items: unknown[] }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -110,7 +115,7 @@ export interface MultiComboBoxPropTypes extends MultiComboBoxAttributes, Omit<Co
  */
 const MultiComboBox = withWebComponent<MultiComboBoxPropTypes, MultiComboBoxDomRef>(
   'ui5-multi-combobox',
-  ['filter', 'placeholder', 'value', 'valueState'],
+  ['filter', 'placeholder', 'value', 'valueState', 'waitForDefine'],
   ['allowCustomValues', 'disabled', 'readonly', 'required'],
   ['icon', 'valueStateMessage'],
   ['change', 'input', 'open-change', 'selection-change']

--- a/packages/main/src/webComponents/MultiComboBoxItem/index.tsx
+++ b/packages/main/src/webComponents/MultiComboBoxItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/MultiComboBoxItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/MultiComboBoxItem.js';
 
 interface MultiComboBoxItemAttributes {
   /**
@@ -21,7 +20,14 @@ interface MultiComboBoxItemAttributes {
 
 export interface MultiComboBoxItemDomRef extends MultiComboBoxItemAttributes, Ui5DomRef {}
 
-export interface MultiComboBoxItemPropTypes extends MultiComboBoxItemAttributes, CommonProps {}
+export interface MultiComboBoxItemPropTypes extends MultiComboBoxItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `MultiComboBoxItem` represents the item for a `MultiComboBox`
@@ -30,7 +36,7 @@ export interface MultiComboBoxItemPropTypes extends MultiComboBoxItemAttributes,
  */
 const MultiComboBoxItem = withWebComponent<MultiComboBoxItemPropTypes, MultiComboBoxItemDomRef>(
   'ui5-mcb-item',
-  ['additionalText', 'text'],
+  ['additionalText', 'text', 'waitForDefine'],
   ['selected'],
   [],
   []

--- a/packages/main/src/webComponents/MultiInput/index.tsx
+++ b/packages/main/src/webComponents/MultiInput/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/MultiInput.js';
 import { ReactNode } from 'react';
 import { InputType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/MultiInput.js';
 
 interface MultiInputAttributes {
   /**
@@ -172,6 +171,12 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
    * Fired when a suggestion item, that is displayed in the suggestion popup, is selected.
    */
   onSuggestionItemSelect?: (event: Ui5CustomEvent<HTMLInputElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -187,7 +192,17 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
  */
 const MultiInput = withWebComponent<MultiInputPropTypes, MultiInputDomRef>(
   'ui5-multi-input',
-  ['accessibleName', 'accessibleNameRef', 'maxlength', 'name', 'placeholder', 'type', 'value', 'valueState'],
+  [
+    'accessibleName',
+    'accessibleNameRef',
+    'maxlength',
+    'name',
+    'placeholder',
+    'type',
+    'value',
+    'valueState',
+    'waitForDefine'
+  ],
   ['showValueHelpIcon', 'disabled', 'readonly', 'required', 'showSuggestions'],
   ['tokens', 'icon', 'valueStateMessage'],
   ['token-delete', 'value-help-trigger', 'change', 'input', 'suggestion-item-preview', 'suggestion-item-select']

--- a/packages/main/src/webComponents/NotificationAction/index.tsx
+++ b/packages/main/src/webComponents/NotificationAction/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/NotificationAction.js';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/NotificationAction.js';
 
 interface NotificationActionAttributes {
   /**
@@ -38,7 +37,14 @@ interface NotificationActionAttributes {
 
 export interface NotificationActionDomRef extends NotificationActionAttributes, Ui5DomRef {}
 
-export interface NotificationActionPropTypes extends NotificationActionAttributes, CommonProps {}
+export interface NotificationActionPropTypes extends NotificationActionAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `NotificationAction` represents an abstract action, used in the `NotificationListItem` and the `NotificationListItemBase` items
@@ -47,7 +53,7 @@ export interface NotificationActionPropTypes extends NotificationActionAttribute
  */
 const NotificationAction = withWebComponent<NotificationActionPropTypes, NotificationActionDomRef>(
   'ui5-notification-action',
-  ['design', 'icon', 'text'],
+  ['design', 'icon', 'text', 'waitForDefine'],
   ['disabled'],
   [],
   []

--- a/packages/main/src/webComponents/NotificationListGroupItem/index.tsx
+++ b/packages/main/src/webComponents/NotificationListGroupItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/NotificationListGroupItem.js';
 import { ReactNode } from 'react';
 import { Priority } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/NotificationListGroupItem.js';
 
 interface NotificationListGroupItemAttributes {
   /**
@@ -77,6 +76,12 @@ export interface NotificationListGroupItemPropTypes extends NotificationListGrou
    * Fired when the `Close` button is pressed.
    */
   onClose?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -93,7 +98,7 @@ export interface NotificationListGroupItemPropTypes extends NotificationListGrou
  */
 const NotificationListGroupItem = withWebComponent<NotificationListGroupItemPropTypes, NotificationListGroupItemDomRef>(
   'ui5-li-notification-group',
-  ['busyDelay', 'priority', 'titleText'],
+  ['busyDelay', 'priority', 'titleText', 'waitForDefine'],
   ['collapsed', 'showCounter', 'busy', 'read', 'showClose', 'selected'],
   ['actions'],
   ['toggle', 'close']

--- a/packages/main/src/webComponents/NotificationListItem/index.tsx
+++ b/packages/main/src/webComponents/NotificationListItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/NotificationListItem.js';
 import { ReactNode } from 'react';
-import { WrappingType, Priority } from '../../enums';
+import { Priority, WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/NotificationListItem.js';
 
 interface NotificationListItemAttributes {
   /**
@@ -90,6 +89,12 @@ export interface NotificationListItemPropTypes extends NotificationListItemAttri
    * Fired when the `Close` button is pressed.
    */
   onClose?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -105,7 +110,7 @@ export interface NotificationListItemPropTypes extends NotificationListItemAttri
  */
 const NotificationListItem = withWebComponent<NotificationListItemPropTypes, NotificationListItemDomRef>(
   'ui5-li-notification',
-  ['wrappingType', 'busyDelay', 'priority', 'titleText'],
+  ['wrappingType', 'busyDelay', 'priority', 'titleText', 'waitForDefine'],
   ['busy', 'read', 'showClose', 'selected'],
   ['avatar', 'footnotes', 'actions'],
   ['close']

--- a/packages/main/src/webComponents/Option/index.tsx
+++ b/packages/main/src/webComponents/Option/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/Option.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Option.js';
 
 interface OptionAttributes {
   /**
@@ -37,6 +36,12 @@ export interface OptionPropTypes extends OptionAttributes, CommonProps {
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -46,7 +51,7 @@ export interface OptionPropTypes extends OptionAttributes, CommonProps {
  */
 const Option = withWebComponent<OptionPropTypes, OptionDomRef>(
   'ui5-option',
-  ['icon', 'value'],
+  ['icon', 'value', 'waitForDefine'],
   ['disabled', 'selected'],
   [],
   []

--- a/packages/main/src/webComponents/Page/index.tsx
+++ b/packages/main/src/webComponents/Page/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/Page.js';
 import { ReactNode } from 'react';
 import { PageBackgroundDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/Page.js';
 
 interface PageAttributes {
   /**
@@ -56,6 +55,12 @@ export interface PagePropTypes extends PageAttributes, CommonProps {
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base--page#adding-custom-components-to-slots).
    */
   header?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -65,7 +70,7 @@ export interface PagePropTypes extends PageAttributes, CommonProps {
  */
 const Page = withWebComponent<PagePropTypes, PageDomRef>(
   'ui5-page',
-  ['backgroundDesign'],
+  ['backgroundDesign', 'waitForDefine'],
   ['disableScrolling', 'floatingFooter', 'hideFooter'],
   ['footer', 'header'],
   []

--- a/packages/main/src/webComponents/Panel/index.tsx
+++ b/packages/main/src/webComponents/Panel/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Panel.js';
 import { ReactNode } from 'react';
 import { PanelAccessibleRole, TitleLevel } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Panel.js';
 
 interface PanelAttributes {
   /**
@@ -62,6 +61,12 @@ export interface PanelPropTypes extends PanelAttributes, CommonProps {
    * Fired when the component is expanded/collapsed by user interaction.
    */
   onToggle?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -71,7 +76,7 @@ export interface PanelPropTypes extends PanelAttributes, CommonProps {
  */
 const Panel = withWebComponent<PanelPropTypes, PanelDomRef>(
   'ui5-panel',
-  ['accessibleName', 'accessibleRole', 'headerLevel', 'headerText'],
+  ['accessibleName', 'accessibleRole', 'headerLevel', 'headerText', 'waitForDefine'],
   ['collapsed', 'fixed', 'noAnimation'],
   ['header'],
   ['toggle']

--- a/packages/main/src/webComponents/Popover/index.tsx
+++ b/packages/main/src/webComponents/Popover/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Popover.js';
 import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Popover.js';
 
 interface PopoverAttributes {
   /**
@@ -140,6 +139,12 @@ export interface PopoverPropTypes extends PopoverAttributes, CommonProps {
    * Fired before the component is opened. This event can be cancelled, which will prevent the popup from opening. **This event does not bubble.**
    */
   onBeforeOpen?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -156,7 +161,8 @@ const Popover = withWebComponent<PopoverPropTypes, PopoverDomRef>(
     'verticalAlign',
     'accessibleName',
     'accessibleNameRef',
-    'initialFocus'
+    'initialFocus',
+    'waitForDefine'
   ],
   ['allowTargetOverlap', 'hideArrow', 'hideBackdrop', 'modal', 'preventFocusRestore'],
   ['footer', 'header'],

--- a/packages/main/src/webComponents/ProductSwitch/index.tsx
+++ b/packages/main/src/webComponents/ProductSwitch/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/ProductSwitch.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/ProductSwitch.js';
 
 interface ProductSwitchAttributes {}
 
@@ -14,6 +13,12 @@ export interface ProductSwitchPropTypes extends ProductSwitchAttributes, CommonP
    * Defines the items of the `ProductSwitch`.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -23,7 +28,7 @@ export interface ProductSwitchPropTypes extends ProductSwitchAttributes, CommonP
  */
 const ProductSwitch = withWebComponent<ProductSwitchPropTypes, ProductSwitchDomRef>(
   'ui5-product-switch',
-  [],
+  ['waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/ProductSwitchItem/index.tsx
+++ b/packages/main/src/webComponents/ProductSwitchItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/ProductSwitchItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/ProductSwitchItem.js';
 
 interface ProductSwitchItemAttributes {
   /**
@@ -49,6 +48,12 @@ export interface ProductSwitchItemPropTypes extends ProductSwitchItemAttributes,
    * Fired when the `ProductSwitchItem` is activated either with a click/tap or by using the Enter or Space key.
    */
   onClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -60,7 +65,7 @@ export interface ProductSwitchItemPropTypes extends ProductSwitchItemAttributes,
  */
 const ProductSwitchItem = withWebComponent<ProductSwitchItemPropTypes, ProductSwitchItemDomRef>(
   'ui5-product-switch-item',
-  ['icon', 'subtitleText', 'target', 'targetSrc', 'titleText'],
+  ['icon', 'subtitleText', 'target', 'targetSrc', 'titleText', 'waitForDefine'],
   [],
   [],
   ['click']

--- a/packages/main/src/webComponents/ProgressIndicator/index.tsx
+++ b/packages/main/src/webComponents/ProgressIndicator/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/ProgressIndicator.js';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ProgressIndicator.js';
 
 interface ProgressIndicatorAttributes {
   /**
@@ -41,7 +40,14 @@ interface ProgressIndicatorAttributes {
 
 export interface ProgressIndicatorDomRef extends ProgressIndicatorAttributes, Ui5DomRef {}
 
-export interface ProgressIndicatorPropTypes extends ProgressIndicatorAttributes, CommonProps {}
+export interface ProgressIndicatorPropTypes extends ProgressIndicatorAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * Shows the progress of a process in a graphical way. To indicate the progress, the inside of the component is filled with a color.
@@ -50,7 +56,7 @@ export interface ProgressIndicatorPropTypes extends ProgressIndicatorAttributes,
  */
 const ProgressIndicator = withWebComponent<ProgressIndicatorPropTypes, ProgressIndicatorDomRef>(
   'ui5-progress-indicator',
-  ['displayValue', 'value', 'valueState'],
+  ['displayValue', 'value', 'valueState', 'waitForDefine'],
   ['disabled', 'hideValue'],
   [],
   []

--- a/packages/main/src/webComponents/RadioButton/index.tsx
+++ b/packages/main/src/webComponents/RadioButton/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/RadioButton.js';
 import { ValueState, WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/RadioButton.js';
 
 interface RadioButtonAttributes {
   /**
@@ -78,6 +77,12 @@ export interface RadioButtonPropTypes extends RadioButtonAttributes, Omit<Common
    * Fired when the component checked state changes.
    */
   onChange?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -88,7 +93,7 @@ export interface RadioButtonPropTypes extends RadioButtonAttributes, Omit<Common
  */
 const RadioButton = withWebComponent<RadioButtonPropTypes, RadioButtonDomRef>(
   'ui5-radio-button',
-  ['accessibleNameRef', 'name', 'text', 'value', 'valueState', 'wrappingType'],
+  ['accessibleNameRef', 'name', 'text', 'value', 'valueState', 'wrappingType', 'waitForDefine'],
   ['checked', 'disabled', 'readonly'],
   [],
   ['change']

--- a/packages/main/src/webComponents/RangeSlider/index.tsx
+++ b/packages/main/src/webComponents/RangeSlider/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/RangeSlider.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/RangeSlider.js';
 
 interface RangeSliderAttributes {
   /**
@@ -61,6 +60,12 @@ export interface RangeSliderPropTypes extends RangeSliderAttributes, Omit<Common
    * Fired when the value changes due to user interaction that is not yet finished - during mouse/touch dragging.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -70,7 +75,7 @@ export interface RangeSliderPropTypes extends RangeSliderAttributes, Omit<Common
  */
 const RangeSlider = withWebComponent<RangeSliderPropTypes, RangeSliderDomRef>(
   'ui5-range-slider',
-  ['endValue', 'startValue', 'labelInterval', 'max', 'min', 'step'],
+  ['endValue', 'startValue', 'labelInterval', 'max', 'min', 'step', 'waitForDefine'],
   ['disabled', 'showTickmarks', 'showTooltip'],
   [],
   ['change', 'input']

--- a/packages/main/src/webComponents/RatingIndicator/index.tsx
+++ b/packages/main/src/webComponents/RatingIndicator/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/RatingIndicator.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/RatingIndicator.js';
 
 interface RatingIndicatorAttributes {
   /**
@@ -45,6 +44,12 @@ export interface RatingIndicatorPropTypes extends RatingIndicatorAttributes, Omi
    * The event is fired when the value changes.
    */
   onChange?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -54,7 +59,7 @@ export interface RatingIndicatorPropTypes extends RatingIndicatorAttributes, Omi
  */
 const RatingIndicator = withWebComponent<RatingIndicatorPropTypes, RatingIndicatorDomRef>(
   'ui5-rating-indicator',
-  ['accessibleName', 'max', 'value'],
+  ['accessibleName', 'max', 'value', 'waitForDefine'],
   ['disabled', 'readonly'],
   [],
   ['change']

--- a/packages/main/src/webComponents/ResponsivePopover/index.tsx
+++ b/packages/main/src/webComponents/ResponsivePopover/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/ResponsivePopover.js';
 import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ResponsivePopover.js';
 
 interface ResponsivePopoverAttributes {
   /**
@@ -140,6 +139,12 @@ export interface ResponsivePopoverPropTypes extends ResponsivePopoverAttributes,
    * Fired before the component is opened. This event can be cancelled, which will prevent the popup from opening. **This event does not bubble.**
    */
   onBeforeOpen?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -156,7 +161,8 @@ const ResponsivePopover = withWebComponent<ResponsivePopoverPropTypes, Responsiv
     'verticalAlign',
     'accessibleName',
     'accessibleNameRef',
-    'initialFocus'
+    'initialFocus',
+    'waitForDefine'
   ],
   ['allowTargetOverlap', 'hideArrow', 'hideBackdrop', 'modal', 'preventFocusRestore'],
   ['footer', 'header'],

--- a/packages/main/src/webComponents/SegmentedButton/index.tsx
+++ b/packages/main/src/webComponents/SegmentedButton/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/SegmentedButton.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/SegmentedButton.js';
 
 interface SegmentedButtonAttributes {
   /**
@@ -33,6 +32,12 @@ export interface SegmentedButtonPropTypes extends SegmentedButtonAttributes, Com
    * Fired when the selected item changes.
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLButtonElement, { selectedItem: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -44,7 +49,7 @@ export interface SegmentedButtonPropTypes extends SegmentedButtonAttributes, Com
  */
 const SegmentedButton = withWebComponent<SegmentedButtonPropTypes, SegmentedButtonDomRef>(
   'ui5-segmented-button',
-  ['accessibleName'],
+  ['accessibleName', 'waitForDefine'],
   [],
   [],
   ['selection-change']

--- a/packages/main/src/webComponents/SegmentedButtonItem/index.tsx
+++ b/packages/main/src/webComponents/SegmentedButtonItem/index.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import '@ui5/webcomponents/dist/SegmentedButtonItem.js';
+import { MouseEventHandler, ReactNode } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/SegmentedButtonItem.js';
 
 interface SegmentedButtonItemAttributes {
   /**
@@ -46,6 +45,12 @@ export interface SegmentedButtonItemPropTypes extends SegmentedButtonItemAttribu
    * **Note:** The event will not be fired if the `disabled` property is set to `true`.
    */
   onClick?: MouseEventHandler<HTMLElement>;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -57,7 +62,7 @@ export interface SegmentedButtonItemPropTypes extends SegmentedButtonItemAttribu
  */
 const SegmentedButtonItem = withWebComponent<SegmentedButtonItemPropTypes, SegmentedButtonItemDomRef>(
   'ui5-segmented-button-item',
-  ['accessibleName', 'accessibleNameRef', 'icon'],
+  ['accessibleName', 'accessibleNameRef', 'icon', 'waitForDefine'],
   ['pressed', 'disabled'],
   [],
   ['click']

--- a/packages/main/src/webComponents/Select/index.tsx
+++ b/packages/main/src/webComponents/Select/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Select.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Select.js';
 
 interface SelectAttributes {
   /**
@@ -78,6 +77,12 @@ export interface SelectPropTypes extends SelectAttributes, Omit<CommonProps, 'on
    * Fired when the selected option changes.
    */
   onChange?: (event: Ui5CustomEvent<HTMLSelectElement, { selectedOption: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -87,7 +92,7 @@ export interface SelectPropTypes extends SelectAttributes, Omit<CommonProps, 'on
  */
 const Select = withWebComponent<SelectPropTypes, SelectDomRef>(
   'ui5-select',
-  ['accessibleName', 'accessibleNameRef', 'name', 'valueState'],
+  ['accessibleName', 'accessibleNameRef', 'name', 'valueState', 'waitForDefine'],
   ['disabled', 'required'],
   ['valueStateMessage'],
   ['change']

--- a/packages/main/src/webComponents/ShellBar/index.tsx
+++ b/packages/main/src/webComponents/ShellBar/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/ShellBar.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/ShellBar.js';
 
 interface ShellBarAttributes {
   /**
@@ -142,6 +141,12 @@ export interface ShellBarPropTypes extends ShellBarAttributes, CommonProps {
    * Fired, when the profile slot is present.
    */
   onProfileClick?: (event: Ui5CustomEvent<HTMLElement, { targetRef: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -151,7 +156,7 @@ export interface ShellBarPropTypes extends ShellBarAttributes, CommonProps {
  */
 const ShellBar = withWebComponent<ShellBarPropTypes, ShellBarDomRef>(
   'ui5-shellbar',
-  ['accessibilityTexts', 'notificationsCount', 'primaryTitle', 'secondaryTitle'],
+  ['accessibilityTexts', 'notificationsCount', 'primaryTitle', 'secondaryTitle', 'waitForDefine'],
   ['showCoPilot', 'showNotifications', 'showProductSwitch'],
   ['logo', 'menuItems', 'profile', 'searchField', 'startButton'],
   ['co-pilot-click', 'logo-click', 'menu-item-click', 'notifications-click', 'product-switch-click', 'profile-click']

--- a/packages/main/src/webComponents/ShellBarItem/index.tsx
+++ b/packages/main/src/webComponents/ShellBarItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/ShellBarItem.js';
 import { MouseEventHandler } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/ShellBarItem.js';
 
 interface ShellBarItemAttributes {
   /**
@@ -27,6 +26,12 @@ export interface ShellBarItemPropTypes extends ShellBarItemAttributes, Omit<Comm
    * Fired, when the item is pressed.
    */
   onClick?: MouseEventHandler<HTMLElement>;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -36,7 +41,7 @@ export interface ShellBarItemPropTypes extends ShellBarItemAttributes, Omit<Comm
  */
 const ShellBarItem = withWebComponent<ShellBarItemPropTypes, ShellBarItemDomRef>(
   'ui5-shellbar-item',
-  ['count', 'icon', 'text'],
+  ['count', 'icon', 'text', 'waitForDefine'],
   [],
   [],
   ['click']

--- a/packages/main/src/webComponents/SideNavigation/index.tsx
+++ b/packages/main/src/webComponents/SideNavigation/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/SideNavigation.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/SideNavigation.js';
 
 interface SideNavigationAttributes {
   /**
@@ -40,6 +39,12 @@ export interface SideNavigationPropTypes extends SideNavigationAttributes, Commo
    * Fired when the selection has changed via user interaction
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLElement, { item: ReactNode }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -53,7 +58,7 @@ export interface SideNavigationPropTypes extends SideNavigationAttributes, Commo
  */
 const SideNavigation = withWebComponent<SideNavigationPropTypes, SideNavigationDomRef>(
   'ui5-side-navigation',
-  [],
+  ['waitForDefine'],
   ['collapsed'],
   ['fixedItems', 'header'],
   ['selection-change']

--- a/packages/main/src/webComponents/SideNavigationItem/index.tsx
+++ b/packages/main/src/webComponents/SideNavigationItem/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/SideNavigationItem.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/SideNavigationItem.js';
 
 interface SideNavigationItemAttributes {
   /**
@@ -38,6 +37,12 @@ export interface SideNavigationItemPropTypes extends SideNavigationItemAttribute
    * If you wish to nest menus, you can pass inner menu items to the default slot.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -47,7 +52,7 @@ export interface SideNavigationItemPropTypes extends SideNavigationItemAttribute
  */
 const SideNavigationItem = withWebComponent<SideNavigationItemPropTypes, SideNavigationItemDomRef>(
   'ui5-side-navigation-item',
-  ['icon', 'text'],
+  ['icon', 'text', 'waitForDefine'],
   ['expanded', 'selected', 'wholeItemToggleable'],
   [],
   []

--- a/packages/main/src/webComponents/SideNavigationSubItem/index.tsx
+++ b/packages/main/src/webComponents/SideNavigationSubItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents-fiori/dist/SideNavigationSubItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/SideNavigationSubItem.js';
 
 interface SideNavigationSubItemAttributes {
   /**
@@ -24,7 +23,14 @@ interface SideNavigationSubItemAttributes {
 
 export interface SideNavigationSubItemDomRef extends SideNavigationSubItemAttributes, Ui5DomRef {}
 
-export interface SideNavigationSubItemPropTypes extends SideNavigationSubItemAttributes, CommonProps {}
+export interface SideNavigationSubItemPropTypes extends SideNavigationSubItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `SideNavigationSubItem` is intended to be used inside a `SideNavigationItem` only.
@@ -33,7 +39,7 @@ export interface SideNavigationSubItemPropTypes extends SideNavigationSubItemAtt
  */
 const SideNavigationSubItem = withWebComponent<SideNavigationSubItemPropTypes, SideNavigationSubItemDomRef>(
   'ui5-side-navigation-sub-item',
-  ['icon', 'text'],
+  ['icon', 'text', 'waitForDefine'],
   ['selected'],
   [],
   []

--- a/packages/main/src/webComponents/Slider/index.tsx
+++ b/packages/main/src/webComponents/Slider/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/Slider.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Slider.js';
 
 interface SliderAttributes {
   /**
@@ -57,6 +56,12 @@ export interface SliderPropTypes extends SliderAttributes, Omit<CommonProps, 'on
    * Fired when the value changes due to user interaction that is not yet finished - during mouse/touch dragging.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -66,7 +71,7 @@ export interface SliderPropTypes extends SliderAttributes, Omit<CommonProps, 'on
  */
 const Slider = withWebComponent<SliderPropTypes, SliderDomRef>(
   'ui5-slider',
-  ['value', 'labelInterval', 'max', 'min', 'step'],
+  ['value', 'labelInterval', 'max', 'min', 'step', 'waitForDefine'],
   ['disabled', 'showTickmarks', 'showTooltip'],
   [],
   ['change', 'input']

--- a/packages/main/src/webComponents/SortItem/index.tsx
+++ b/packages/main/src/webComponents/SortItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents-fiori/dist/SortItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/SortItem.js';
 
 interface SortItemAttributes {
   /**
@@ -17,14 +16,27 @@ interface SortItemAttributes {
 
 export interface SortItemDomRef extends SortItemAttributes, Ui5DomRef {}
 
-export interface SortItemPropTypes extends SortItemAttributes, CommonProps {}
+export interface SortItemPropTypes extends SortItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  *
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/SortItem" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const SortItem = withWebComponent<SortItemPropTypes, SortItemDomRef>('ui5-sort-item', ['text'], ['selected'], [], []);
+const SortItem = withWebComponent<SortItemPropTypes, SortItemDomRef>(
+  'ui5-sort-item',
+  ['text', 'waitForDefine'],
+  ['selected'],
+  [],
+  []
+);
 
 SortItem.displayName = 'SortItem';
 

--- a/packages/main/src/webComponents/SplitButton/index.tsx
+++ b/packages/main/src/webComponents/SplitButton/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/SplitButton.js';
 import { ReactNode } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/SplitButton.js';
 
 interface SplitButtonAttributes {
   /**
@@ -58,6 +57,12 @@ export interface SplitButtonPropTypes extends SplitButtonAttributes, Omit<Common
    * Fired when the user clicks on the default action.
    */
   onClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -67,7 +72,7 @@ export interface SplitButtonPropTypes extends SplitButtonAttributes, Omit<Common
  */
 const SplitButton = withWebComponent<SplitButtonPropTypes, SplitButtonDomRef>(
   'ui5-split-button',
-  ['accessibleName', 'activeIcon', 'design', 'icon'],
+  ['accessibleName', 'activeIcon', 'design', 'icon', 'waitForDefine'],
   ['disabled'],
   [],
   ['arrow-click', 'click']

--- a/packages/main/src/webComponents/StandardListItem/index.tsx
+++ b/packages/main/src/webComponents/StandardListItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/StandardListItem.js';
 import { ReactNode } from 'react';
-import { ValueState, ListItemType } from '../../enums';
+import { ListItemType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/StandardListItem.js';
 
 interface StandardListItemAttributes {
   /**
@@ -68,6 +67,12 @@ export interface StandardListItemPropTypes extends StandardListItemAttributes, C
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
   onDetailClick?: (event: Ui5CustomEvent<HTMLLIElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -77,7 +82,7 @@ export interface StandardListItemPropTypes extends StandardListItemAttributes, C
  */
 const StandardListItem = withWebComponent<StandardListItemPropTypes, StandardListItemDomRef>(
   'ui5-li',
-  ['accessibleName', 'additionalText', 'additionalTextState', 'description', 'icon', 'image', 'type'],
+  ['accessibleName', 'additionalText', 'additionalTextState', 'description', 'icon', 'image', 'type', 'waitForDefine'],
   ['iconEnd', 'selected'],
   [],
   ['detail-click']

--- a/packages/main/src/webComponents/StepInput/index.tsx
+++ b/packages/main/src/webComponents/StepInput/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/StepInput.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/StepInput.js';
 
 interface StepInputAttributes {
   /**
@@ -93,6 +92,12 @@ export interface StepInputPropTypes extends StepInputAttributes, Omit<CommonProp
    * Fired when the input operation has finished by pressing Enter or on focusout.
    */
   onChange?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -114,7 +119,8 @@ const StepInput = withWebComponent<StepInputPropTypes, StepInputDomRef>(
     'step',
     'value',
     'valuePrecision',
-    'valueState'
+    'valueState',
+    'waitForDefine'
   ],
   ['disabled', 'readonly', 'required'],
   ['valueStateMessage'],

--- a/packages/main/src/webComponents/SuggestionGroupItem/index.tsx
+++ b/packages/main/src/webComponents/SuggestionGroupItem/index.tsx
@@ -1,8 +1,7 @@
+import '@ui5/webcomponents/dist/SuggestionGroupItem.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/SuggestionGroupItem.js';
 
 interface SuggestionGroupItemAttributes {
   /**
@@ -13,7 +12,14 @@ interface SuggestionGroupItemAttributes {
 
 export interface SuggestionGroupItemDomRef extends SuggestionGroupItemAttributes, Ui5DomRef {}
 
-export interface SuggestionGroupItemPropTypes extends SuggestionGroupItemAttributes, CommonProps {}
+export interface SuggestionGroupItemPropTypes extends SuggestionGroupItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `SuggestionGroupItem` is type of suggestion item, that can be used to split the `Input` suggestions into groups
@@ -22,7 +28,7 @@ export interface SuggestionGroupItemPropTypes extends SuggestionGroupItemAttribu
  */
 const SuggestionGroupItem = withWebComponent<SuggestionGroupItemPropTypes, SuggestionGroupItemDomRef>(
   'ui5-suggestion-group-item',
-  ['text'],
+  ['text', 'waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/SuggestionItem/index.tsx
+++ b/packages/main/src/webComponents/SuggestionItem/index.tsx
@@ -1,9 +1,8 @@
-import { ValueState, ListItemType } from '../../enums';
+import '@ui5/webcomponents/dist/SuggestionItem.js';
+import { ListItemType, ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/SuggestionItem.js';
 
 interface SuggestionItemAttributes {
   /**
@@ -52,7 +51,14 @@ interface SuggestionItemAttributes {
 
 export interface SuggestionItemDomRef extends SuggestionItemAttributes, Ui5DomRef {}
 
-export interface SuggestionItemPropTypes extends SuggestionItemAttributes, CommonProps {}
+export interface SuggestionItemPropTypes extends SuggestionItemAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `SuggestionItem` represents the suggestion item of the `Input`
@@ -61,7 +67,7 @@ export interface SuggestionItemPropTypes extends SuggestionItemAttributes, Commo
  */
 const SuggestionItem = withWebComponent<SuggestionItemPropTypes, SuggestionItemDomRef>(
   'ui5-suggestion-item',
-  ['additionalText', 'additionalTextState', 'description', 'icon', 'image', 'text', 'type'],
+  ['additionalText', 'additionalTextState', 'description', 'icon', 'image', 'text', 'type', 'waitForDefine'],
   ['iconEnd'],
   [],
   []

--- a/packages/main/src/webComponents/Switch/index.tsx
+++ b/packages/main/src/webComponents/Switch/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Switch.js';
 import { SwitchDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Switch.js';
 
 interface SwitchAttributes {
   /**
@@ -50,6 +49,12 @@ export interface SwitchPropTypes extends SwitchAttributes, Omit<CommonProps, 'on
    * Fired when the component checked state changes.
    */
   onChange?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -62,7 +67,7 @@ export interface SwitchPropTypes extends SwitchAttributes, Omit<CommonProps, 'on
  */
 const Switch = withWebComponent<SwitchPropTypes, SwitchDomRef>(
   'ui5-switch',
-  ['accessibleNameRef', 'design', 'textOff', 'textOn'],
+  ['accessibleNameRef', 'design', 'textOff', 'textOn', 'waitForDefine'],
   ['checked', 'disabled'],
   [],
   ['change']

--- a/packages/main/src/webComponents/Tab/index.tsx
+++ b/packages/main/src/webComponents/Tab/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Tab.js';
 import { ReactNode } from 'react';
 import { SemanticColor } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Tab.js';
 
 interface TabAttributes {
   /**
@@ -58,6 +57,12 @@ export interface TabPropTypes extends TabAttributes, CommonProps {
    * Defines the tab content.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -67,7 +72,7 @@ export interface TabPropTypes extends TabAttributes, CommonProps {
  */
 const Tab = withWebComponent<TabPropTypes, TabDomRef>(
   'ui5-tab',
-  ['additionalText', 'design', 'icon', 'text'],
+  ['additionalText', 'design', 'icon', 'text', 'waitForDefine'],
   ['disabled', 'selected'],
   [],
   []

--- a/packages/main/src/webComponents/TabContainer/index.tsx
+++ b/packages/main/src/webComponents/TabContainer/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/TabContainer.js';
 import { ReactNode } from 'react';
 import { TabLayout, TabsOverflowMode } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TabContainer.js';
 
 interface TabContainerAttributes {
   /**
@@ -73,6 +72,12 @@ export interface TabContainerPropTypes extends TabContainerAttributes, CommonPro
    * Fired when a tab is selected.
    */
   onTabSelect?: (event: Ui5CustomEvent<HTMLElement, { tab: ReactNode; tabIndex: number }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -82,7 +87,7 @@ export interface TabContainerPropTypes extends TabContainerAttributes, CommonPro
  */
 const TabContainer = withWebComponent<TabContainerPropTypes, TabContainerDomRef>(
   'ui5-tabcontainer',
-  ['tabLayout', 'tabsOverflowMode'],
+  ['tabLayout', 'tabsOverflowMode', 'waitForDefine'],
   ['collapsed', 'fixed', 'showOverflow'],
   ['overflowButton', 'startOverflowButton'],
   ['tab-select']

--- a/packages/main/src/webComponents/TabSeparator/index.tsx
+++ b/packages/main/src/webComponents/TabSeparator/index.tsx
@@ -1,21 +1,33 @@
+import '@ui5/webcomponents/dist/TabSeparator.js';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TabSeparator.js';
 
 interface TabSeparatorAttributes {}
 
 export interface TabSeparatorDomRef extends TabSeparatorAttributes, Ui5DomRef {}
 
-export interface TabSeparatorPropTypes extends TabSeparatorAttributes, CommonProps {}
+export interface TabSeparatorPropTypes extends TabSeparatorAttributes, CommonProps {
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
+}
 
 /**
  * The `TabSeparator` represents a vertical line to separate tabs inside a `TabContainer`
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/TabSeparator" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const TabSeparator = withWebComponent<TabSeparatorPropTypes, TabSeparatorDomRef>('ui5-tab-separator', [], [], [], []);
+const TabSeparator = withWebComponent<TabSeparatorPropTypes, TabSeparatorDomRef>(
+  'ui5-tab-separator',
+  ['waitForDefine'],
+  [],
+  [],
+  []
+);
 
 TabSeparator.displayName = 'TabSeparator';
 

--- a/packages/main/src/webComponents/Table/index.tsx
+++ b/packages/main/src/webComponents/Table/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Table.js';
 import { ReactNode } from 'react';
 import { TableGrowingMode, TableMode } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Table.js';
 
 interface TableAttributes {
   /**
@@ -112,6 +111,12 @@ export interface TablePropTypes extends TableAttributes, CommonProps {
   onSelectionChange?: (
     event: Ui5CustomEvent<HTMLElement, { selectedRows: unknown[]; previouslySelectedRows: unknown[] }>
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -125,7 +130,7 @@ export interface TablePropTypes extends TableAttributes, CommonProps {
  */
 const Table = withWebComponent<TablePropTypes, TableDomRef>(
   'ui5-table',
-  ['busyDelay', 'growing', 'growingButtonSubtext', 'growingButtonText', 'mode', 'noDataText'],
+  ['busyDelay', 'growing', 'growingButtonSubtext', 'growingButtonText', 'mode', 'noDataText', 'waitForDefine'],
   ['busy', 'hideNoData', 'stickyColumnHeader'],
   ['columns'],
   ['load-more', 'popin-change', 'row-click', 'selection-change']

--- a/packages/main/src/webComponents/TableCell/index.tsx
+++ b/packages/main/src/webComponents/TableCell/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/TableCell.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TableCell.js';
 
 interface TableCellAttributes {}
 
@@ -14,6 +13,12 @@ export interface TableCellPropTypes extends TableCellAttributes, CommonProps {
    * Specifies the content of the component.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -21,7 +26,13 @@ export interface TableCellPropTypes extends TableCellAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/TableCell" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const TableCell = withWebComponent<TableCellPropTypes, TableCellDomRef>('ui5-table-cell', [], [], [], []);
+const TableCell = withWebComponent<TableCellPropTypes, TableCellDomRef>(
+  'ui5-table-cell',
+  ['waitForDefine'],
+  [],
+  [],
+  []
+);
 
 TableCell.displayName = 'TableCell';
 

--- a/packages/main/src/webComponents/TableColumn/index.tsx
+++ b/packages/main/src/webComponents/TableColumn/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/TableColumn.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TableColumn.js';
 
 interface TableColumnAttributes {
   /**
@@ -32,6 +31,12 @@ export interface TableColumnPropTypes extends TableColumnAttributes, CommonProps
    * Defines the content of the column header.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -41,7 +46,7 @@ export interface TableColumnPropTypes extends TableColumnAttributes, CommonProps
  */
 const TableColumn = withWebComponent<TableColumnPropTypes, TableColumnDomRef>(
   'ui5-table-column',
-  ['minWidth', 'popinText'],
+  ['minWidth', 'popinText', 'waitForDefine'],
   ['demandPopin'],
   [],
   []

--- a/packages/main/src/webComponents/TableGroupRow/index.tsx
+++ b/packages/main/src/webComponents/TableGroupRow/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents/dist/TableGroupRow.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TableGroupRow.js';
 
 interface TableGroupRowAttributes {}
 
@@ -15,6 +14,12 @@ export interface TableGroupRowPropTypes extends TableGroupRowAttributes, CommonP
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -24,7 +29,7 @@ export interface TableGroupRowPropTypes extends TableGroupRowAttributes, CommonP
  */
 const TableGroupRow = withWebComponent<TableGroupRowPropTypes, TableGroupRowDomRef>(
   'ui5-table-group-row',
-  [],
+  ['waitForDefine'],
   [],
   [],
   []

--- a/packages/main/src/webComponents/TableRow/index.tsx
+++ b/packages/main/src/webComponents/TableRow/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/TableRow.js';
 import { ReactNode } from 'react';
 import { TableRowType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TableRow.js';
 
 interface TableRowAttributes {
   /**
@@ -35,6 +34,12 @@ export interface TableRowPropTypes extends TableRowAttributes, CommonProps {
    * **Note:** Use `TableCell` for the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -42,7 +47,13 @@ export interface TableRowPropTypes extends TableRowAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/TableRow" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const TableRow = withWebComponent<TableRowPropTypes, TableRowDomRef>('ui5-table-row', ['type'], ['selected'], [], []);
+const TableRow = withWebComponent<TableRowPropTypes, TableRowDomRef>(
+  'ui5-table-row',
+  ['type', 'waitForDefine'],
+  ['selected'],
+  [],
+  []
+);
 
 TableRow.displayName = 'TableRow';
 

--- a/packages/main/src/webComponents/TextArea/index.tsx
+++ b/packages/main/src/webComponents/TextArea/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/TextArea.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TextArea.js';
 
 interface TextAreaAttributes {
   /**
@@ -117,6 +116,12 @@ export interface TextAreaPropTypes extends TextAreaAttributes, Omit<CommonProps,
    * Fired when the value of the component changes at each keystroke or when something is pasted.
    */
   onInput?: (event: Ui5CustomEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -137,7 +142,8 @@ const TextArea = withWebComponent<TextAreaPropTypes, TextAreaDomRef>(
     'placeholder',
     'rows',
     'value',
-    'valueState'
+    'valueState',
+    'waitForDefine'
   ],
   ['disabled', 'growing', 'readonly', 'required', 'showExceededText'],
   ['valueStateMessage'],

--- a/packages/main/src/webComponents/TimePicker/index.tsx
+++ b/packages/main/src/webComponents/TimePicker/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/TimePicker.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TimePicker.js';
 
 interface TimePickerAttributes {
   /**
@@ -97,6 +96,12 @@ export interface TimePickerPropTypes extends TimePickerAttributes, Omit<CommonPr
    * Fired when the value of the `TimePicker` is changed at each key stroke.
    */
   onInput?: (event: Ui5CustomEvent<HTMLInputElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -106,7 +111,7 @@ export interface TimePickerPropTypes extends TimePickerAttributes, Omit<CommonPr
  */
 const TimePicker = withWebComponent<TimePickerPropTypes, TimePickerDomRef>(
   'ui5-time-picker',
-  ['formatPattern', 'placeholder', 'value', 'valueState'],
+  ['formatPattern', 'placeholder', 'value', 'valueState', 'waitForDefine'],
   ['disabled', 'readonly'],
   ['valueStateMessage'],
   ['change', 'input']

--- a/packages/main/src/webComponents/Timeline/index.tsx
+++ b/packages/main/src/webComponents/Timeline/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/Timeline.js';
 import { ReactNode } from 'react';
 import { TimelineLayout } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/Timeline.js';
 
 interface TimelineAttributes {
   /**
@@ -25,6 +24,12 @@ export interface TimelinePropTypes extends TimelineAttributes, CommonProps {
    * Determines the content of the `Timeline`.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -32,7 +37,13 @@ export interface TimelinePropTypes extends TimelineAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Timeline" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Timeline = withWebComponent<TimelinePropTypes, TimelineDomRef>('ui5-timeline', ['layout'], [], [], []);
+const Timeline = withWebComponent<TimelinePropTypes, TimelineDomRef>(
+  'ui5-timeline',
+  ['layout', 'waitForDefine'],
+  [],
+  [],
+  []
+);
 
 Timeline.displayName = 'Timeline';
 

--- a/packages/main/src/webComponents/TimelineItem/index.tsx
+++ b/packages/main/src/webComponents/TimelineItem/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/TimelineItem.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/TimelineItem.js';
 
 interface TimelineItemAttributes {
   /**
@@ -44,6 +43,12 @@ export interface TimelineItemPropTypes extends TimelineItemAttributes, CommonPro
    * **Note:** The event will not be fired if the `name-clickable` attribute is not set.
    */
   onNameClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -53,7 +58,7 @@ export interface TimelineItemPropTypes extends TimelineItemAttributes, CommonPro
  */
 const TimelineItem = withWebComponent<TimelineItemPropTypes, TimelineItemDomRef>(
   'ui5-timeline-item',
-  ['icon', 'name', 'subtitleText', 'titleText'],
+  ['icon', 'name', 'subtitleText', 'titleText', 'waitForDefine'],
   ['nameClickable'],
   [],
   ['name-click']

--- a/packages/main/src/webComponents/Title/index.tsx
+++ b/packages/main/src/webComponents/Title/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Title.js';
 import { ReactNode } from 'react';
 import { TitleLevel, WrappingType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Title.js';
 
 interface TitleAttributes {
   /**
@@ -29,6 +28,12 @@ export interface TitlePropTypes extends TitleAttributes, CommonProps {
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -36,7 +41,13 @@ export interface TitlePropTypes extends TitleAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Title" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Title = withWebComponent<TitlePropTypes, TitleDomRef>('ui5-title', ['level', 'wrappingType'], [], [], []);
+const Title = withWebComponent<TitlePropTypes, TitleDomRef>(
+  'ui5-title',
+  ['level', 'wrappingType', 'waitForDefine'],
+  [],
+  [],
+  []
+);
 
 Title.displayName = 'Title';
 

--- a/packages/main/src/webComponents/Toast/index.tsx
+++ b/packages/main/src/webComponents/Toast/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Toast.js';
 import { ReactNode } from 'react';
 import { ToastPlacement } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Toast.js';
 
 interface ToastAttributes {
   /**
@@ -46,6 +45,12 @@ export interface ToastPropTypes extends ToastAttributes, CommonProps {
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -53,7 +58,13 @@ export interface ToastPropTypes extends ToastAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Toast" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Toast = withWebComponent<ToastPropTypes, ToastDomRef>('ui5-toast', ['duration', 'placement'], [], [], []);
+const Toast = withWebComponent<ToastPropTypes, ToastDomRef>(
+  'ui5-toast',
+  ['duration', 'placement', 'waitForDefine'],
+  [],
+  [],
+  []
+);
 
 Toast.displayName = 'Toast';
 

--- a/packages/main/src/webComponents/ToggleButton/index.tsx
+++ b/packages/main/src/webComponents/ToggleButton/index.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import '@ui5/webcomponents/dist/ToggleButton.js';
+import { MouseEventHandler, ReactNode } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/ToggleButton.js';
 
 interface ToggleButtonAttributes {
   /**
@@ -69,6 +68,12 @@ export interface ToggleButtonPropTypes extends ToggleButtonAttributes, Omit<Comm
    * **Note:** The event will not be fired if the `disabled` property is set to `true`.
    */
   onClick?: MouseEventHandler<HTMLElement>;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -80,7 +85,7 @@ export interface ToggleButtonPropTypes extends ToggleButtonAttributes, Omit<Comm
  */
 const ToggleButton = withWebComponent<ToggleButtonPropTypes, ToggleButtonDomRef>(
   'ui5-toggle-button',
-  ['accessibleName', 'accessibleNameRef', 'design', 'icon'],
+  ['accessibleName', 'accessibleNameRef', 'design', 'icon', 'waitForDefine'],
   ['pressed', 'disabled', 'iconEnd', 'submits'],
   [],
   ['click']

--- a/packages/main/src/webComponents/Token/index.tsx
+++ b/packages/main/src/webComponents/Token/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/Token.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Token.js';
 
 interface TokenAttributes {
   /**
@@ -37,6 +36,12 @@ export interface TokenPropTypes extends TokenAttributes, Omit<CommonProps, 'onSe
    * Fired when the the component is selected by user interaction with mouse or by clicking space.
    */
   onSelect?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -46,7 +51,7 @@ export interface TokenPropTypes extends TokenAttributes, Omit<CommonProps, 'onSe
  */
 const Token = withWebComponent<TokenPropTypes, TokenDomRef>(
   'ui5-token',
-  ['text'],
+  ['text', 'waitForDefine'],
   ['readonly', 'selected'],
   ['closeIcon'],
   ['select']

--- a/packages/main/src/webComponents/Tree/index.tsx
+++ b/packages/main/src/webComponents/Tree/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents/dist/Tree.js';
 import { ReactNode } from 'react';
 import { ListMode } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/Tree.js';
 
 interface TreeAttributes {
   /**
@@ -89,6 +88,12 @@ export interface TreePropTypes extends TreeAttributes, CommonProps {
   onSelectionChange?: (
     event: Ui5CustomEvent<HTMLElement, { selectedItems: unknown[]; previouslySelectedItems: unknown[] }>
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -98,7 +103,7 @@ export interface TreePropTypes extends TreeAttributes, CommonProps {
  */
 const Tree = withWebComponent<TreePropTypes, TreeDomRef>(
   'ui5-tree',
-  ['footerText', 'headerText', 'mode', 'noDataText'],
+  ['footerText', 'headerText', 'mode', 'noDataText', 'waitForDefine'],
   [],
   ['header'],
   ['item-click', 'item-delete', 'item-mouseout', 'item-mouseover', 'item-toggle', 'selection-change']

--- a/packages/main/src/webComponents/TreeItem/index.tsx
+++ b/packages/main/src/webComponents/TreeItem/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents/dist/TreeItem.js';
 import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents/dist/TreeItem.js';
 
 interface TreeItemAttributes {
   /**
@@ -65,6 +64,12 @@ export interface TreeItemPropTypes extends TreeItemAttributes, CommonProps {
    * Defines the items of this component.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -74,7 +79,7 @@ export interface TreeItemPropTypes extends TreeItemAttributes, CommonProps {
  */
 const TreeItem = withWebComponent<TreeItemPropTypes, TreeItemDomRef>(
   'ui5-tree-item',
-  ['additionalText', 'additionalTextState', 'icon', 'text'],
+  ['additionalText', 'additionalTextState', 'icon', 'text', 'waitForDefine'],
   ['expanded', 'hasChildren', 'indeterminate', 'selected'],
   [],
   []

--- a/packages/main/src/webComponents/UploadCollection/index.tsx
+++ b/packages/main/src/webComponents/UploadCollection/index.tsx
@@ -1,11 +1,10 @@
-import { ReactNode, DragEventHandler } from 'react';
+import '@ui5/webcomponents-fiori/dist/UploadCollection.js';
+import { DragEventHandler, ReactNode } from 'react';
 import { ListMode } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/UploadCollection.js';
 
 interface UploadCollectionAttributes {
   /**
@@ -72,6 +71,12 @@ export interface UploadCollectionPropTypes extends UploadCollectionAttributes, O
    * Fired when selection is changed by user interaction in `SingleSelect` and `MultiSelect` modes.
    */
   onSelectionChange?: (event: Ui5CustomEvent<HTMLElement, { selectedItems: unknown[] }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -81,7 +86,7 @@ export interface UploadCollectionPropTypes extends UploadCollectionAttributes, O
  */
 const UploadCollection = withWebComponent<UploadCollectionPropTypes, UploadCollectionDomRef>(
   'ui5-upload-collection',
-  ['accessibleName', 'mode', 'noDataDescription', 'noDataText'],
+  ['accessibleName', 'mode', 'noDataDescription', 'noDataText', 'waitForDefine'],
   ['hideDragOverlay'],
   ['header'],
   ['drop', 'item-delete', 'selection-change']

--- a/packages/main/src/webComponents/UploadCollectionItem/index.tsx
+++ b/packages/main/src/webComponents/UploadCollectionItem/index.tsx
@@ -1,11 +1,10 @@
+import '@ui5/webcomponents-fiori/dist/UploadCollectionItem.js';
 import { ReactNode } from 'react';
-import { UploadState, ListItemType } from '../../enums';
+import { ListItemType, UploadState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/UploadCollectionItem.js';
 
 interface UploadCollectionItemAttributes {
   /**
@@ -98,6 +97,12 @@ export interface UploadCollectionItemPropTypes extends UploadCollectionItemAttri
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
   onDetailClick?: (event: Ui5CustomEvent<HTMLElement>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -107,7 +112,7 @@ export interface UploadCollectionItemPropTypes extends UploadCollectionItemAttri
  */
 const UploadCollectionItem = withWebComponent<UploadCollectionItemPropTypes, UploadCollectionItemDomRef>(
   'ui5-upload-collection-item',
-  ['file', 'fileName', 'progress', 'uploadState', 'type'],
+  ['file', 'fileName', 'progress', 'uploadState', 'type', 'waitForDefine'],
   ['disableDeleteButton', 'fileNameClickable', 'hideRetryButton', 'hideTerminateButton', 'selected'],
   ['thumbnail'],
   ['file-name-click', 'rename', 'retry', 'terminate', 'detail-click']

--- a/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
+++ b/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/ViewSettingsDialog.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/ViewSettingsDialog.js';
 
 interface ViewSettingsDialogAttributes {
   /**
@@ -44,6 +43,12 @@ export interface ViewSettingsDialogPropTypes extends ViewSettingsDialogAttribute
    * Fired when confirmation button is activated.
    */
   onConfirm?: (event: Ui5CustomEvent<HTMLElement, { sortOrder: string; sortBy: string }>) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -53,7 +58,7 @@ export interface ViewSettingsDialogPropTypes extends ViewSettingsDialogAttribute
  */
 const ViewSettingsDialog = withWebComponent<ViewSettingsDialogPropTypes, ViewSettingsDialogDomRef>(
   'ui5-view-settings-dialog',
-  [],
+  ['waitForDefine'],
   ['sortDescending'],
   ['filterItems', 'sortItems'],
   ['cancel', 'confirm']

--- a/packages/main/src/webComponents/Wizard/index.tsx
+++ b/packages/main/src/webComponents/Wizard/index.tsx
@@ -1,10 +1,9 @@
+import '@ui5/webcomponents-fiori/dist/Wizard.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/Wizard.js';
 
 interface WizardAttributes {}
 
@@ -23,6 +22,12 @@ export interface WizardPropTypes extends WizardAttributes, CommonProps {
   onStepChange?: (
     event: Ui5CustomEvent<HTMLElement, { step: ReactNode; previousStep: ReactNode; changeWithClick: boolean }>
   ) => void;
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -30,7 +35,13 @@ export interface WizardPropTypes extends WizardAttributes, CommonProps {
  *
  * <ui5-link href="https://sap.github.io/ui5-webcomponents/playground/components/Wizard" target="_blank">UI5 Web Components Playground</ui5-link>
  */
-const Wizard = withWebComponent<WizardPropTypes, WizardDomRef>('ui5-wizard', [], [], [], ['step-change']);
+const Wizard = withWebComponent<WizardPropTypes, WizardDomRef>(
+  'ui5-wizard',
+  ['waitForDefine'],
+  [],
+  [],
+  ['step-change']
+);
 
 Wizard.displayName = 'Wizard';
 

--- a/packages/main/src/webComponents/WizardStep/index.tsx
+++ b/packages/main/src/webComponents/WizardStep/index.tsx
@@ -1,9 +1,8 @@
+import '@ui5/webcomponents-fiori/dist/WizardStep.js';
 import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-import '@ui5/webcomponents-fiori/dist/WizardStep.js';
 
 interface WizardStepAttributes {
   /**
@@ -53,6 +52,12 @@ export interface WizardStepPropTypes extends WizardStepAttributes, CommonProps {
    * Defines the step content.
    */
   children?: ReactNode | ReactNode[];
+  /**
+   * Defines whether the component should wait for the underlying custom element of the web component to be defined. This can be useful, for example, for using instance methods when mounting the component.
+   *
+   * __Note:__ This adds a rendering cycle to your component.
+   */
+  waitForDefine?: boolean;
 }
 
 /**
@@ -62,7 +67,7 @@ export interface WizardStepPropTypes extends WizardStepAttributes, CommonProps {
  */
 const WizardStep = withWebComponent<WizardStepPropTypes, WizardStepDomRef>(
   'ui5-wizard-step',
-  ['icon', 'subtitleText', 'titleText'],
+  ['icon', 'subtitleText', 'titleText', 'waitForDefine'],
   ['branching', 'disabled', 'selected'],
   [],
   []


### PR DESCRIPTION
This PR adds the possibility to wait for a custom element to be defined. This can be useful, for example, for using instance methods when mounting the component.