### PR TITLE
fix(ActionSheet): allow key navigation between action buttons with screen readers

### DIFF
--- a/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
+++ b/packages/main/src/components/ActionSheet/__snapshots__/ActionSheet.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ActionSheet Render without Crashing 1`] = `
     <div
       aria-label="Available Actions"
       data-component-name="ActionSheetMobileContent"
-      role="presentation"
+      role="application"
     >
       <ui5-button
         aria-label="1 of 3 Accept"
@@ -65,7 +65,7 @@ exports[`ActionSheet does not crash with other component 1`] = `
     <div
       aria-label="Available Actions"
       data-component-name="ActionSheetMobileContent"
-      role="presentation"
+      role="application"
     >
       <ui5-label
         aria-label="1 of 1 I should not crash"

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -204,7 +204,7 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
       <div
         className={isPhone() ? classes.contentMobile : undefined}
         data-component-name="ActionSheetMobileContent"
-        role={a11yConfig?.actionSheetMobileContent?.role ?? 'presentation'}
+        role={a11yConfig?.actionSheetMobileContent?.role ?? 'application'}
         aria-label={a11yConfig?.actionSheetMobileContent?.ariaLabel ?? i18nBundle.getText(AVAILABLE_ACTIONS)}
         onKeyDown={handleKeyDown}
         ref={actionBtnsRef}


### PR DESCRIPTION
This PR changes the role of the actions container to `application`, preventing screen readers like JAWS from intercepting the standard input events like `key-down` or `focus`.

Fixes #2646