### PR TITLE
fix(Toolbar): fire `onOverflowChange` event if `children` are changed

### DIFF
--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -265,21 +265,29 @@ const Toolbar = forwardRef((props: ToolbarPropTypes, ref: Ref<HTMLDivElement>) =
     [onClick, active]
   );
 
+  const prevChildren = useRef(React.Children.toArray(children));
+  const debouncedOverflowChange = useRef(debounce(onOverflowChange, 60)).current;
   useEffect(() => {
-    if (lastVisibleIndex !== null && typeof onOverflowChange === 'function') {
+    const haveChildrenChanged = prevChildren.current.length !== React.Children.toArray(children).length;
+    if ((lastVisibleIndex !== null || haveChildrenChanged) && typeof onOverflowChange === 'function') {
+      prevChildren.current = React.Children.toArray(children);
       const toolbarChildren = contentRef.current?.children;
       let toolbarElements = [];
       const overflowElements = overflowContentRef.current?.children;
       if (toolbarChildren?.length > 0) {
         toolbarElements = Array.from(toolbarChildren).filter((item, index) => index <= lastVisibleIndex);
       }
-      onOverflowChange({
+      debouncedOverflowChange({
         toolbarElements,
         overflowElements,
         target: outerContainer.current
       });
     }
-  }, [lastVisibleIndex]);
+    return () => {
+      debouncedOverflowChange.cancel();
+    };
+  }, [lastVisibleIndex, children, debouncedOverflowChange]);
+
   const CustomTag = as as React.ElementType;
   const styleWithMinWidth = minWidth !== '0' ? { minWidth, ...style } : style;
   return (


### PR DESCRIPTION
This PR also debounces the event, so it doesn't get called twice.

Fixes #3530