### PR TITLE
fix(Form): prevent crash if window range is initially not available

### DIFF
--- a/packages/base/src/hooks/useResponsiveContentPadding.ts
+++ b/packages/base/src/hooks/useResponsiveContentPadding.ts
@@ -18,7 +18,7 @@ const useStyles = createUseStyles(
  * @param {HTMLElement} element
  */
 export const useResponsiveContentPadding = (element: HTMLElement) => {
-  const [currentRange, setCurrentRange] = useState(() => getCurrentRange().name);
+  const [currentRange, setCurrentRange] = useState(() => getCurrentRange()?.name ?? 'Desktop');
   const classes = useStyles();
   const requestAnimationFrameRef = useRef<number | undefined>();
 

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -139,8 +139,8 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
   labelSpanMap.set('LargeDesktop', labelSpanXL);
 
   const [componentRef, formRef] = useSyncRef<HTMLFormElement>(ref);
-  // use the window range set as first best guess
-  const [currentRange, setCurrentRange] = useState(Device.getCurrentRange().name);
+  // use the window range set as first best guess, if not available use Desktop
+  const [currentRange, setCurrentRange] = useState(Device.getCurrentRange()?.name ?? 'Desktop');
   const lastRange = useRef(currentRange);
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds a fallback for the rare (and strange) case that the window range is initially not available. 

Fixes #2799