### PR TITLE
Revert "fix(DynamicPage): prevent footer from "jumping" in rare cases (#3486)"

### DIFF
--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -152,7 +152,7 @@ const DynamicPage = forwardRef((props: DynamicPagePropTypes, ref: Ref<HTMLDivEle
     const observer = new IntersectionObserver(debouncedObserverFn, {
       root: dynamicPageRef.current,
       threshold: 0.98,
-      rootMargin: '0px 0px -70px 0px' // negative bottom margin for footer height
+      rootMargin: '0px 0px -60px 0px' // negative bottom margin for footer height
     });
 
     if (contentRef.current) {


### PR DESCRIPTION
The margin wasn't the root cause of the issue, so the "fix" just shifted the problem and did not solve it.