### PR TITLE
fix(withWebcomponent): add optional chaining for event listener registration

### DIFF
--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -112,7 +112,7 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
           const eventHandler = rest[createEventPropName(eventName)] as EventHandler;
           if (typeof eventHandler === 'function') {
             eventRegistry.current[eventName] = eventHandler;
-            ref.current.addEventListener(eventName, eventRegistry.current[eventName]);
+            ref.current?.addEventListener(eventName, eventRegistry.current[eventName]);
           }
         });
 


### PR DESCRIPTION
In some test scenarios the `ref` is initially not defined, which resulted in an error. This PR adds optional chaining to prevent this.