### PR TITLE
docs: improve subcomponents args table

### DIFF
--- a/.storybook/components/ArgsTableWithNote.tsx
+++ b/.storybook/components/ArgsTableWithNote.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable } from '@storybook/addon-docs';
 import { MessageStrip, MessageStripDesign } from '@ui5/webcomponents-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { createUseStyles } from 'react-jss';
 
 const useStyles = createUseStyles({
@@ -15,10 +15,16 @@ const useStyles = createUseStyles({
 
 interface ArgsTableWithNotePropTypes {
   hideHTMLPropsNote?: boolean;
+  /**
+   * Customize the text of the note above the table.
+   *
+   * Defaults to: "This component supports all HTML attributes."
+   */
+  noteText?: ReactNode | ReactNode[];
 }
 
 export const ArgsTableWithNote = (args: ArgsTableWithNotePropTypes & React.ComponentProps<typeof ArgsTable>) => {
-  const { hideHTMLPropsNote, ...rest } = args;
+  const { hideHTMLPropsNote, noteText, ...rest } = args;
   const classes = useStyles();
   if (hideHTMLPropsNote) {
     return <ArgsTable {...rest} />;
@@ -26,7 +32,7 @@ export const ArgsTableWithNote = (args: ArgsTableWithNotePropTypes & React.Compo
   return (
     <div className={classes.tableContainer}>
       <MessageStrip design={MessageStripDesign.Information} hideCloseButton className={classes.strip}>
-        This component supports all HTML attributes.
+        {noteText ?? 'This component supports all HTML attributes.'}
       </MessageStrip>
       <ArgsTable {...rest} />
     </div>

--- a/packages/main/src/components/AnalyticalCard/AnalyticalCard.stories.mdx
+++ b/packages/main/src/components/AnalyticalCard/AnalyticalCard.stories.mdx
@@ -139,8 +139,10 @@ Available options are: <ul> <li><code>None</code></li> <li><code>Error</code></l
         description: 'General unit of measurement for the header. Displayed as side information to the subtitle.'
       },
       onClick: { description: 'Fired when the `AnalyticalCardHeader` header is clicked.' },
+      children: {
+        description: `Additional side number indicators. For example "Deviation" and "Target". Not more than two side indicators should be used.\n\n__Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use \`NumericSideIndicator\` in order to preserve the intended design.\n\n __This prop is not required!__`
+      },
       header: { table: { disable: true } },
-      children: { table: { disable: true } },
       ref: { table: { disable: true } }
     }}
   >
@@ -170,18 +172,10 @@ Available options are: <ul> <li><code>None</code></li> <li><code>Error</code></l
       return (
         <AnalyticalCard
           header={
-            <AnalyticalCardHeader
-              titleText={args.titleText}
-              subtitleText={args.subtitleText}
-              trend={args.trend}
-              value={args.value}
-              state={args.state}
-              scale={args.scale}
-              onClick={args.onClick}
-              description={args.description}
-              status={args.status}
-              unitOfMeasurement={args.unitOfMeasurement}
-            />
+            <AnalyticalCardHeader {...args}>
+              <NumericSideIndicator titleText="Indicator1" number="12" />
+              <NumericSideIndicator titleText="Indicator2" number="5" />
+            </AnalyticalCardHeader>
           }
         >
           <LineChart
@@ -197,6 +191,15 @@ Available options are: <ul> <li><code>None</code></li> <li><code>Error</code></l
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="Customizable header" />
+<ArgsTableWithNote
+  story="Customizable header"
+  noteText={
+    <>
+      {`The props in the table below are part of the "AnalyticalCardHeader" component.`}
+      <br />
+      {`This component supports all HTML attributes.`}
+    </>
+  }
+/>
 
 <Footer />

--- a/packages/main/src/components/Toolbar/Toolbar.stories.mdx
+++ b/packages/main/src/components/Toolbar/Toolbar.stories.mdx
@@ -169,7 +169,7 @@ line.
 If the horizontally available space isn't enough to fit all items in it, an overflow button is displayed.<br/>
 **Note:** You can change the width of the toolbar by dragging the `width` slider in the table below.
 
-<ArgsTableWithNote story="With overflow button" />
+<ArgsTableWithNote story="With overflow button" hideHTMLPropsNote />
 
 <Canvas>
   <Story
@@ -191,7 +191,8 @@ If the horizontally available space isn't enough to fit all items in it, an over
       onOverflowChange: { table: { disable: true } },
       className: { table: { disable: true } },
       style: { table: { disable: true } },
-      tooltip: { table: { disable: true } }
+      tooltip: { table: { disable: true } },
+      overflowPopoverRef: { table: { disable: true } }
     }}
   >
     {(args) => {

--- a/packages/main/src/webComponents/Calendar/Calendar.stories.mdx
+++ b/packages/main/src/webComponents/Calendar/Calendar.stories.mdx
@@ -61,6 +61,7 @@ import '@ui5/webcomponents-localization/dist/features/calendar/Persian.js';
       maxDate: { table: { disable: true } },
       minDate: { table: { disable: true } },
       primaryCalendarType: { table: { disable: true } },
+      secondaryCalendarType: { table: { disable: true } },
       children: { table: { disable: true } },
       onSelectedDatesChange: { table: { disable: true } },
       style: { table: { disable: true } },
@@ -81,6 +82,9 @@ import '@ui5/webcomponents-localization/dist/features/calendar/Persian.js';
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with CalendarDate" />
+<ArgsTableWithNote
+  story="with CalendarDate"
+  noteText={`The props in the table below are part of the "CalendarDate" component.`}
+/>
 
 <Footer />

--- a/packages/main/src/webComponents/List/List.stories.mdx
+++ b/packages/main/src/webComponents/List/List.stories.mdx
@@ -69,8 +69,8 @@ import '@ui5/webcomponents-icons/dist/employee.js';
 
 ## StandardListItem
 
-The <code>StandardListItem</code> represents the simplest type of item for a <code>StandardListItemst</code>. This is a
-list item, providing the most common use cases such as <code>text</code>, <code>image</code> and <code>icon</code>
+The `StandardListItem` represents the simplest type of an item in a `List`. It is a
+list item, providing the most common use cases like displaying a `text`, `image` and `icon`.
 
 <Canvas>
   <Story
@@ -104,13 +104,24 @@ list item, providing the most common use cases such as <code>text</code>, <code>
         description: `Defines the state of the <code>additionalTextState</code>. <br> Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Erorr"</code>.`
       },
       type: {
-        description: `Defines the visual indication and behavior of the list items. Available options are <code>Active</code> (by default), <code>Inactive</code> and <code>Detail</code>. <br><br> <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press and hover, while with type <code>Inactive</code> and <code>Detail</code> - will not.`
+        description: `Defines the visual indication and behavior of the list items. Available options are <code>Active</code> (by default), <code>Inactive</code> and <code>Detail</code>. <br><br> <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press and hover, while with type <code>Inactive</code> and <code>Detail</code> - will not.`,
+        control: { type: 'select' },
+        options: ListItemType
       },
-      selected: { description: `Defines the selected state of the <code>ListItem</code>.` },
+      selected: {
+        description: `Defines the selected state of the <code>ListItem</code>.`
+      },
       children: {
         description: `Defines the text of the <code>StandardListItem</code>. <br><br> <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.`
       },
+      onDetailClick: {
+        description: `Fired when the user clicks on the detail button when type is \`Detail\`.`,
+        control: { action: 'onDetailClick' }
+      },
+      accessibleNameRef: { table: { disable: true } },
+      accessibleRole: { table: { disable: true } },
       busy: { table: { disable: true } },
+      busyDelay: { table: { disable: true } },
       footerText: { table: { disable: true } },
       headerText: { table: { disable: true } },
       growing: { table: { disable: true } },
@@ -137,7 +148,10 @@ list item, providing the most common use cases such as <code>text</code>, <code>
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with StandardListItem" />
+<ArgsTableWithNote
+  story="with StandardListItem"
+  noteText={`The props in the table below are part of the "StandardListItem" component.`}
+/>
 
 <br />
 

--- a/packages/main/src/webComponents/ShellBar/ShellBar.stories.mdx
+++ b/packages/main/src/webComponents/ShellBar/ShellBar.stories.mdx
@@ -1,14 +1,12 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { ArgsTableWithNote } from '@docs/ArgsTableWithNote';
-import { ShellBar } from './index';
-import { ShellBarItem } from '../ShellBarItem';
-import { Avatar } from '../Avatar';
-import { StandardListItem } from '../StandardListItem';
+import { Avatar, Popover, ShellBar, ShellBarItem, StandardListItem } from '../..';
 import { DocsHeader } from '@docs/DocsHeader';
 import { Footer } from '@docs/Footer';
 import Description from './ShellBarDescription.md';
 import '@ui5/webcomponents-icons/dist/add.js';
 import image from '../../../../../.storybook/demoImages/Person.png';
+import { useRef } from 'react';
 
 <Meta
   title="Layouts & Floorplans / ShellBar"
@@ -91,17 +89,15 @@ This component exposes public methods. You can invoke them directly on the insta
     args={{
       count: '2',
       icon: 'add',
-      stableDomRef: undefined,
       text: 'add'
     }}
     argTypes={{
       count: { description: `Defines the count displayed in the top-right corner.` },
       icon: { description: `Defines the name of the item's icon.` },
-      stableDomRef: { description: `Defines the stable selector that you can use via getStableDomRef method.` },
       text: {
         description: `Defines the item text.<br /><br />__Note:__ <code>text</code> will only be visible in mobile view.`
       },
-      onItemClick: {
+      onClick: {
         description: `Fired, when the item is pressed.<br /><br />__Note:__ To get the DOM reference of the clicked \`ShellBarItem\`, use \`event.detail.targetRef\`.`
       },
       notificationsCount: { table: { disable: true } },
@@ -121,18 +117,33 @@ This component exposes public methods. You can invoke them directly on the insta
       onMenuItemClick: { table: { disable: true } },
       onNotificationsClick: { table: { disable: true } },
       onProductSwitchClick: { table: { disable: true } },
-      onProfileClick: { table: { disable: true } }
+      onProfileClick: { table: { disable: true } },
+      className: { table: { disable: true } },
+      style: { table: { disable: true } }
     }}
   >
-    {(args) => (
-      <ShellBar>
-        <ShellBarItem {...args} />
-      </ShellBar>
-    )}
+    {(args) => {
+      const popoverRef = useRef(null);
+      const handleShellBarItemClick = (e) => {
+        args.onClick(e);
+        popoverRef.current.showAt(e.detail.targetRef);
+      };
+      return (
+        <>
+          <ShellBar>
+            <ShellBarItem {...args} onClick={handleShellBarItemClick} />
+          </ShellBar>
+          <Popover ref={popoverRef}>Hello there!</Popover>
+        </>
+      );
+    }}
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with customizable ShellBarItem" />
+<ArgsTableWithNote
+  story="with customizable ShellBarItem"
+  noteText={`The props in the table below are part of the "ShellBarItem" component.`}
+/>
 
 ### Recipe: How to open a popover on ShellBarItem click?
 

--- a/packages/main/src/webComponents/SideNavigation/SideNavigation.stories.mdx
+++ b/packages/main/src/webComponents/SideNavigation/SideNavigation.stories.mdx
@@ -79,18 +79,26 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
       expanded: true,
       icon: 'wrench',
       selected: false,
-      text: 'Customizable Item'
+      text: 'Customizable Item',
+      wholeItemToggleable: false
     }}
     argTypes={{
       collapsed: { table: { disable: true } },
       fixedItems: { table: { disable: true } },
+      header: { table: { disable: true } },
+      onSelectionChange: { table: { disable: true } },
+      className: { table: { disable: true } },
+      style: { table: { disable: true } },
       expanded: { description: `Defines if the item is expanded` },
       icon: {
-        description: `Defines the icon of the item. <br><br><br/><br/>The SAP-icons font provides numerous options. <br> See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.`
+        description: `Defines the icon of the item. \n\nThe SAP-icons font provides numerous options. See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.`
       },
       selected: { description: `Defines whether the subitem is selected` },
       text: { description: `Defines the text of the item.` },
-      children: { description: `If you wish to nest menus, you can pass inner menu items to the default slot.` }
+      children: { description: `If you wish to nest menus, you can pass inner menu items to the default slot.` },
+      wholeItemToggleable: {
+        description: `Defines whether pressing the whole item or only pressing the icon will show/hide the items's sub items(if present). If set to true, pressing the whole item will toggle the sub items, and it won't fire the \`click\` event. By default, only pressing the arrow icon will toggle the sub items & the click event will be fired if the item is pressed outside of the icon.`
+      }
     }}
   >
     {(args) => {
@@ -106,6 +114,9 @@ import '@ui5/webcomponents-icons/dist/wrench.js';
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="Customizable SideNavigationItem" />
+<ArgsTableWithNote
+  story="Customizable SideNavigationItem"
+  noteText={`The props in the table below are part of the "SideNavigationItem" component.`}
+/>
 
 <Footer />

--- a/packages/main/src/webComponents/Table/Table.stories.mdx
+++ b/packages/main/src/webComponents/Table/Table.stories.mdx
@@ -137,17 +137,26 @@ The `TableColumn` component allows defining column specific properties that are 
       minWidth: {
         description: `Defines the minimum table width required to display this column. By default it is always displayed. <br><br> The responsive behavior of the <code>Table</code> is determined by this property. As an example, by setting <code>minWidth</code> property to <code>40em</code> shows this column on tablet (and desktop) but hides it on mobile. <br> For further responsive design options, see <code>demandPopin</code> property.`
       },
-      popinText: { description: `he text for the column when it pops in.` },
-      noDataText: { table: { disable: true } },
-      hideNoData: { table: { disable: true } },
-      stickyColumnHeader: { table: { disable: true } },
-      columns: { control: { table: true } },
-      onPopinChange: { table: { disable: true } },
-      onRowClick: { table: { disable: true } },
+      popinText: { description: `The text for the column when it pops in.` },
       children: {
         description: `Defines the content of the column header.`,
         control: { disable: false }
-      }
+      },
+      noDataText: { table: { disable: true } },
+      hideNoData: { table: { disable: true } },
+      stickyColumnHeader: { table: { disable: true } },
+      columns: { table: { disable: true } },
+      onPopinChange: { table: { disable: true } },
+      accessibleName: { table: { disable: true } },
+      accessibleNameRef: { table: { disable: true } },
+      busy: { table: { disable: true } },
+      busyDelay: { table: { disable: true } },
+      growing: { table: { disable: true } },
+      growingButtonSubtext: { table: { disable: true } },
+      growingButtonText: { table: { disable: true } },
+      mode: { table: { disable: true } },
+      onLoadMore: { table: { disable: true } },
+      onSelectionChange: { table: { disable: true } }
     }}
   >
     {(args) => {
@@ -206,7 +215,16 @@ The `TableColumn` component allows defining column specific properties that are 
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with customizable TableColumn" />
+<ArgsTableWithNote
+  story="with customizable TableColumn"
+  noteText={
+    <>
+      {`The props in the table below are part of the "TableColumn" component.`}
+      <br />
+      {`This component supports all HTML attributes.`}
+    </>
+  }
+/>
 
 ## Growing Table
 

--- a/packages/main/src/webComponents/Tree/Tree.stories.mdx
+++ b/packages/main/src/webComponents/Tree/Tree.stories.mdx
@@ -12,6 +12,7 @@ import '@ui5/webcomponents-icons/dist/paste.js';
 import '@ui5/webcomponents-icons/dist/wrench.js';
 import '@ui5/webcomponents-icons/dist/download-from-cloud.js';
 import { useState } from 'react';
+import { ValueState } from '../../enums';
 
 <Meta
   title="Data Display / Tree"
@@ -93,7 +94,10 @@ tree items.
       hasChildren: true,
       icon: 'wrench',
       selected: false,
-      text: 'Customizable TreeItem'
+      text: 'Customizable TreeItem',
+      additionalText: 'Additional Text',
+      additionalTextState: ValueState.None,
+      indeterminate: false
     }}
     argTypes={{
       expanded: {
@@ -106,8 +110,16 @@ tree items.
       selected: {
         description: `Defines whether the tree node is selected by the user. Only has effect if the <code>Tree</code> is in one of the following modes: in <code>SingleSelect</code>, <code>SingleSelectBegin</code>, <code>SingleSelectEnd</code> and <code>MultiSelect</code>.`
       },
+      additionalText: { description: `Defines the \`additionalText\`, displayed in the end of the tree item.` },
+      additionalTextState: {
+        description: `Defines the state of the \`additionalText\`.\n\nAvailable options are: \`"None"\` (by default), \`"Success"\`, \`"Warning"\`, \`"Information"\` and \`"Erorr"\`.`,
+        control: { type: 'select', options: ValueState }
+      },
       text: { description: `Defines the text of the tree item.` },
       children: { description: `Defines the items of this <code>TreeItem</code>.` },
+      indeterminate: {
+        description: `Defines whether the selection of a tree node is displayed as partially selected.\n\n**Note:** The indeterminate state can be set only programatically and can’t be achieved by user interaction, meaning that the resulting visual state depends on the values of the \`indeterminate\` and \`selected\` properties: \n* If a tree node has both \`selected\` and \`indeterminate\` set to \`true\`, it is displayed as partially selected.\n*   If a tree node has \`selected\` set to \`true\` and \`indeterminate\` set to \`false\`, it is displayed as selected.\n*   If a tree node has \`selected\` set to \`false\`, it is displayed as not selected regardless of the value of the \`indeterminate\` property.\n\n**Note:** This property takes effect only when the \`Tree\` is in \`MultiSelect\` mode.`
+      },
       footerText: { table: { disable: true } },
       headerText: { table: { disable: true } },
       mode: { table: { disable: true } },
@@ -116,7 +128,11 @@ tree items.
       onItemClick: { table: { disable: true } },
       onItemDelete: { table: { disable: true } },
       onItemToggle: { table: { disable: true } },
-      onSelectionChange: { table: { disable: true } }
+      onSelectionChange: { table: { disable: true } },
+      onItemMouseout: { table: { disable: true } },
+      className: { table: { disable: true } },
+      style: { table: { disable: true } },
+      onItemMouseover: { table: { disable: true } }
     }}
   >
     {(args) => {
@@ -134,7 +150,10 @@ tree items.
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with customizable TreeItem" />
+<ArgsTableWithNote
+  story="with customizable TreeItem"
+  noteText={`The props in the table below are part of the "TreeItem" component.`}
+/>
 
 <br />
 

--- a/packages/main/src/webComponents/UploadCollection/UploadCollection.stories.mdx
+++ b/packages/main/src/webComponents/UploadCollection/UploadCollection.stories.mdx
@@ -14,6 +14,7 @@ import { Icon } from '../Icon';
 import { Title } from '../Title';
 import { UploadCollectionItem } from '../UploadCollectionItem';
 import { UploadCollection } from './index';
+import { ListItemType } from '../../enums';
 
 <Meta
   title="Inputs / UploadCollection"
@@ -115,44 +116,70 @@ export const UploadCollectionComponent = () => {
       uploadState: UploadState.Ready,
       children: 'UploadCollectionItem',
       thumbnail: <Icon name="document" />,
-      onFileNameClick: () => {},
-      onRename: () => {},
-      onRetry: () => {},
-      onTerminate: () => {}
+      type: ListItemType.Active,
+      selected: false
     }}
     argTypes={{
       mode: { table: { disable: true } },
+      accessibleName: { table: { disable: true } },
       noDataDescription: { table: { disable: true } },
       noDataText: { table: { disable: true } },
       hideDragOverlay: { table: { disable: true } },
       header: { table: { disable: true } },
       onItemDelete: { table: { disable: true } },
       onSelectionChange: { table: { disable: true } },
+      onDrop: { table: { disable: true } },
+      type: {
+        description: `Defines the visual indication and behavior of the list items. Available options are \`Active\` (by default), \`Inactive\` and \`Detail\`.\n\n**Note:** When set to \`Active\`, the item will provide visual response upon press and hover, while with type \`Inactive\` and \`Detail\` - will not.`
+      },
+      selected: { description: `Defines the selected state of the \`ListItem\`.` },
       thumbnail: {
+        description: `A thumbnail, which will be shown in the beginning of the \`UploadCollectionItem\`.\n\n**Note:** Use \`Icon\` or \`img\` for the intended design.\n\n__Note:__ When passing a custom React component to this prop, you have to make sure your component reads the \`slot\` prop and appends it to the most outer element of your component.Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).`,
         control: { disable: true }
       },
       children: {
         description: `Hold the description of the <code>UploadCollectionItem</code>. Will be shown below the file name.`,
-        control: { disable: false }
+        control: { disable: true }
       },
+      disableDeleteButton: { description: `Disables the delete button.` },
+      file: { control: { disable: true }, description: `Holds an instance of \`File\` associated with this item.` },
       fileName: { description: `The name of the file.` },
+      fileNameClickable: {
+        description: `If set to \`true\` the file name will be clickable and it will fire \`onFileNameClick\` event upon click.`
+      },
+      hideRetryButton: { description: `Hides the retry button when \`uploadState\` property is \`Error\`.` },
+      hideTerminateButton: {
+        description: `Hides the terminate button when \`uploadState\` property is \`Uploading\`.`
+      },
+      progress: {
+        description: `The upload progress in percentage.\n\n**Note:** Expected values are in the interval \[0, 100\].`
+      },
       uploadState: {
-        options: ['Complete', 'Error', 'Ready', 'Uploading'],
+        description: `If set to \`Uploading\` or \`Error\`, a progress indicator showing the \`progress\` is displayed. Also if set to \`Error\`, a refresh button is shown. When this icon is pressed \`onRetry\` event is fired. If set to \`Uploading\`, a terminate button is shown. When this icon is pressed \`onTerminate\` event is fired.`,
+        options: UploadState,
         control: {
-          type: 'radio'
+          type: 'select'
         }
       },
       onFileNameClick: {
-        control: { disable: true }
+        description: `Fired when the file name is clicked.\n\n**Note:** This event is only available when \`fileNameClickable\` property is \`true\`.`,
+        control: { action: 'onFileNameClick' }
       },
       onRename: {
-        control: { disable: true }
+        description: `Fired when the \`fileName\` property gets changed.\n\n**Note:** An edit button is displayed on each item, when the \`UploadCollectionItem\` \`type\` property is set to \`Detail\`.`,
+        control: { action: 'onRename' }
       },
       onRetry: {
-        control: { disable: true }
+        description: `Fired when the retry button is pressed.\n\n**Note:** Retry button is displayed when \`uploadState\` property is set to \`Error\`.`,
+        control: { action: 'onRetry' }
       },
       onTerminate: {
-        control: { disable: true }
+        description: `Fired when the terminate button is pressed.\n\n**Note:** Terminate button is displayed when \`uploadState\` property is set to \`Uploading\`.`,
+        control: { action: 'onTerminate' }
+      },
+      onDetailClick: {
+        description: `Fired when the terminate button is pressed.\n\n**Note:** Terminate button is displayed when \`uploadState\` property is set to \`Uploading\`.`,
+        control: { action: 'onDetailClick' }
       }
     }}
   >
@@ -166,7 +193,10 @@ export const UploadCollectionComponent = () => {
   </Story>
 </Canvas>
 
-<ArgsTableWithNote story="with UploadCollectionItem" />
+<ArgsTableWithNote
+  story="with UploadCollectionItem"
+  noteText={`The props in the table below are part of the "UploadCollectionItem" component.`}
+/>
 
 <br />
 


### PR DESCRIPTION
This PR adds a note above args tables where subcomponents like `StandardListItem` can be configured, it also cleans up some tables where old props were used, or props were missing.