### PR TITLE
fix(Toolbar): correctly align icon-only buttons in overflow popover

### DIFF
--- a/packages/main/src/components/Toolbar/Toolbar.jss.ts
+++ b/packages/main/src/components/Toolbar/Toolbar.jss.ts
@@ -88,6 +88,9 @@ export const styles = {
     '& [ui5-button]::part(button)': {
       justifyContent: 'flex-start'
     },
+    '& [ui5-button][icon-only]::part(button)': {
+      padding: 'revert'
+    },
     '& :last-child': {
       marginBottom: 0
     }

--- a/packages/main/src/components/Toolbar/Toolbar.stories.mdx
+++ b/packages/main/src/components/Toolbar/Toolbar.stories.mdx
@@ -189,6 +189,7 @@ If the horizontally available space isn't enough to fit all items in it, an over
         <Toolbar {...args} style={{ width: `${args.width}px` }}>
           <Text>Toolbar</Text>
           <Button>Button One</Button>
+          <Button icon="accept" />
           <Button>Button Two</Button>
           <Select style={{ width: 'auto' }} />
           <Switch />


### PR DESCRIPTION
This PR fixes Icon only Buttons having no padding in the overflow popover.

Fixes #2892