### PR TITLE
fix(AnalyticalTable): allow adding columns in runtime

### DIFF
--- a/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
@@ -38,10 +38,14 @@ const stringToPx = (dataPoint, id) => {
   }
   return 0;
 };
-const smartColumns = (columns: AnalyticalTableColumnDefinition[], instance, visibleColumns) => {
+const smartColumns = (columns: AnalyticalTableColumnDefinition[], instance, hiddenColumns) => {
   const { rows, state, webComponentsReactProperties } = instance;
   const rowSample = rows.slice(0, ROW_SAMPLE_SIZE);
   const { tableClientWidth: totalWidth } = state;
+
+  const visibleColumns = columns.filter(
+    (column) => (column.isVisible ?? true) && !hiddenColumns.includes(column.id ?? column.accessor)
+  );
 
   const columnMeta: Record<string, IColumnMeta> = visibleColumns.reduce(
     (metadata: Record<string, IColumnMeta>, column) => {
@@ -177,9 +181,8 @@ const columns = (columns: AnalyticalTableColumnDefinition[], { instance }) => {
       return column ?? false;
     })
     .filter(Boolean);
-
   if (scaleWidthMode === TableScaleWidthMode.Smart) {
-    return smartColumns(columns, instance, visibleColumns);
+    return smartColumns(columns, instance, hiddenColumns);
   }
 
   const calculateDefaultTableWidth = () => {


### PR DESCRIPTION
`visibleColumns` is never updated in the `columns` hook, that's why we have to use `columns` here and check for visibility ourself.

Fixes #3295