### PR TITLE
fix(Toolbar): stretch overflow popover to available screen width on phones

### DIFF
--- a/packages/base/src/hooks/useIsRTL.ts
+++ b/packages/base/src/hooks/useIsRTL.ts
@@ -4,7 +4,7 @@ import { useIsomorphicLayoutEffect } from '../hooks';
 
 const GLOBAL_DIR_CSS_VAR = '--_ui5_dir';
 
-const detectRTL = (elementRef: RefObject<HTMLElement>) => {
+const detectRTL = <RefType extends HTMLElement>(elementRef: RefObject<RefType>) => {
   if (!elementRef.current) {
     return getRTL();
   }
@@ -30,7 +30,7 @@ const detectRTL = (elementRef: RefObject<HTMLElement>) => {
   return getRTL();
 };
 
-const useIsRTL = (elementRef: RefObject<HTMLElement>): boolean => {
+const useIsRTL = <RefType extends HTMLElement>(elementRef: RefObject<RefType>): boolean => {
   const [isRTL, setRTL] = useState<boolean>(getRTL()); // use config RTL as best guess
   const isMounted = useRef(false);
   useIsomorphicLayoutEffect(() => {

--- a/packages/main/src/components/Toolbar/OverflowPopover.tsx
+++ b/packages/main/src/components/Toolbar/OverflowPopover.tsx
@@ -1,4 +1,6 @@
 import '@ui5/webcomponents-icons/dist/overflow.js';
+import { Device, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
+import clsx from 'clsx';
 import React, { FC, ReactElement, ReactNode, Ref, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ButtonDesign } from '../../enums/ButtonDesign';
@@ -6,7 +8,6 @@ import { PopoverPlacementType } from '../../enums/PopoverPlacementType';
 import { stopPropagation } from '../../internal/stopPropagation';
 import { Popover, PopoverDomRef } from '../../webComponents/Popover';
 import { ToggleButton, ToggleButtonDomRef } from '../../webComponents/ToggleButton';
-import { useSyncRef } from '@ui5/webcomponents-react-base';
 
 interface OverflowPopoverProps {
   lastVisibleIndex: number;
@@ -18,6 +19,8 @@ interface OverflowPopoverProps {
   showMoreText: string;
   overflowPopoverRef?: Ref<PopoverDomRef>;
 }
+
+const isPhone = Device.isPhone();
 
 export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopoverProps) => {
   const {
@@ -34,6 +37,7 @@ export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopover
   const [componentRef, popoverRef] = useSyncRef<PopoverDomRef>(overflowPopoverRef);
   const [pressed, setPressed] = useState(false);
   const toggleBtnRef = useRef<ToggleButtonDomRef>(null);
+  const isRtl = useIsRTL(popoverRef);
 
   const handleToggleButtonClick = useCallback(
     (e) => {
@@ -113,14 +117,18 @@ export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopover
       />
       {createPortal(
         <Popover
-          className={classes.popover}
+          className={clsx(classes.popover, isPhone && classes.popoverPhone)}
           placementType={PopoverPlacementType.Bottom}
           ref={componentRef}
           onAfterClose={handleClose}
           onBeforeOpen={handleOpen}
           hideArrow
         >
-          <div className={classes.popoverContent} ref={overflowContentRef}>
+          <div
+            className={clsx(classes.popoverContent, isPhone && classes.popoverContentPhone)}
+            ref={overflowContentRef}
+            data-rtl={isRtl}
+          >
             {renderChildren()}
           </div>
         </Popover>,

--- a/packages/main/src/components/Toolbar/Toolbar.jss.ts
+++ b/packages/main/src/components/Toolbar/Toolbar.jss.ts
@@ -72,8 +72,14 @@ export const styles = {
       padding: 0
     }
   },
+  popoverPhone: {
+    width: '100%',
+    maxWidth: '100%',
+    left: '0 !important',
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0
+  },
   popoverContent: {
-    maxWidth: '20rem',
     padding: CssSizeVariables.sapWcrToolbarPopoverContentPadding,
     display: 'flex',
     flexDirection: 'column',
@@ -86,6 +92,10 @@ export const styles = {
     '& :last-child': {
       marginBottom: 0
     }
+  },
+  popoverContentPhone: {
+    '&[data-rtl="true"]': { paddingLeft: 0 },
+    '&[data-rtl="false"]': { paddingRight: 0 }
   },
   childContainer: { display: 'flex' }
 };

--- a/packages/main/src/components/Toolbar/Toolbar.stories.mdx
+++ b/packages/main/src/components/Toolbar/Toolbar.stories.mdx
@@ -190,7 +190,7 @@ If the horizontally available space isn't enough to fit all items in it, an over
           <Text>Toolbar</Text>
           <Button>Button One</Button>
           <Button>Button Two</Button>
-          <Select />
+          <Select style={{ width: 'auto' }} />
           <Switch />
           <Button>Button Three</Button>
           <Button>Button Four</Button>

--- a/packages/main/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
+++ b/packages/main/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
@@ -299,6 +299,7 @@ exports[`Toolbar overflow menu 1`] = `
   >
     <div
       class="Toolbar-popoverContent"
+      data-rtl="false"
     >
       <span
         class="Text-text"
@@ -412,6 +413,7 @@ exports[`Toolbar overflow menu 2`] = `
   >
     <div
       class="Toolbar-popoverContent"
+      data-rtl="false"
     >
       <span
         class="Text-text"
@@ -535,6 +537,7 @@ exports[`Toolbar overflow menu 3`] = `
   >
     <div
       class="Toolbar-popoverContent"
+      data-rtl="false"
     >
       <div
         aria-label="Separator"

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -36,7 +36,7 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick'> {
   /**
    * Defines the content of the `Toolbar`.
    */
-  children?: ReactNode | ReactNode[] | ReactFragment;
+  children?: ReactNode | ReactNode[];
   /**
    * Defines the visual style of the `Toolbar`.<br />
    * <b>Note:</b> The visual styles are theme-dependent.

--- a/packages/main/src/interfaces/Ui5DomRef.ts
+++ b/packages/main/src/interfaces/Ui5DomRef.ts
@@ -4,13 +4,13 @@ export interface Ui5DomRef extends Omit<HTMLElement, 'focus'> {
    *
    * @param callback
    */
-  attachInvalidate?: (callback) => void;
+  attachInvalidate: (callback) => void;
   /**
    * Detach the callback that is executed whenever the component is invalidated
    *
    * @param callback
    */
-  detachInvalidate?: (callback) => void;
+  detachInvalidate: (callback) => void;
   /**
    * Returns the DOM Element inside the Shadow Root that corresponds to the opening tag in the UI5 Web Component's template
    *
@@ -18,27 +18,27 @@ export interface Ui5DomRef extends Omit<HTMLElement, 'focus'> {
    *
    * Use this method instead of "this.shadowRoot" to read the Shadow DOM, if ever necessary
    */
-  getDomRef?: () => HTMLElement;
+  getDomRef: () => HTMLElement;
   /**
    * Returns the DOM Element marked with `data-sap-focus-ref` inside the template.
    * This is the element that will receive the focus by default.
    */
-  getFocusDomRef?: () => HTMLElement;
+  getFocusDomRef: () => HTMLElement;
   /**
    * Returns the DOM Element marked with `data-sap-focus-ref` inside the template.
    * This is the element that will receive the focus by default.
    */
-  getFocusDomRefAsync?: () => Promise<HTMLElement>;
+  getFocusDomRefAsync: () => Promise<HTMLElement>;
   /**
    * Set the focus to the element, returned by "getFocusDomRef()" (marked by "data-sap-focus-ref")
    */
-  focus?: () => Promise<void>;
+  focus: () => Promise<void>;
   /**
    * Used to duck-type UI5 elements without using instanceof
    */
-  readonly isUI5Element?: boolean;
+  readonly isUI5Element: boolean;
   /**
    * Returns the `staticAreaItem` DOM Element.
    */
-  readonly getStaticAreaItemDomRef?: HTMLElement;
+  readonly getStaticAreaItemDomRef: HTMLElement;
 }


### PR DESCRIPTION
This PR stretches the overflow popover of the Toolbar to the available screen width. It also improves the `useIsRtl` hook by allowing UI5DomRef elements to be passed to it.

Fixes #2735