### PR TITLE
feat(VariantManagement): add hideCreatedBy property

### DIFF
--- a/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
+++ b/packages/main/src/components/VariantManagement/ManageViewsDialog.tsx
@@ -47,6 +47,7 @@ interface ManageViewsDialogPropTypes {
   showShare: boolean;
   showApplyAutomatically: boolean;
   showSetAsDefault: boolean;
+  showCreatedBy: boolean;
   variantNames: string[];
   portalContainer: Element;
 }
@@ -59,6 +60,7 @@ export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
     showShare,
     showApplyAutomatically,
     showSetAsDefault,
+    showCreatedBy,
     variantNames,
     portalContainer
   } = props;
@@ -93,9 +95,11 @@ export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
           {applyAutomaticallyHeaderText}
         </TableColumn>
       )}
-      <TableColumn demandPopin minWidth={600} popinText={createdByHeaderText}>
-        {createdByHeaderText}
-      </TableColumn>
+      {showCreatedBy && (
+        <TableColumn demandPopin minWidth={600} popinText={createdByHeaderText}>
+          {createdByHeaderText}
+        </TableColumn>
+      )}
       <TableColumn key="delete-variant-item" />
     </>
   );
@@ -197,6 +201,7 @@ export const ManageViewsDialog = (props: ManageViewsDialogPropTypes) => {
               showShare={showShare}
               showApplyAutomatically={showApplyAutomatically}
               showSetAsDefault={showSetAsDefault}
+              showCreatedBy={showCreatedBy}
               key={itemProps?.children}
             />
           );

--- a/packages/main/src/components/VariantManagement/MangeViewsTableRows.tsx
+++ b/packages/main/src/components/VariantManagement/MangeViewsTableRows.tsx
@@ -34,6 +34,7 @@ interface ManageViewsTableRowsProps extends VariantItemPropTypes {
   showShare: boolean;
   showApplyAutomatically: boolean;
   showSetAsDefault: boolean;
+  showCreatedBy: boolean;
   changedVariantNames: Map<string, any>;
   setChangedVariantNames: (varNames: any) => void;
   setInvalidVariants: (invalidVars: any) => void;
@@ -51,6 +52,7 @@ export const ManageViewsTableRows = (props: ManageViewsTableRowsProps) => {
     showShare,
     showApplyAutomatically,
     showSetAsDefault,
+    showCreatedBy,
     labelReadOnly,
     favorite,
     children,
@@ -198,9 +200,11 @@ export const ManageViewsTableRows = (props: ManageViewsTableRowsProps) => {
           />
         </TableCell>
       )}
-      <TableCell>
-        <Text>{author}</Text>
-      </TableCell>
+      {showCreatedBy && (
+        <TableCell>
+          <Text>{author}</Text>
+        </TableCell>
+      )}
       <TableCell>
         {!(hideDelete ?? global) && (
           <Button

--- a/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
+++ b/packages/main/src/components/VariantManagement/VariantManagement.test.tsx
@@ -232,7 +232,7 @@ describe('VariantManagement', () => {
 
   test('Hide variant props', () => {
     const { getByText } = render(
-      <VariantManagement hideApplyAutomatically hideSetAsDefault hideShare>
+      <VariantManagement hideApplyAutomatically hideSetAsDefault hideShare hideCreatedBy>
         {TwoVariantItems}
       </VariantManagement>
     );
@@ -250,6 +250,7 @@ describe('VariantManagement', () => {
     expect(within(table).queryByText('Sharing')).toBeNull();
     expect(within(table).queryByText('Default')).toBeNull();
     expect(within(table).queryByText('ApplyAutomatically')).toBeNull();
+    expect(within(table).queryByText('Created By')).toBeNull();
   });
 
   test('Save As', () => {

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -126,7 +126,7 @@ export interface VariantManagementPropTypes extends Omit<CommonProps, 'onSelect'
    */
   hideApplyAutomatically?: boolean;
   /**
-   * Indicates that the Author is visible in the Manage Views dialogs.
+   * Indicates that the Author is visible in the Manage Views dialog.
    */
   hideCreatedBy?: boolean;
   /**

--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -126,6 +126,10 @@ export interface VariantManagementPropTypes extends Omit<CommonProps, 'onSelect'
    */
   hideApplyAutomatically?: boolean;
   /**
+   * Indicates that the Author is visible in the Manage Views dialogs.
+   */
+  hideCreatedBy?: boolean;
+  /**
    * Indicates that the Save View dialog button is visible.
    */
   hideSaveAs?: boolean;
@@ -247,6 +251,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
     hideManageVariants,
     hideApplyAutomatically,
     hideSetAsDefault,
+    hideCreatedBy,
     hideSaveAs,
     dirtyStateText,
     dirtyState,
@@ -573,6 +578,7 @@ const VariantManagement = forwardRef((props: VariantManagementPropTypes, ref: Re
             handleSaveManageViews={handleSaveManageViews}
             showShare={!hideShare}
             showApplyAutomatically={!hideApplyAutomatically}
+            showCreatedBy={!hideCreatedBy}
             showSetAsDefault={!hideSetAsDefault}
             variantNames={variantNames}
             portalContainer={portalContainer}


### PR DESCRIPTION
Adds a hideCreatedBy property to the VariantManagement component in order to hide the 'Created By' column on the manage view dialog.

Fixes #2891