### PR TITLE
fix(AnalyticalTable): support custom `subRowsKey` in combination with `selectSubRows`

### DIFF
--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -553,7 +553,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
 
   const isRtl = useIsRTL(analyticalTableRef);
 
-  const getSubRows = useCallback((row) => row[subRowsKey] || [], [subRowsKey]);
+  const getSubRows = useCallback((row) => row.subRows || row[subRowsKey] || [], [subRowsKey]);
 
   const data = useMemo(() => {
     if (props.data.length === 0) {


### PR DESCRIPTION
This PR makes it possible to select all sub-rows when a row is selected and a custom `subRowsKey` is used. 

