### PR TITLE
feat(DynamicPage): make role of footer customizable

### DIFF
--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -396,6 +396,31 @@ describe('DynamicPage', () => {
     getByText('Footer');
     expect(asFragment()).toMatchSnapshot();
   });
+  test('a11y config', () => {
+    const { rerender } = render(
+      <DynamicPage
+        headerTitle={<DynamicPageTitle />}
+        headerContent={<DynamicPageHeader />}
+        footer={<Bar data-testid="footer" design={BarDesign.FloatingFooter} />}
+      />
+    );
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute('role', 'contentinfo');
+    expect(document.querySelector('[data-component-name="DynamicPageAnchorBar"]')).toHaveAttribute(
+      'role',
+      'navigation'
+    );
+
+    rerender(
+      <DynamicPage
+        headerTitle={<DynamicPageTitle />}
+        headerContent={<DynamicPageHeader />}
+        footer={<Bar data-testid="footer" design={BarDesign.FloatingFooter} />}
+        a11yConfig={{ dynamicPageAnchorBar: { role: 'anchorbar' }, dynamicPageFooter: { role: 'footer' } }}
+      />
+    );
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute('role', 'footer');
+    expect(document.querySelector('[data-component-name="DynamicPageAnchorBar"]')).toHaveAttribute('role', 'anchorbar');
+  });
 
   createCustomPropsTest(DynamicPage);
 });

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -254,7 +254,7 @@ exports[`DynamicPage always show content header 1`] = `
     </div>
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"
-      data-component-name="DynamicPageAnchorBar"
+      data-component-name="DynamicPageAnchorBarContainer"
       style="top: 0px;"
     >
       <section
@@ -440,7 +440,7 @@ exports[`DynamicPage hider header button 1`] = `
     </div>
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"
-      data-component-name="DynamicPageAnchorBar"
+      data-component-name="DynamicPageAnchorBarContainer"
       style="top: 0px;"
     >
       <section
@@ -644,7 +644,7 @@ exports[`DynamicPage render footer 1`] = `
   >
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"
-      data-component-name="DynamicPageAnchorBar"
+      data-component-name="DynamicPageAnchorBarContainer"
       style="top: 0px;"
     >
       <section
@@ -668,9 +668,10 @@ exports[`DynamicPage render footer 1`] = `
       data-component-name="DynamicPageContent"
       style="margin-top: 0px; padding-bottom: 1rem;"
     />
-    <footer
+    <div
       class="DynamicPage-footer"
       data-component-name="DynamicPageFooter"
+      role="contentinfo"
       style="position: absolute;"
     >
       <ui5-bar
@@ -685,7 +686,7 @@ exports[`DynamicPage render footer 1`] = `
           Footer
         </span>
       </ui5-bar>
-    </footer>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -943,7 +944,7 @@ exports[`DynamicPage with content 1`] = `
     </div>
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"
-      data-component-name="DynamicPageAnchorBar"
+      data-component-name="DynamicPageAnchorBarContainer"
       style="top: 0px;"
     >
       <section
@@ -1937,7 +1938,7 @@ exports[`DynamicPage without content 1`] = `
     </div>
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"
-      data-component-name="DynamicPageAnchorBar"
+      data-component-name="DynamicPageAnchorBarContainer"
       style="top: 0px;"
     >
       <section

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -64,6 +64,9 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
     dynamicPageAnchorBar?: {
       role?: string;
     };
+    dynamicPageFooter?: {
+      role?: string;
+    };
   };
 }
 
@@ -251,7 +254,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
           topHeaderHeight
         })}
       <FlexBox
-        data-component-name="DynamicPageAnchorBar"
+        data-component-name="DynamicPageAnchorBarContainer"
         className={anchorBarClasses}
         ref={anchorBarRef}
         style={{
@@ -295,13 +298,14 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
         {children}
       </div>
       {footer && (
-        <footer
+        <div
           className={classes.footer}
           style={{ position: isOverflowing ? 'sticky' : 'absolute' }}
           data-component-name="DynamicPageFooter"
+          role={a11yConfig?.dynamicPageFooter?.role ?? 'contentinfo'}
         >
           {footer}
-        </footer>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
This PR adds the `dynamicPageFooter` entry to the `a11yConfig` prop, making it possible to change the role of the footer.

Closes #2421