### PR TITLE
chore(AnalyticalTable): don't execute column scale logic if undefined `scaleWidthMode` is used

### DIFF
--- a/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
@@ -28,7 +28,13 @@ const columns = (columns, { instance }) => {
   const { hiddenColumns, tableClientWidth: totalWidth } = state;
   const { scaleWidthMode, loading } = instance.webComponentsReactProperties;
 
-  if (columns.length === 0 || !totalWidth) return columns;
+  if (
+    columns.length === 0 ||
+    !totalWidth ||
+    !TableScaleWidthMode[instance.webComponentsReactProperties.scaleWidthMode]
+  ) {
+    return columns;
+  }
 
   //map columns to visibleColumns
   const visibleColumns = instance.visibleColumns

--- a/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
@@ -28,11 +28,7 @@ const columns = (columns, { instance }) => {
   const { hiddenColumns, tableClientWidth: totalWidth } = state;
   const { scaleWidthMode, loading } = instance.webComponentsReactProperties;
 
-  if (
-    columns.length === 0 ||
-    !totalWidth ||
-    !TableScaleWidthMode[instance.webComponentsReactProperties.scaleWidthMode]
-  ) {
+  if (columns.length === 0 || !totalWidth || !TableScaleWidthMode[scaleWidthMode]) {
     return columns;
   }
 


### PR DESCRIPTION
This PR disables the logic within the internally used `useDynamicColumnWidths` hook when using a different `scaleWidthMode` than the ones specified in the `TableScaleWidthMode` enum.