### PR TITLE
fix(DynamicPage): prevent error in React Strict Mode

### DIFF
--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -182,8 +182,10 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
 
   const onHoverToggleButton = (e) => {
     // TODO background color should be sapObjectHeader_Hover_Background (same color as sapTile_Active_Background)
-    topHeaderRef.current.style.backgroundColor =
-      e?.type === 'mouseover' ? ThemingParameters.sapTile_Active_Background : null;
+    if (topHeaderRef.current) {
+      topHeaderRef.current.style.backgroundColor =
+        e?.type === 'mouseover' ? ThemingParameters.sapTile_Active_Background : null;
+    }
   };
 
   const onToggleHeaderContent = (e) => {


### PR DESCRIPTION
This PR fixes an error in React Strict Mode. It was thrown while hovering the toggle button of the anchor bar when no `DynamicPageTitle` was set.