### PR TITLE
feat(DynamicPageTitle): allow a subset of `Toolbar` props to be passed to each toolbar

### DIFF
--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -298,15 +298,20 @@ import { ProductsTable } from '../../../../../.storybook/components/ProductsTabl
 
 ## DynamicPage with custom actions and navigationActions overflow button
 
-With the `actionsOverflowButton` and the `navigationActionsOverflowButton` props of the `DynamicPageTitle` it is possible to change the overflow button of the respective actions toolbar.
-The `navigationActionsOverflowButton` is only displayed, if the `navigationActions` toolbar is used. (width < 1280px)
+The `DynamicPageTitle` offers two props (`actionsToolbarProps` and `navigationActionsToolbarProps`) to configure the props of the `actions` and `navigationActions` toolbars.
+With these objects it's possible to e.g. configure the overflow button displayed within each toolbar by setting the `overflowButton` prop.
+`navigationActionsToolbarProps` only has an effect, if the `navigationActions` toolbar is used. (width < 1280px)
 
 <Canvas>
   <Story name="with custom overflow button">
     {() => {
       const titleProps = {
-        actionsOverflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="navigation-down-arrow" />,
-        navigationActionsOverflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="menu2" />,
+        actionsToolbarProps: {
+          overflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="navigation-down-arrow" />
+        },
+        navigationActionsToolbarProps: {
+          overflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="menu2" />
+        },
         actions: (
           <>
             <Button key={'edit'} design={ButtonDesign.Emphasized}>

--- a/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.test.tsx
@@ -453,12 +453,20 @@ describe('DynamicPage', () => {
         style={{ width: '50px' }}
         headerTitle={
           <DynamicPageTitle
-            actionsOverflowButton={<ToggleButton data-testid="actionBtn" icon="question-mark" />}
-            navigationActionsOverflowButton={<ToggleButton data-testid="navActionBtn" icon="question-mark" />}
+            actionsToolbarProps={{ overflowButton: <ToggleButton data-testid="actionBtn" icon="question-mark" /> }}
+            navigationActionsToolbarProps={{
+              overflowButton: <ToggleButton data-testid="navActionBtn" icon="question-mark" />
+            }}
             actions={
               <>
                 <Button>Actions Button 1</Button>
                 <Button>Actions Button 2</Button>
+              </>
+            }
+            navigationActions={
+              <>
+                <Button>Navigation Actions Button 1</Button>
+                <Button>Navigation Actions Button 2</Button>
               </>
             }
           />

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.mdx
@@ -301,15 +301,20 @@ import SampleImage from '../../../../../.storybook/demoImages/Person.png';
 
 ## ObjectPage with custom actions and navigationActions overflow button
 
-With the `actionsOverflowButton` and the `navigationActionsOverflowButton` props of the `DynamicPageTitle` it is possible to change the overflow button of the respective actions toolbar.
-The `navigationActionsOverflowButton` is only displayed, if the `navigationActions` toolbar is used. (width < 1280px)
+The `DynamicPageTitle` offers two props (`actionsToolbarProps` and `navigationActionsToolbarProps`) to configure the props of the `actions` and `navigationActions` toolbars.
+With these objectes it's possible to e.g. configure the overflow button displayed within each toolbar by setting the `overflowButton` prop.
+`navigationActionsToolbarProps` only has an effect, if the `navigationActions` toolbar is used. (width < 1280px)
 
 <Canvas>
   <Story name="with custom overflow button">
     {() => {
       const titleProps = {
-        actionsOverflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="navigation-down-arrow" />,
-        navigationActionsOverflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="menu2" />,
+        actionsToolbarProps: {
+          overflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="navigation-down-arrow" />
+        },
+        navigationActionsToolbarProps: {
+          overflowButton: <ToggleButton design={ButtonDesign.Transparent} icon="menu2" />
+        },
         actions: (
           <>
             <Button key={'edit'} design={ButtonDesign.Emphasized}>


### PR DESCRIPTION
This PR deprecates the `actionsOverflowButton`, `navigationActionsOverflowButton` and `onToolbarOverflowChange` props. Depending on which toolbar should be configured, all props should be passed to either the `actionsToolbarProps` or `navigationActionsToolbarProps`.

Closes #3353