### PR TITLE
fix(AnalyticalTable): don't bubble up click event of th popover

### DIFF
--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/ColumnHeaderModal.tsx
@@ -179,6 +179,7 @@ export const ColumnHeaderModal = (props: ColumnHeaderModalProperties) => {
       placementType={PopoverPlacementType.Bottom}
       ref={ref}
       className={classes.popover}
+      onClick={stopPropagation}
       onAfterClose={onAfterClose}
       onAfterOpen={onAfterOpen}
     >


### PR DESCRIPTION
This PR prevents the table header popover's click event to bubble up to the th itself, preventing users from opening it again.