### PR TITLE
feat(Form): introduce `backgroundDesign` prop

### DIFF
--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -457,7 +457,7 @@ exports[`DynamicPage hider header button 1`] = `
       style="padding-bottom: 0px;"
     >
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -555,7 +555,7 @@ exports[`DynamicPage hider header button 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -972,7 +972,7 @@ exports[`DynamicPage with content 1`] = `
       style="padding-bottom: 0px;"
     >
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem; z-index: 0;"
       >
@@ -1070,7 +1070,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -1150,7 +1150,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -1248,7 +1248,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -1328,7 +1328,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem; z-index: 0;"
       >
@@ -1426,7 +1426,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -1506,7 +1506,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >
@@ -1604,7 +1604,7 @@ exports[`DynamicPage with content 1`] = `
         </div>
       </form>
       <form
-        class="Form-form Form-labelSpan4"
+        class="Form-form Form-labelSpan4 Form-transparent"
         data-columns="4"
         style="padding-bottom: 2rem;"
       >

--- a/packages/main/src/components/Form/Form.jss.ts
+++ b/packages/main/src/components/Form/Form.jss.ts
@@ -66,9 +66,15 @@ const styles = {
       '--ui5wcr_form_full_span': 'span 144'
     }
   },
+  solid: {
+    backgroundColor: ThemingParameters.sapGroup_ContentBackground
+  },
+  transparent: {
+    backgroundColor: 'transparent'
+  },
   formTitle: {
-    borderBottom: `1px solid ${ThemingParameters.sapGroup_TitleBorderColor}`,
-    marginBottom: '1.75rem',
+    borderBlockEnd: `1px solid ${ThemingParameters.sapGroup_TitleBorderColor}`,
+    marginBlockEnd: '1.75rem',
     gridColumn: 'var(--ui5wcr_form_full_span)'
   },
   ...labelSpanClasses(),

--- a/packages/main/src/components/Form/Form.stories.mdx
+++ b/packages/main/src/components/Form/Form.stories.mdx
@@ -5,6 +5,7 @@ import { ArgsTableWithNote } from '@docs/ArgsTableWithNote';
 import {
   CheckBox,
   Form,
+  FormBackgroundDesign,
   FormGroup,
   FormItem,
   Input,
@@ -34,6 +35,7 @@ import {
     as: { control: { disable: true } }
   }}
   args={{
+    backgroundDesign: FormBackgroundDesign.Transparent,
     titleText: 'Test Form',
     labelSpanS: 12,
     labelSpanM: 2,

--- a/packages/main/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/main/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Create a Form should use a single FormGroup's heading as a Form heading if one is not set 1`] = `
 <DocumentFragment>
   <form
-    class="Form-form Form-labelSpan4"
+    class="Form-form Form-labelSpan4 Form-transparent"
     data-columns="2"
   >
     <h6
@@ -60,7 +60,7 @@ exports[`Create a Form should use a single FormGroup's heading as a Form heading
 exports[`Create a Form size rate L; should create Label and Element with 33% and 66% width respectively and display: flex for top FormItem div 1`] = `
 <DocumentFragment>
   <form
-    class="Form-form Form-labelSpan4"
+    class="Form-form Form-labelSpan4 Form-transparent"
     data-columns="1"
   >
     <ui5-title
@@ -73,6 +73,7 @@ exports[`Create a Form size rate L; should create Label and Element with 33% and
     <h6
       aria-label="Group 1"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 1"
     >
       Group 1
@@ -121,6 +122,7 @@ exports[`Create a Form size rate L; should create Label and Element with 33% and
     <h6
       aria-label="Group 2"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 2"
     >
       Group 2
@@ -173,7 +175,7 @@ exports[`Create a Form size rate L; should create Label and Element with 33% and
 exports[`Create a Form size rate M; should create Label and Element with 16% and 83% width respectively and display: flex for top FormItem div 1`] = `
 <DocumentFragment>
   <form
-    class="Form-form Form-labelSpan2"
+    class="Form-form Form-labelSpan2 Form-transparent"
     data-columns="1"
   >
     <ui5-title
@@ -186,6 +188,7 @@ exports[`Create a Form size rate M; should create Label and Element with 16% and
     <h6
       aria-label="Group 1"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 1"
     >
       Group 1
@@ -234,6 +237,7 @@ exports[`Create a Form size rate M; should create Label and Element with 16% and
     <h6
       aria-label="Group 2"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 2"
     >
       Group 2
@@ -286,7 +290,7 @@ exports[`Create a Form size rate M; should create Label and Element with 16% and
 exports[`Create a Form size rate S; should create Label and Element with 100% width and display: block for top FormItem div 1`] = `
 <DocumentFragment>
   <form
-    class="Form-form Form-labelSpan12"
+    class="Form-form Form-labelSpan12 Form-transparent"
     data-columns="1"
   >
     <ui5-title
@@ -299,6 +303,7 @@ exports[`Create a Form size rate S; should create Label and Element with 100% wi
     <h6
       aria-label="Group 1"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 1"
     >
       Group 1
@@ -345,6 +350,7 @@ exports[`Create a Form size rate S; should create Label and Element with 100% wi
     <h6
       aria-label="Group 2"
       class="FormGroup-title"
+      data-component-name="FormGroupTitle"
       title="Group 2"
     >
       Group 2
@@ -395,7 +401,7 @@ exports[`Create a Form size rate S; should create Label and Element with 100% wi
 exports[`Create a Form size rate XL; should create Label and Element with 33% and 66% width respectively and display: flex for top FormItem div 1`] = `
 <DocumentFragment>
   <form
-    class="Form-form Form-labelSpan4"
+    class="Form-form Form-labelSpan4 Form-transparent"
     data-columns="2"
   >
     <ui5-title

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -5,8 +5,8 @@ import React, {
   cloneElement,
   CSSProperties,
   forwardRef,
-  ReactNode,
   ReactElement,
+  ReactNode,
   Ref,
   useEffect,
   useMemo,
@@ -14,7 +14,7 @@ import React, {
   useState
 } from 'react';
 import { createUseStyles } from 'react-jss';
-import { TitleLevel } from '../../enums/TitleLevel';
+import { FormBackgroundDesign, TitleLevel } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Title } from '../../webComponents/Title';
 import { styles } from './Form.jss';
@@ -25,6 +25,10 @@ export interface FormPropTypes extends CommonProps {
    * intended design.
    */
   children: ReactNode | ReactNode[];
+  /**
+   * Specifies the background color of the Form content.
+   */
+  backgroundDesign?: FormBackgroundDesign;
   /**
    * Form title
    */
@@ -118,20 +122,21 @@ const useStyles = createUseStyles(styles, { name: 'Form' });
  */
 const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
   const {
-    titleText,
+    as,
+    backgroundDesign,
     children,
-    className,
-    slot,
-    style,
     columnsS,
     columnsM,
     columnsL,
     columnsXL,
+    className,
     labelSpanS,
     labelSpanM,
     labelSpanL,
     labelSpanXL,
-    as,
+    slot,
+    titleText,
+    style,
     ...rest
   } = props;
 
@@ -273,7 +278,12 @@ const Form = forwardRef((props: FormPropTypes, ref: Ref<HTMLFormElement>) => {
     return [computedFormGroups, titleText];
   }, [children, currentRange, titleText, currentNumberOfColumns, currentLabelSpan]);
 
-  const formClassNames = clsx(classes.form, classes[`labelSpan${((currentLabelSpan - 1) % 12) + 1}`], className);
+  const formClassNames = clsx(
+    classes.form,
+    classes[`labelSpan${((currentLabelSpan - 1) % 12) + 1}`],
+    classes[backgroundDesign.toLowerCase()],
+    className
+  );
 
   const CustomTag = as as React.ElementType;
   return (
@@ -299,6 +309,7 @@ Form.displayName = 'Form';
 
 Form.defaultProps = {
   as: 'form',
+  backgroundDesign: FormBackgroundDesign.Transparent,
   columnsS: 1,
   columnsM: 1,
   columnsL: 1,

--- a/packages/main/src/components/FormGroup/index.tsx
+++ b/packages/main/src/components/FormGroup/index.tsx
@@ -21,13 +21,13 @@ const useStyles = createUseStyles(
       alignItems: 'center',
       height: CssSizeVariables.sapWcrFormGroupTitleHeight,
       lineHeight: CssSizeVariables.sapWcrFormGroupTitleHeight,
-      fontFamily: ThemingParameters.sapFontFamily,
-      color: ThemingParameters.sapTextColor,
-      fontSize: ThemingParameters.sapFontSize,
+      fontFamily: ThemingParameters.sapFontHeaderFamily,
+      color: ThemingParameters.sapGroup_TitleTextColor,
+      fontSize: ThemingParameters.sapFontHeader6Size,
       fontWeight: 'bold',
       backgroundColor: ThemingParameters.sapGroup_TitleBackground,
       margin: 0,
-      paddingTop: '1rem'
+      marginBlockStart: '1rem'
     },
     spacer: { height: '1rem', gridColumn: 'span 12' }
   },
@@ -44,7 +44,7 @@ const FormGroup: FC<FormGroupPropTypes> = (props: FormGroupPropTypes) => {
 
   return (
     <>
-      <h6 className={classes.title} title={titleText} aria-label={titleText}>
+      <h6 className={classes.title} title={titleText} aria-label={titleText} data-component-name="FormGroupTitle">
         {titleText}
       </h6>
       {children}

--- a/packages/main/src/enums/FormBackgroundDesign.ts
+++ b/packages/main/src/enums/FormBackgroundDesign.ts
@@ -1,0 +1,10 @@
+export enum FormBackgroundDesign {
+  /**
+   * A solid background color dependent on the theme.
+   */
+  Solid = 'Solid',
+  /**
+   * Transparent background.
+   */
+  Transparent = 'Transparent'
+}

--- a/packages/main/src/enums/index.ts
+++ b/packages/main/src/enums/index.ts
@@ -22,6 +22,7 @@ export * from './FlexBoxAlignItems';
 export * from './FlexBoxDirection';
 export * from './FlexBoxJustifyContent';
 export * from './FlexBoxWrap';
+export * from './FormBackgroundDesign';
 export * from './GlobalStyleClasses';
 export * from './GridPosition';
 export * from './IllustrationMessageSize';


### PR DESCRIPTION
This PR also replaces all CSS properties with physical direction mapping with the corresponding logical one.