### PR TITLE
feat(AnalyticalTable): add `useManualRowSelect` plugin hook

### DIFF
--- a/.storybook/mockData/FriendsManualSelect25.json
+++ b/.storybook/mockData/FriendsManualSelect25.json
@@ -1,0 +1,234 @@
+[
+  {
+    "name": "Owens Glover",
+    "age": 22,
+    "friend": {
+      "name": "Daisy Giles",
+      "age": 33
+    },
+    "status": "Error",
+    "isSelected": true
+  },
+  {
+    "name": "Waller Nguyen",
+    "age": 56,
+    "friend": {
+      "name": "Lola Banks",
+      "age": 55
+    },
+    "status": "None",
+    "isSelected": true
+  },
+  {
+    "name": "Bowen Mckay",
+    "age": 32,
+    "friend": {
+      "name": "Graham Wells",
+      "age": 51
+    },
+    "status": "Information"
+  },
+  {
+    "name": "Freida Weeks",
+    "age": 68,
+    "friend": {
+      "name": "Lee Johnson",
+      "age": 61
+    },
+    "status": "Error"
+  },
+  {
+    "name": "England Whitehead",
+    "age": 82,
+    "friend": {
+      "name": "Phillips Merritt",
+      "age": 19
+    },
+    "status": "Information",
+    "isSelected": true
+  },
+  {
+    "name": "Alissa Duke",
+    "age": 43,
+    "friend": {
+      "name": "Rosella Slater",
+      "age": 58
+    },
+    "status": "None"
+  },
+  {
+    "name": "Randolph Grant",
+    "age": 76,
+    "friend": {
+      "name": "Madge Mitchell",
+      "age": 48
+    },
+    "status": "Warning"
+  },
+  {
+    "name": "Malone Hampton",
+    "age": 42,
+    "friend": {
+      "name": "Landry Hancock",
+      "age": 33
+    },
+    "status": "Error"
+  },
+  {
+    "name": "Lorna Hinton",
+    "age": 27,
+    "friend": {
+      "name": "Maddox House",
+      "age": 67
+    },
+    "status": "None"
+  },
+  {
+    "name": "Janis Wade",
+    "age": 19,
+    "friend": {
+      "name": "Nell Hines",
+      "age": 82
+    },
+    "status": "Error",
+    "isSelected": true
+  },
+  {
+    "name": "Rose Vance",
+    "age": 47,
+    "friend": {
+      "name": "Jacobson Wilcox",
+      "age": 69
+    },
+    "status": "Information"
+  },
+  {
+    "name": "Rowe Hamilton",
+    "age": 85,
+    "friend": {
+      "name": "Vasquez Craft",
+      "age": 79
+    },
+    "status": "Warning"
+  },
+  {
+    "name": "Trisha Ellis",
+    "age": 42,
+    "friend": {
+      "name": "Jacobs Ramsey",
+      "age": 41
+    },
+    "status": "Success"
+  },
+  {
+    "name": "Bowers Rowe",
+    "age": 57,
+    "friend": {
+      "name": "Brigitte Buckner",
+      "age": 19
+    },
+    "status": "None"
+  },
+  {
+    "name": "Gamble Rice",
+    "age": 85,
+    "friend": {
+      "name": "Manning Jenkins",
+      "age": 57
+    },
+    "status": "Error",
+    "isSelected": true
+  },
+  {
+    "name": "Letitia Finch",
+    "age": 54,
+    "friend": {
+      "name": "Silva Fulton",
+      "age": 52
+    },
+    "status": "Information"
+  },
+  {
+    "name": "Elinor Middleton",
+    "age": 71,
+    "friend": {
+      "name": "Hines Mckenzie",
+      "age": 33
+    },
+    "status": "None"
+  },
+  {
+    "name": "Jeannine Lopez",
+    "age": 38,
+    "friend": {
+      "name": "Benjamin Rodriguez",
+      "age": 76
+    },
+    "status": "Error",
+    "isSelected": true
+  },
+  {
+    "name": "Natasha Simon",
+    "age": 73,
+    "friend": {
+      "name": "Simon Morin",
+      "age": 20
+    },
+    "status": "Error"
+  },
+  {
+    "name": "Marquita Morrison",
+    "age": 61,
+    "friend": {
+      "name": "Mitzi Blake",
+      "age": 80
+    },
+    "status": "Error"
+  },
+  {
+    "name": "Lula Mason",
+    "age": 49,
+    "friend": {
+      "name": "Holmes York",
+      "age": 31
+    },
+    "status": "Information"
+  },
+  {
+    "name": "Ginger Strong",
+    "age": 79,
+    "friend": {
+      "name": "Higgins Shannon",
+      "age": 25
+    },
+    "status": "None"
+  },
+  {
+    "name": "Reeves Finley",
+    "age": 84,
+    "friend": {
+      "name": "Sheila Hickman",
+      "age": 25
+    },
+    "status": "None",
+    "isSelected": true
+  },
+  {
+    "name": "Reilly Mcpherson",
+    "age": 34,
+    "friend": {
+      "name": "Horton Smith",
+      "age": 37
+    },
+    "status": "Warning"
+  },
+  {
+    "name": "Moreno Moore",
+    "age": 39,
+    "friend": {
+      "name": "Lacey Fox",
+      "age": 55
+    },
+    "status": "None"
+  }
+]

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -3,6 +3,7 @@ import { Footer } from '@docs/Footer';
 import dataLarge from '../../../../../.storybook/mockData/Friends500.json';
 import dataSmall from '../../../../../.storybook/mockData/Friends500.json';
 import dataTree from '../../../../../.storybook/mockData/FriendsTree.json';
+import dataManualSelect from '../../../../../.storybook/mockData/FriendsManualSelect25.json';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import '@ui5/webcomponents-icons/dist/delete.js';
 import '@ui5/webcomponents-icons/dist/edit.js';
@@ -18,6 +19,7 @@ import {
   FlexBoxAlignItems,
   FlexBoxDirection,
   FlexBoxJustifyContent,
+  Label,
   MessageStrip,
   Panel,
   SegmentedButton,
@@ -375,6 +377,72 @@ _ES6 Import: `import { AnalyticalTableHooks } from '@ui5/webcomponents-react';`_
   isTreeTable
   tableHooks={[AnalyticalTableHooks.useIndeterminateRowSelection()]}
   reactTableOptions={{ selectSubRows: true }}
+/>
+```
+
+### Manual control of selected lines
+
+The `useManualRowSelect` plugin hook allows controlling the selected rows manually. It accepts a parameter (`manualRowSelectedKey`) which defaults to `isSelected`.
+If this key is found on the original data row, and it is `true`, this row will be manually selected.
+
+<Canvas>
+  <Story name="Plugin: useManualRowSelect" args={{ data: dataManualSelect }}>
+    {(args) => {
+      const [collapsed, setCollapsed] = useReducer((coll) => !coll, true);
+      const [collapsedCode, setCollapsedCode] = useReducer((coll) => !coll, true);
+      const [data, toggleFirstRowSelected] = useReducer((prev) => {
+        const [, ...updatedData] = prev;
+        if (prev[0].isSelected) {
+          return [{ ...prev[0], isSelected: false }, ...updatedData];
+        } else {
+          return [{ ...prev[0], isSelected: true }, ...updatedData];
+        }
+      }, args.data);
+      return (
+        <Panel collapsed={collapsed} onToggle={setCollapsed} headerText="Show useManualRowSelect example">
+          {collapsed ? (
+            <BusyIndicator active style={{ width: '100%' }}>
+              <span style={{ height: '800px' }} />
+            </BusyIndicator>
+          ) : (
+            <>
+              <Button onClick={toggleFirstRowSelected}>Toggle `isSelected` of 1st row</Button>
+              <br />
+              <Label>Clicking this button will refresh the data array passed to the `data` prop.</Label>
+              <br />
+              <br />
+              <AnalyticalTable
+                selectionMode={TableSelectionMode.MultiSelect}
+                data={data}
+                columns={args.columns}
+                tableHooks={[AnalyticalTableHooks.useManualRowSelect('isSelected')]}
+              />
+              <Button onClick={setCollapsedCode}>Show first entries in data array</Button>
+              {!collapsedCode && (
+                <FlexBox direction="Column">
+                  <span>{JSON.stringify(data[0], null, 2)}</span>
+                  <span>{JSON.stringify(data[1], null, 2)}</span>
+                  <span>{JSON.stringify(data[2], null, 2)}</span>
+                  <span>{JSON.stringify(data[3], null, 2)}</span>
+                  <span>{JSON.stringify(data[4], null, 2)}</span>
+                  <span>...</span>
+                </FlexBox>
+              )}
+            </>
+          )}
+        </Panel>
+      );
+    }}
+  </Story>
+</Canvas>
+
+```jsx
+<AnalyticalTable
+  selectionMode={TableSelectionMode.MultiSelect}
+  data={data}
+  columns={columns}
+  // you could also omit the `'isSelected'`, as this is the default value
+  tableHooks={[AnalyticalTableHooks.useManualRowSelect('isSelected')]}
 />
 ```
 

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.test.tsx
@@ -7,7 +7,11 @@ import { TableVisibleRowCountMode } from '../../enums/TableVisibleRowCountMode';
 import { ValueState } from '../../enums/ValueState';
 import { Button } from '../../webComponents/Button';
 import { AnalyticalTable } from './index';
-import { useIndeterminateRowSelection, useRowDisableSelection } from './pluginHooks/AnalyticalTableHooks';
+import {
+  useIndeterminateRowSelection,
+  useRowDisableSelection,
+  useManualRowSelect
+} from './pluginHooks/AnalyticalTableHooks';
 
 const columns = [
   {
@@ -1197,6 +1201,75 @@ describe('AnalyticalTable', () => {
       target: { scrollY: 100 }
     });
     expect(scroll).toHaveBeenCalledTimes(1);
+  });
+
+  const manualSelectData = [
+    {
+      name: 'Selected',
+      age: 40,
+      friend: {
+        name: 'MAR',
+        age: 28
+      },
+      isSelected: true
+    },
+    {
+      name: 'Not selected',
+      age: 20,
+      friend: {
+        name: 'Nei',
+        age: 50
+      },
+      isSelected: false
+    },
+    {
+      name: 'Not selected2',
+      age: 20,
+      friend: {
+        name: 'Nei',
+        age: 50
+      }
+    }
+  ];
+  test('plugin hook: useManualRowSelect', () => {
+    const { getByText, rerender } = render(
+      <AnalyticalTable
+        selectionMode={TableSelectionMode.MultiSelect}
+        data={manualSelectData}
+        columns={columns}
+        tableHooks={[useManualRowSelect('isSelected')]}
+      />
+    );
+    const row0 = getByText('Selected').parentNode.parentNode;
+    const row1 = getByText('Not selected').parentNode.parentNode;
+    const row2 = getByText('Not selected2').parentNode.parentNode;
+    expect(row0).toHaveAttribute('data-is-selected');
+    expect(row1).not.toHaveAttribute('data-is-selected');
+    expect(row2).not.toHaveAttribute('data-is-selected');
+
+    const [, ...updatedManualSelectData] = manualSelectData;
+    rerender(
+      <AnalyticalTable
+        selectionMode={TableSelectionMode.MultiSelect}
+        data={[
+          {
+            name: 'Selected',
+            age: 40,
+            friend: {
+              name: 'MAR',
+              age: 28
+            },
+            isSelected: false
+          },
+          ...updatedManualSelectData
+        ]}
+        columns={columns}
+        tableHooks={[useManualRowSelect('isSelected')]}
+      />
+    );
+    expect(row0).not.toHaveAttribute('data-is-selected');
+    expect(row1).not.toHaveAttribute('data-is-selected');
+    expect(row2).not.toHaveAttribute('data-is-selected');
   });
 
   createCustomPropsTest(AnalyticalTable);

--- a/packages/main/src/components/AnalyticalTable/pluginHooks/AnalyticalTableHooks.ts
+++ b/packages/main/src/components/AnalyticalTable/pluginHooks/AnalyticalTableHooks.ts
@@ -1,4 +1,5 @@
 import { useRowDisableSelection } from './useRowDisableSelection';
 import { useIndeterminateRowSelection } from './useIndeterminateRowSelection';
+import { useManualRowSelect } from './useManualRowSelect';
 
-export { useRowDisableSelection, useIndeterminateRowSelection };
+export { useRowDisableSelection, useIndeterminateRowSelection, useManualRowSelect };

--- a/packages/main/src/components/AnalyticalTable/pluginHooks/useManualRowSelect.ts
+++ b/packages/main/src/components/AnalyticalTable/pluginHooks/useManualRowSelect.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+/**
+ * A plugin hook for manual row selection.
+ *
+ * @param {string} manualRowSelectedKey - If this key is found on the original data row, and it is true, this row will be manually selected. __Defaults to `"isSelected"`__.
+ */
+export const useManualRowSelect = (manualRowSelectedKey: string = 'isSelected') => {
+  const instanceAfterData = ({ flatRows, toggleRowSelected }) => {
+    useEffect(() => {
+      flatRows.forEach(({ id, original }) => {
+        if (manualRowSelectedKey in original) {
+          toggleRowSelected(id, original.isSelected);
+        }
+      });
+    }, [flatRows, manualRowSelectedKey]);
+  };
+
+  const manualRowSelect = (hooks) => {
+    hooks.useInstanceAfterData.push(instanceAfterData);
+  };
+
+  manualRowSelect.pluginName = 'useManualRowSelect';
+
+  return manualRowSelect;
+};


### PR DESCRIPTION
This PR adds the `useManualRowSelect` plugin hook. With it it's possible to change selected rows by setting a key in the data array. 