### PR TITLE
fix(Form): correct alignment

### DIFF
--- a/packages/main/src/components/Form/Form.jss.ts
+++ b/packages/main/src/components/Form/Form.jss.ts
@@ -14,7 +14,7 @@ const labelSpanClasses = () => {
 const styles = {
   form: {
     display: 'grid',
-    alignItems: 'baseline',
+    alignItems: 'center',
     rowGap: '0.25rem',
     columnGap: '0.5rem',
     gridTemplateColumns: `repeat(12, 1fr)`,

--- a/packages/main/src/components/Form/Form.stories.mdx
+++ b/packages/main/src/components/Form/Form.stories.mdx
@@ -28,7 +28,8 @@ import { CheckBox, Form, FormGroup, FormItem, Input, InputType, Label, Option, S
     columnsS: 1,
     columnsM: 1,
     columnsL: 1,
-    columnsXL: 2
+    columnsXL: 2,
+    style: { alignItems: 'center' }
   }}
 />
 
@@ -59,8 +60,15 @@ import { CheckBox, Form, FormGroup, FormItem, Input, InputType, Label, Option, S
               <Option>Italy</Option>
             </Select>
           </FormItem>
-          <FormItem label="Additional Comment">
-            <TextArea rows={5} style={{ width: '210px' }} />
+          <FormItem
+            style={{ alignSelf: 'start' }}
+            label={<Label style={{ alignSelf: 'start', paddingTop: '0.25rem' }}>Additional Comment</Label>}
+          >
+            <TextArea
+              rows={5}
+              style={{ width: '210px', '--_ui5_textarea_margin': 0 }}
+              placeholder="The styles of the Label of the TextArea FormItem is set to: alignSelf: 'start', paddingTop: '0.25rem'"
+            />
           </FormItem>
           <FormItem label={'Home address'}>
             <CheckBox checked />

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -103,6 +103,7 @@ export interface FormPropTypes extends CommonProps {
 const useStyles = createUseStyles(styles, { name: 'Form' });
 /**
  * The `Form` component arranges labels and fields into groups and rows. There are different ways to visualize forms for different screen sizes.
+ * It is possible to change the alignment of all labels by setting the CSS `align-items` property, per default all labels are centered.
  */
 const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
   const {

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -120,7 +120,15 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
       return (
         <ObjectPage {...args}>
           <ObjectPageSection titleText="Goals" id="goals" aria-label="Goals">
-            <Form columnsL={3} columnsXL={3} labelSpanXL={6} labelSpanL={6} columnsM={2} labelSpanM={6}>
+            <Form
+              columnsL={3}
+              columnsXL={3}
+              labelSpanXL={6}
+              labelSpanL={6}
+              columnsM={2}
+              labelSpanM={6}
+              style={{ alignItems: 'baseline' }}
+            >
               <FormItem label="Evangelize the UI framework across the company">
                 <Text>4 days overdue - Cascaded</Text>
               </FormItem>
@@ -134,7 +142,7 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
           </ObjectPageSection>
           <ObjectPageSection titleText="Personal" id="personal" aria-label="Personal">
             <ObjectPageSubSection titleText="Connect" id="personal-connect" aria-label="Connect">
-              <Form columnsXL={4} columnsL={4}>
+              <Form columnsXL={4} columnsL={4} style={{ alignItems: 'baseline' }}>
                 <FormGroup titleText="Phone Numbers">
                   <FormItem label="Home">
                     <Text>+1 234-567-8901</Text>
@@ -171,7 +179,7 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
               id="personal-payment-information"
               aria-label="Payment Information"
             >
-              <Form columnsXL={4} columnsL={4}>
+              <Form columnsXL={4} columnsL={4} style={{ alignItems: 'baseline' }}>
                 <FormGroup titleText="Salary">
                   <FormItem label="Bank Transfer">
                     <Text>Money Bank, Inc.</Text>
@@ -191,7 +199,7 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
               id="employment-job-information"
               aria-label="Job Information"
             >
-              <Form columnsXL={4} columnsL={4}>
+              <Form columnsXL={4} columnsL={4} style={{ alignItems: 'baseline' }}>
                 <FormItem label="Job Classification">
                   <FlexBox direction={FlexBoxDirection.Column}>
                     <Text>Senior UI Developer</Text>
@@ -223,7 +231,7 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
               id="employment-employee-details"
               aria-label="Employee Details"
             >
-              <Form columnsXL={4} columnsL={4}>
+              <Form columnsXL={4} columnsL={4} style={{ alignItems: 'baseline' }}>
                 <FormItem label="Start Date">
                   <Text>Jan 01, 2018</Text>
                 </FormItem>
@@ -249,7 +257,7 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
               id="employment-job-relationship"
               aria-label="Job Relationship"
             >
-              <Form columnsXL={4} columnsL={4}>
+              <Form columnsXL={4} columnsL={4} style={{ alignItems: 'baseline' }}>
                 <FormItem label="Manager">
                   <Text>John Doe</Text>
                 </FormItem>


### PR DESCRIPTION
In ui5-wc v1.3.0 `alignItems: "baseline"` on the form doesn;t behave the same anymore for input fields. This PR centers the labels per default and adds a comment on how the alignment can be changed by app developers.