### PR TITLE
fix(AnalyticalTable): don't scroll to top when collapsing rows

### DIFF
--- a/packages/main/src/components/AnalyticalTable/TableBody/VirtualTableBodyContainer.tsx
+++ b/packages/main/src/components/AnalyticalTable/TableBody/VirtualTableBodyContainer.tsx
@@ -16,7 +16,8 @@ export const VirtualTableBodyContainer = (props) => {
     internalRowHeight,
     handleExternalScroll,
     visibleRows,
-    popInRowHeight
+    popInRowHeight,
+    dataLength
   } = props;
   const [isMounted, setIsMounted] = useState(false);
 
@@ -30,19 +31,16 @@ export const VirtualTableBodyContainer = (props) => {
 
   const lastScrollTop = useRef(0);
   const firedInfiniteLoadEvents = useRef(new Set());
-  const prevRowsLength = useRef(rows.length);
+  const prevDataLength = useRef(dataLength);
 
   useEffect(() => {
-    if (prevRowsLength.current > rows.length) {
+    if (prevDataLength.current > dataLength) {
       firedInfiniteLoadEvents.current.clear();
       parentRef.current.scrollTop = 0;
       lastScrollTop.current = 0;
     }
-  }, [rows.length, prevRowsLength.current]);
-
-  useEffect(() => {
-    prevRowsLength.current = rows.length;
-  }, [rows.length]);
+    prevDataLength.current = dataLength;
+  }, [dataLength]);
 
   const onScroll = useCallback(
     (event) => {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -21,7 +21,6 @@ import React, {
   forwardRef,
   MutableRefObject,
   ReactNode,
-  ReactText,
   Ref,
   RefObject,
   useCallback,
@@ -1002,6 +1001,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
               rows={rows}
               handleExternalScroll={handleBodyScroll}
               visibleRows={internalVisibleRowCount}
+              dataLength={data?.length}
             >
               <VirtualTableBody
                 classes={classes}


### PR DESCRIPTION
This PR fixes the issue of expandable rows making the table scroll to top when collapsed. `scrollTop` is now only set to zero if in the updated `data` array there are less entries than before. Previously, this depended on the rows of the table, which changed each time a row was collapsed.