### PR TITLE
fix(DynamicPageTitle): use "large" font size for title if no `headerContent` is set

### DIFF
--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -643,7 +643,6 @@ exports[`DynamicPage render footer 1`] = `
 <DocumentFragment>
   <div
     class="DynamicPage-dynamicPage sapScrollBar DynamicPage-backgroundSolid"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <div
       class="FlexBox-flexBox FlexBox-flexBoxDirectionRow FlexBox-justifyContentStart FlexBox-alignItemsStretch FlexBox-flexWrapNoWrap DynamicPage-anchorBar"

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -232,7 +232,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
   };
 
   const dynamicPageStyles = { ...style };
-  if (headerContentHeight === 0) {
+  if (headerContentHeight === 0 && headerContent) {
     dynamicPageStyles[DynamicPageCssVariables.titleFontSize] = ThemingParameters.sapObjectHeader_Title_SnappedFontSize;
   }
 

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`ObjectPage Default with Sections 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -159,7 +158,6 @@ exports[`ObjectPage Default with SubSections 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -472,7 +470,6 @@ exports[`ObjectPage IconTabBar Mode 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar ObjectPage-iconTabBarMode"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -633,7 +630,6 @@ exports[`ObjectPage Not crashing with 0 sections 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar ObjectPage-iconTabBarMode"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -671,7 +667,6 @@ exports[`ObjectPage Not crashing with 1 section - Default Mode 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -745,7 +740,6 @@ exports[`ObjectPage Not crashing with 1 section - IconTabBar Mode 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar ObjectPage-iconTabBarMode"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -1288,7 +1282,6 @@ exports[`ObjectPage with footer 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"
@@ -2753,7 +2746,6 @@ exports[`ObjectPage with title 1`] = `
   <div
     class="ObjectPage-objectPage sapScrollBar"
     data-component-name="ObjectPage"
-    style="--ui5wcr_DynamicPage_title_fontsize: var(--sapObjectHeader_Title_SnappedFontSize);"
   >
     <header
       aria-roledescription="Object Page header"

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -727,7 +727,7 @@ const ObjectPage = forwardRef((props: ObjectPagePropTypes, ref: RefObject<HTMLDi
   );
 
   const objectPageStyles = { ...style };
-  if (headerContentHeight === 0) {
+  if (headerContentHeight === 0 && headerContent) {
     objectPageStyles[DynamicPageCssVariables.titleFontSize] = ThemingParameters.sapObjectHeader_Title_SnappedFontSize;
   }
 


### PR DESCRIPTION
This currently only applies for themes from the Horizon family, as in other themes the font size stays the same in collapsed and expanded state.