### PR TITLE
fix(cra-template-seed): use `onInput` for react change events

### DIFF
--- a/packages/cra-template-seed/template/.prettierrc
+++ b/packages/cra-template-seed/template/.prettierrc
@@ -1,7 +1,7 @@
 {
   "trailingComma": "all",
   "singleQuote": true,
-  "printWidth": 200,
+  "printWidth": 120,
   "tabWidth": 2,
   "endOfLine": "lf"
 }

--- a/packages/cra-template-seed/template/src/components/Form/Input/Input.js
+++ b/packages/cra-template-seed/template/src/components/Form/Input/Input.js
@@ -1,8 +1,6 @@
-import React from 'react';
-
-import { spacing } from '@ui5/webcomponents-react-base';
-
 import { Input as UI5Input, ValueState } from '@ui5/webcomponents-react';
+import { spacing } from '@ui5/webcomponents-react-base';
+import React from 'react';
 import FieldBase from '../FieldBase/FieldBase';
 
 const Input = ({ field, form: { touched, errors }, labelText, style, ...props }) => {
@@ -15,9 +13,19 @@ const Input = ({ field, form: { touched, errors }, labelText, style, ...props })
     width: '100%',
   };
 
+  const { onChange, ...formikProps } = field;
+
   return (
     <FieldBase labelText={labelText} required={props.required} for={props.for} showColon={props.showColon}>
-      <UI5Input data-testid="input-wrapper" valueState={errorState} valueStateMessage={<span>{errorMsg}</span>} style={innerStyle} {...props} {...field} />
+      <UI5Input
+        data-testid="input-wrapper"
+        valueState={errorState}
+        valueStateMessage={<span>{errorMsg}</span>}
+        style={innerStyle}
+        {...props}
+        {...formikProps}
+        onInput={onChange}
+      />
     </FieldBase>
   );
 };

--- a/packages/cra-template-seed/template/src/components/Form/TextArea/TextArea.js
+++ b/packages/cra-template-seed/template/src/components/Form/TextArea/TextArea.js
@@ -1,13 +1,14 @@
-import React from 'react';
-
-import { spacing } from '@ui5/webcomponents-react-base';
 import { TextArea as UI5TextArea, ValueState } from '@ui5/webcomponents-react';
+import { spacing } from '@ui5/webcomponents-react-base';
+import React from 'react';
 
 import FieldBase from '../FieldBase/FieldBase';
 
 const TextArea = ({ field, form: { touched, errors }, labelText, rows, style, ...props }) => {
   const errorMsg = touched[field.name] && errors[field.name];
   const errorState = errorMsg ? ValueState.Error : ValueState.None;
+
+  const { onChange, ...formikProps } = field;
 
   return (
     <FieldBase labelText={labelText} required={props.required} for={props.for} showColon={props.showColon}>
@@ -18,7 +19,8 @@ const TextArea = ({ field, form: { touched, errors }, labelText, rows, style, ..
         rows={rows}
         style={style ? style : spacing.sapUiSmallMarginBottom}
         {...props}
-        {...field}
+        {...formikProps}
+        onInput={onChange}
       />
     </FieldBase>
   );


### PR DESCRIPTION
This behaviour comes closer to the standard react [`onChange` handling](https://reactjs.org/docs/dom-elements.html#onchange).

Fixes #2911 