### PR TITLE
feat(AnalyticalTable): add `retainColumnWidth` prop

### DIFF
--- a/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useDynamicColumnWidths.ts
@@ -18,7 +18,7 @@ const columnsDeps = (deps, { instance: { state, webComponentsReactProperties, vi
   return [
     ...deps,
     hasRows,
-    state.tableClientWidth,
+    !state.tableColResized && state.tableClientWidth,
     state.hiddenColumns.length,
     visibleColumns?.length,
     webComponentsReactProperties.scaleWidthMode,

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -315,6 +315,10 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    */
   rowHeight?: number;
   /**
+   * Defines whether the table should retain its column width, when a column has been manually resized and the container width has changed.
+   */
+  retainColumnWidth?: boolean;
+  /**
    * Defines whether the table should display rows with alternating row colors.
    */
   alternateRowColor?: boolean;
@@ -543,6 +547,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     overscanCount,
     overscanCountHorizontal,
     portalContainer,
+    retainColumnWidth,
     reactTableOptions,
     renderRowSubComponent,
     rowHeight,
@@ -902,6 +907,15 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     } as CSSProperties;
   }, [tableState.tableClientWidth, style, rowHeight, totalColumnsWidth]);
 
+  useEffect(() => {
+    if (retainColumnWidth && tableState.columnResizing?.isResizingColumn && tableState.tableColResized == null) {
+      dispatch({ type: 'TABLE_COL_RESIZED', payload: true });
+    }
+    if (tableState.tableColResized && !retainColumnWidth) {
+      dispatch({ type: 'TABLE_COL_RESIZED', payload: undefined });
+    }
+  }, [tableState.columnResizing, retainColumnWidth, tableState.tableColResized]);
+
   const parentRef: RefObject<DivWithCustomScrollProp> = useRef(null);
 
   const verticalScrollBarRef: RefObject<DivWithCustomScrollProp> = useRef(null);
@@ -979,7 +993,6 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
               if (headerGroup.getHeaderGroupProps) {
                 headerProps = headerGroup.getHeaderGroupProps();
               }
-
               return (
                 tableRef.current && (
                   <ColumnHeaderContainer

--- a/packages/main/src/components/AnalyticalTable/tableReducer/stateReducer.ts
+++ b/packages/main/src/components/AnalyticalTable/tableReducer/stateReducer.ts
@@ -45,6 +45,8 @@ export const stateReducer = (prevState, action) => {
       return { ...prevState, isRtl: payload.isRtl };
     case 'SUB_COMPONENTS_HEIGHT':
       return { ...prevState, subComponentsHeight: payload };
+    case 'TABLE_COL_RESIZED':
+      return { ...prevState, tableColResized: payload };
     default:
       return prevState;
   }


### PR DESCRIPTION
This PR adds the `retainColumnWidth` prop. It controls how the table should react to a container width change, when a column has previously been resized by user interaction.