### PR TITLE
chore: increase minimum react version to 16.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can find our documentation under the following links:
 
 ## Requirements
 
-- [React](https://www.npmjs.com/package/react) and [React-DOM](https://www.npmjs.com/package/react-dom) (**16.8.0 or higher**)
+- [React](https://www.npmjs.com/package/react) and [React-DOM](https://www.npmjs.com/package/react-dom) (**16.14.0 or higher**)
 - [Node.js](https://nodejs.org/) (**version 14 or higher** ⚠️)
 
 <!-- *********************************************************************** -->

--- a/docs/1-Welcome.stories.mdx
+++ b/docs/1-Welcome.stories.mdx
@@ -22,7 +22,7 @@ In addition to that, UI5 Web Components for React is providing complex component
 
 ## Requirements
 
-- [React](https://www.npmjs.com/package/react) and [React-DOM](https://www.npmjs.com/package/react-dom) (**16.8.0 or higher**)
+- [React](https://www.npmjs.com/package/react) and [React-DOM](https://www.npmjs.com/package/react-dom) (**16.14.0 or higher**)
 - [Node.js](https://nodejs.org/) (**version 14 or higher** ⚠️)
 
 ## Getting Started

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@types/react": "*",
     "@ui5/webcomponents-base": "~1.4.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@ui5/webcomponents-react": "^0.25.0",
     "@ui5/webcomponents-react-base": "^0.25.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-jss": "^10.0.4"
   },
   "publishConfig": {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -45,8 +45,8 @@
     "@ui5/webcomponents-base": "~1.4.0",
     "@ui5/webcomponents-fiori": "~1.4.0",
     "@ui5/webcomponents-icons": "~1.4.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
BREAKING CHANGE: minimum required version of `react` and `react-dom` bumped to `16.14.0` in order to use the new `jsx-transform`.
