### PR TITLE
docs(MessageView): define args manually to prevent storybook bug

### DIFF
--- a/packages/main/src/components/MessageView/MessageView.stories.mdx
+++ b/packages/main/src/components/MessageView/MessageView.stories.mdx
@@ -21,7 +21,6 @@ import { MessageView } from './index';
 
 <Meta
   title="User Feedback / MessageView"
-  component={MessageView}
   subcomponents={{ MessageItem }}
   args={{
     showDetailsPageHeader: true,
@@ -73,7 +72,12 @@ import { MessageView } from './index';
     ]
   }}
   argTypes={{
+    showDetailsPageHeader: { description: 'Defines whether the header of the details page will be shown.' },
+    groupItems: { description: 'Defines whether the messages are grouped or not.' },
+    onItemSelect: { description: 'Event is fired when the details of a message are shown.', action: 'onItemSelect' },
     children: {
+      description: `A list with message items. If only one item is provided, the initial page will be the details page for the item.\n\n
+**Note:** Although this prop accepts all HTML Elements, it is strongly recommended that you only use \`Message\` in order to preserve the intended design.`,
       control: { disable: true }
     }
   }}

--- a/packages/main/src/components/MessageView/index.tsx
+++ b/packages/main/src/components/MessageView/index.tsx
@@ -51,7 +51,7 @@ export interface MessageViewPropTypes extends CommonProps {
   groupItems?: boolean;
 
   /**
-   * Defines whether the header of details page will be shown.
+   * Defines whether the header of the details page will be shown.
    */
   showDetailsPageHeader?: boolean;
 
@@ -63,7 +63,7 @@ export interface MessageViewPropTypes extends CommonProps {
   children: ReactNode | ReactNode[];
 
   /**
-   * Event is fired when the details of a message are shown
+   * Event is fired when the details of a message are shown.
    */
   onItemSelect?: (event: Ui5CustomEvent<HTMLElement, { item: HTMLElement }>) => void;
 }


### PR DESCRIPTION
This is a workaround for the args table of the MessageView showing the properties and methods of `Array.prototype`. 