### PR TITLE
fix(AnalyticalTable): update table body height when changed on runtime

### DIFF
--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -2144,7 +2144,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins & hidden column 1`] = `
           />
           <div
             class="sapScrollBar VerticalScrollbar-scrollbar"
-            style="height: -44px;"
+            style="height: 220px;"
           >
             <div
               style="height: 1420px; width: 1px;"
@@ -2598,7 +2598,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins 1`] = `
           />
           <div
             class="sapScrollBar VerticalScrollbar-scrollbar"
-            style="height: -44px;"
+            style="height: 220px;"
           >
             <div
               style="height: 1420px; width: 1px;"
@@ -8535,7 +8535,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins & hidden column 1`] = `
         />
         <div
           class="sapScrollBar VerticalScrollbar-scrollbar"
-          style="height: -44px;"
+          style="height: 220px;"
         >
           <div
             style="height: 1420px; width: 1px;"
@@ -8985,7 +8985,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins 1`] = `
         />
         <div
           class="sapScrollBar VerticalScrollbar-scrollbar"
-          style="height: -44px;"
+          style="height: 220px;"
         >
           <div
             style="height: 1420px; width: 1px;"

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -679,7 +679,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
           : 0;
       const parentHeight = parentElement?.getBoundingClientRect().height;
       const tableHeight = parentHeight ? parentHeight - tableYPosition : 0;
-      const rowCount = Math.floor((tableHeight - extensionsHeight) / popInRowHeight);
+      const rowCount = Math.max(1, Math.floor((tableHeight - extensionsHeight) / popInRowHeight));
       dispatch({
         type: 'VISIBLE_ROWS',
         payload: { visibleRows: rowCount }
@@ -985,6 +985,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
         </div>
         {(tableState.isScrollable === undefined || tableState.isScrollable) && (
           <VerticalScrollbar
+            tableBodyHeight={tableBodyHeight}
             internalRowHeight={internalRowHeight}
             popInRowHeight={popInRowHeight}
             tableRef={tableRef}

--- a/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
+++ b/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
@@ -13,6 +13,7 @@ interface VerticalScrollbarProps {
   rows: any[];
   handleVerticalScrollBarScroll: any;
   popInRowHeight: number;
+  tableBodyHeight: number;
 }
 
 const styles = {
@@ -45,7 +46,8 @@ const styles = {
 const useStyles = createUseStyles(styles, { name: 'VerticalScrollbar' });
 
 export const VerticalScrollbar = forwardRef((props: VerticalScrollbarProps, ref: Ref<HTMLDivElement>) => {
-  const { internalRowHeight, tableRef, minRows, rows, handleVerticalScrollBarScroll, popInRowHeight } = props;
+  const { internalRowHeight, tableRef, minRows, rows, handleVerticalScrollBarScroll, popInRowHeight, tableBodyHeight } =
+    props;
   const classes = useStyles();
   const hasHorizontalScrollbar = tableRef?.current?.clientWidth !== tableRef?.current?.scrollWidth;
 
@@ -65,7 +67,7 @@ export const VerticalScrollbar = forwardRef((props: VerticalScrollbarProps, ref:
       <div
         ref={ref}
         style={{
-          height: tableRef.current ? `${tableRef.current.clientHeight - internalRowHeight}px` : '0'
+          height: tableRef.current ? `${tableBodyHeight}px` : '0'
         }}
         onScroll={handleVerticalScrollBarScroll}
         className={`${GlobalStyleClasses.sapScrollBar} ${classes.scrollbar}`}


### PR DESCRIPTION
The scrollbar container wasn't updated when the body changed its height on runtime, leading to an unnecessary overflow. Also if `TableVisibleRowCountMode.Auto` is used, the table now always shows at least one row.