### PR TITLE
fix(Toolbar): spacings between elements

### DIFF
--- a/packages/main/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
+++ b/packages/main/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`Toolbar overflow menu 1`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"
@@ -264,7 +264,7 @@ exports[`Toolbar overflow menu 1`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"
@@ -364,7 +364,7 @@ exports[`Toolbar overflow menu 2`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"
@@ -377,7 +377,7 @@ exports[`Toolbar overflow menu 2`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"
@@ -477,7 +477,7 @@ exports[`Toolbar overflow menu 3`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <div
             aria-label="Separator"
@@ -487,7 +487,7 @@ exports[`Toolbar overflow menu 3`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"
@@ -500,7 +500,7 @@ exports[`Toolbar overflow menu 3`] = `
         <div
           class="Toolbar-childContainer"
           data-component-name="ToolbarChildContainer"
-          style="visibility: hidden;"
+          style="visibility: hidden; position: absolute; pointer-events: none;"
         >
           <span
             class="Text-text"

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -270,14 +270,14 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
         toolbarElements = Array.from(toolbarChildren).filter((item, index) => index <= lastVisibleIndex);
       }
       onOverflowChange({
-        toolbarElements: toolbarElements,
-        overflowElements: overflowElements,
+        toolbarElements,
+        overflowElements,
         target: outerContainer.current
       });
     }
   }, [lastVisibleIndex]);
   const CustomTag = as as React.ElementType;
-  const styleWithMinWidth = minWidth !== '0' ? { minWidth: minWidth, ...style } : style;
+  const styleWithMinWidth = minWidth !== '0' ? { minWidth, ...style } : style;
   return (
     <CustomTag
       title={tooltip}
@@ -292,7 +292,9 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
         {overflowNeeded &&
           React.Children.map(childrenWithRef, (item, index) => {
             if (index >= lastVisibleIndex + 1 && index > numberOfAlwaysVisibleItems - 1) {
-              return React.cloneElement(item as ReactElement, { style: { visibility: 'hidden' } });
+              return React.cloneElement(item as ReactElement, {
+                style: { visibility: 'hidden', position: 'absolute' }
+              });
             }
             return item;
           })}

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -293,7 +293,7 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
           React.Children.map(childrenWithRef, (item, index) => {
             if (index >= lastVisibleIndex + 1 && index > numberOfAlwaysVisibleItems - 1) {
               return React.cloneElement(item as ReactElement, {
-                style: { visibility: 'hidden', position: 'absolute' }
+                style: { visibility: 'hidden', position: 'absolute', pointerEvents: 'none' }
               });
             }
             return item;


### PR DESCRIPTION
## Proposed change

This is the easier and shorter way I found to fix the bug explained [here](https://github.com/SAP/ui5-webcomponents-react/issues/2032).

```diff
- style: { visibility: 'hidden' }
+ style: { visibility: 'hidden', position: 'absolute', pointerEvents: 'none' }
```

## The problem

The elements inside the toolbar can be hidden based on the size of the window, when they're hidden the CSS property `visibility` is set to `hidden` - But even if they are NOT visible though, they still occupy space, and this is the cause of the bug.
In my solution, other than `visibility: hidden` I also set `position: absolute`, this way we can be sure that the hidden elements don't occupy space, `pointer-events: none` ensures that they will not be clickable in any case.

## Alternatives I've considered

Instead of `visibility: hidden` I tried using `display: none`, but this appears to doesn't work as expected, in fact, it causes an infinite re-render where we can see the item visible for a few milliseconds, then hidden for another few milliseconds and again visible... This issue is probably caused by the `ResizeObserver`.
Force the width to 0 causes the same issue.

## Further comments

I think the proposed solution would be just a temporary solution, Probably, it's better to think about a complete refactor of the Toolbar component.


Closes #2032

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/master/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/master/docs/Guidelines.md#commit-message-style)
