### PR TITLE
fix(AnalyticalTable): allow disabling custom scrollbar styles w/o using CSS

### DIFF
--- a/docs/3-KnowledgeBase.stories.mdx
+++ b/docs/3-KnowledgeBase.stories.mdx
@@ -168,6 +168,10 @@ All globally available style classes are tracked in the `GlobalStyleClasses` enu
 | -------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `sapScrollBar` | If added to an container that supports scrolling, the scrollbar will be styled according to the Fiori guidelines. |
 
+#### Use default browser scrollbar
+
+Some components like the `ObjectPage`, `DynamicPage` and `AnalyticalTable` use the CSS class `sapScrollBar` by default. To prevent these components from using the custom scrollbar, you can pass `data-native-scrollbar` as prop.
+
 ### Style your own components
 
 It's quite likely that you have to create some custom components when you are building an app.

--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -2212,6 +2212,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins & hidden column 1`] = `
         </div>
         <div
           class="FlexBox-flexBox FlexBox-flexBoxDirectionColumn FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap"
+          data-component-name="AnalyticalTableVerticalScrollbarContainer"
           style="position: relative;"
         >
           <div
@@ -2220,6 +2221,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins & hidden column 1`] = `
           />
           <div
             class="sapScrollBar VerticalScrollbar-scrollbar"
+            data-component-name="AnalyticalTableVerticalScrollbar"
             style="height: 220px;"
           >
             <div
@@ -2676,6 +2678,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins 1`] = `
         </div>
         <div
           class="FlexBox-flexBox FlexBox-flexBoxDirectionColumn FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap"
+          data-component-name="AnalyticalTableVerticalScrollbarContainer"
           style="position: relative;"
         >
           <div
@@ -2684,6 +2687,7 @@ exports[`AnalyticalTable RTL: pop-in columns: w/ pop-ins 1`] = `
           />
           <div
             class="sapScrollBar VerticalScrollbar-scrollbar"
+            data-component-name="AnalyticalTableVerticalScrollbar"
             style="height: 220px;"
           >
             <div
@@ -8957,6 +8961,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins & hidden column 1`] = `
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionColumn FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap"
+        data-component-name="AnalyticalTableVerticalScrollbarContainer"
         style="position: relative;"
       >
         <div
@@ -8965,6 +8970,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins & hidden column 1`] = `
         />
         <div
           class="sapScrollBar VerticalScrollbar-scrollbar"
+          data-component-name="AnalyticalTableVerticalScrollbar"
           style="height: 220px;"
         >
           <div
@@ -9417,6 +9423,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins 1`] = `
       </div>
       <div
         class="FlexBox-flexBox FlexBox-flexBoxDirectionColumn FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap"
+        data-component-name="AnalyticalTableVerticalScrollbarContainer"
         style="position: relative;"
       >
         <div
@@ -9425,6 +9432,7 @@ exports[`AnalyticalTable pop-in columns: w/ pop-ins 1`] = `
         />
         <div
           class="sapScrollBar VerticalScrollbar-scrollbar"
+          data-component-name="AnalyticalTableVerticalScrollbar"
           style="height: 220px;"
         >
           <div

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -935,6 +935,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
           data-per-page={internalVisibleRowCount}
           data-component-name="AnalyticalTableContainer"
           ref={tableRef}
+          data-native-scrollbar={props['data-native-scrollbar']}
           className={tableClasses}
         >
           <div className={classes.tableHeaderBackgroundElement} />
@@ -1037,6 +1038,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
             rows={rows}
             handleVerticalScrollBarScroll={handleVerticalScrollBarScroll}
             ref={verticalScrollBarRef}
+            data-native-scrollbar={props['data-native-scrollbar']}
           />
         )}
       </FlexBox>

--- a/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
+++ b/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
@@ -57,7 +57,11 @@ export const VerticalScrollbar = forwardRef((props: VerticalScrollbarProps, ref:
   );
 
   return (
-    <FlexBox direction={FlexBoxDirection.Column} style={{ position: 'relative' }}>
+    <FlexBox
+      direction={FlexBoxDirection.Column}
+      style={{ position: 'relative' }}
+      data-component-name="AnalyticalTableVerticalScrollbarContainer"
+    >
       <div
         style={{
           height: `${internalRowHeight}px`
@@ -70,7 +74,9 @@ export const VerticalScrollbar = forwardRef((props: VerticalScrollbarProps, ref:
           height: tableRef.current ? `${tableBodyHeight}px` : '0'
         }}
         onScroll={handleVerticalScrollBarScroll}
+        data-native-scrollbar={props['data-native-scrollbar']}
         className={`${GlobalStyleClasses.sapScrollBar} ${classes.scrollbar}`}
+        data-component-name="AnalyticalTableVerticalScrollbar"
       >
         <div
           style={{

--- a/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
+++ b/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
@@ -14,6 +14,7 @@ interface VerticalScrollbarProps {
   handleVerticalScrollBarScroll: any;
   popInRowHeight: number;
   tableBodyHeight: number;
+  'data-native-scrollbar'?: any;
 }
 
 const styles = {


### PR DESCRIPTION
To use the default browser styling of the scrollbar it is now possible to use `data-native-scrollbar` for the `AnalyticalTable` as well.