### PR TITLE
feat(DynamicPage): add more aria options to `a11yConfig`

### DIFF
--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -405,6 +405,8 @@ describe('DynamicPage', () => {
       />
     );
     expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute('role', 'contentinfo');
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).not.toHaveAttribute('aria-label');
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).not.toHaveAttribute('aria-labelledby');
     expect(document.querySelector('[data-component-name="DynamicPageAnchorBar"]')).toHaveAttribute(
       'role',
       'navigation'
@@ -415,10 +417,19 @@ describe('DynamicPage', () => {
         headerTitle={<DynamicPageTitle />}
         headerContent={<DynamicPageHeader />}
         footer={<Bar data-testid="footer" design={BarDesign.FloatingFooter} />}
-        a11yConfig={{ dynamicPageAnchorBar: { role: 'anchorbar' }, dynamicPageFooter: { role: 'footer' } }}
+        a11yConfig={{
+          dynamicPageAnchorBar: { role: 'anchorbar' },
+          dynamicPageFooter: { role: 'footer', 'aria-label': 'label', 'aria-labelledby': 'labelledby' }
+        }}
       />
     );
     expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute('role', 'footer');
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute('aria-label', 'label');
+    expect(document.querySelector('[data-component-name="DynamicPageFooter"]')).toHaveAttribute(
+      'aria-labelledby',
+      'labelledby'
+    );
+
     expect(document.querySelector('[data-component-name="DynamicPageAnchorBar"]')).toHaveAttribute('role', 'anchorbar');
   });
 

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -64,6 +64,8 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
     };
     dynamicPageFooter?: {
       role?: string;
+      'aria-label'?: string;
+      'aria-labelledby'?: string;
     };
   };
   /**
@@ -305,6 +307,8 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
           style={{ position: isOverflowing ? 'sticky' : 'absolute' }}
           data-component-name="DynamicPageFooter"
           role={a11yConfig?.dynamicPageFooter?.role ?? 'contentinfo'}
+          aria-label={a11yConfig?.dynamicPageFooter?.['aria-label']}
+          aria-labelledby={a11yConfig?.dynamicPageFooter?.['aria-labelledby']}
         >
           {footer}
         </div>


### PR DESCRIPTION
This PR adds `aria-label` and `aria-labelledby` to `a11yConfig.dynamicPageFooter`

Closes #3239 