### PR TITLE
docs(AnalyticalTable): update links & outline `groupable` support

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -613,7 +613,7 @@ export const TableWithCustomHook = (props) => {
 ```
 
 With the `customHook` callback you can plugin in all available hooks. Please note that some hooks need a return value (e.g. `columns`) which is then always the first parameter of the function, and others are not allowed to return a value (e.g. `useTable`).
-For further details please refer to the [`react-table` documentation](https://react-table.tanstack.com/docs/api/overview).
+For further details please refer to the [`react-table` documentation](https://react-table-v7.tanstack.com/docs/api/overview).
 
 ### How to select rows containing active elements
 
@@ -661,7 +661,7 @@ React.useEffect(() => {
 />
 ```
 
-For more details on this behavior you can double check the [react-table docs](https://react-table.tanstack.com/docs/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes).
+For more details on this behavior you can double check the [react-table docs](https://react-table-v7.tanstack.com/docs/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes).
 
 ### How to scroll to a specific row/offset?
 

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -233,7 +233,7 @@ export interface AnalyticalTableColumnDefinition {
    */
   disableDragAndDrop?: boolean;
 
-  // all other custom properties or [React Table](https://react-table.tanstack.com/) column options
+  // all other custom properties of [React Table](https://react-table-v7.tanstack.com/) column options
   [key: string]: any;
 }
 
@@ -345,6 +345,8 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
   sortable?: boolean;
   /**
    * Defines whether columns are groupable.
+   *
+   * __Note:__ This prop has no effect when `isTreeTable` is true or `renderRowSubComponent` is set.
    */
   groupable?: boolean;
   /**
@@ -397,7 +399,7 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    */
   globalFilterValue?: string;
   /**
-   * Additional options which will be passed to [react-table´s useTable hook](https://react-table.tanstack.com/docs/api/useTable#table-options)
+   * Additional options which will be passed to [react-table´s useTable hook](https://react-table-v7.tanstack.com/docs/api/useTable#table-options)
    */
   reactTableOptions?: Record<string, unknown>;
   /**
@@ -502,7 +504,7 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
 
   /**
    * Exposes the internal table instance.
-   * This object will contain all [instance properties](https://react-table.tanstack.com/docs/api/useTable#instance-properties)
+   * This object will contain all [instance properties](https://react-table-v7.tanstack.com/docs/api/useTable#instance-properties)
    * of the `useTable` hook and all instance properties from `useColumnOrder`, `useExpanded`, `useFilters`,
    * `useGlobalFilter`, `useGroupBy`,`useResizeColumns`, `useRowSelect` and `useSortBy` plugin hooks.
    *


### PR DESCRIPTION
This PR replaces react-table links to v7 and adds a note that the `groupable` prop is not supported when rendering a tree table or when subcomponents are used.

Closes #3247 