### PR TITLE
chore: remove deprecated props

### DIFF
--- a/docs/MigrationGuide.stories.mdx
+++ b/docs/MigrationGuide.stories.mdx
@@ -18,6 +18,28 @@ or the [changelog](?path=/docs/change-log--page)._
 
 ## From 0.28.x to 1.0.1
 
+### Removal of deprecated props
+
+The following props were deprecated in previous versions and have now been removed.
+
+**ActionSheet**
+
+The prop `alwaysShowHeader` has been removed as is not specified by the Fiori Design Guidelines. <br />
+In addition, the `a11yConfig.actionSheetMobileContent.ariaLabel` has been removed as well. You can use the `accessibleName` prop as replacement.
+
+**AnalyticalTable**
+
+The props `onRowSelected` and `onColumnsReordered` have been removed in favor for a more streamlined naming pattern. <br />
+Please use the new prop names `onRowSelect` and `onColumnsReorder`.
+
+**DynamicPageTitle**
+
+The props `actionsOverflowButton` and `navigationActionsOverflowButton` have been removed. <br />
+If needed, you can pass a custom overflow button for the respective toolbar by using the `actionsToolbarProps={{ overflowButton: <Button />}}` and `navigationActionsToolbarProps={{ overflowButton: <Button />}}` props.
+
+In addition, the `onToolbarOverflowChange` event has been removed as well. Previously, this event contained a property `origin` with the value of `actions` or `navigationActions` in order to distinguish between the toolbars. <br />
+Please use `onOverflowChange` of the respective toolbar props object instead (`actionsToolbarProps={{ onOverflowChange: yourHandler }}` and `navigationActionsToolbarProps={{ onOverflowChange: yourHandlerForNavigationActions }}`).
+
 ### VariantManagement: removed option to show the "Cancel" button
 
 The "Cancel" button is not part of the design guidelines anymore, so the prop `showCancelButton` has been removed without replacement.

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -1,7 +1,7 @@
 import { isPhone } from '@ui5/webcomponents-base/dist/Device.js';
-import { deprecationNotice, useI18nBundle, useSyncRef } from '@ui5/webcomponents-react-base';
+import { useI18nBundle, useSyncRef } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { Children, forwardRef, ReactElement, ReactNode, Ref, useEffect, useReducer, useRef } from 'react';
+import React, { Children, forwardRef, ReactElement, ReactNode, Ref, useReducer, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { ButtonDesign } from '../../enums';
@@ -42,20 +42,11 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
    */
   showCancelButton?: boolean;
   /**
-   * Defines whether the `header` or `headerText` should always be displayed or only on mobile devices.
-   *
-   * __Deprecation Notice__: This prop is not specified by the Fiori Guidelines, so it will be removed with v0.29.0
-   *
-   * @deprecated This prop is not specified by the Fiori Guidelines, so it will be removed with v0.29.0
-   */
-  alwaysShowHeader?: boolean;
-  /**
    * Defines internally used a11y properties.
    */
   a11yConfig?: {
     actionSheetMobileContent?: {
       role?: string;
-      ariaLabel?: string;
     };
   };
   /**
@@ -136,7 +127,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
   const {
     a11yConfig,
     allowTargetOverlap,
-    alwaysShowHeader,
     children,
     className,
     footer,
@@ -158,16 +148,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
     onBeforeOpen,
     ...rest
   } = props;
-
-  // deprecations
-  useEffect(() => {
-    if (a11yConfig?.actionSheetMobileContent?.ariaLabel) {
-      deprecationNotice(
-        'ActionSheet',
-        `Using 'a11yConfig.actionSheetMobileContent.ariaLabel' is deprecated and will be removed in the next minor release. Please use the 'accessibleName' prop instead.`
-      );
-    }
-  }, [a11yConfig?.actionSheetMobileContent?.ariaLabel]);
 
   const i18nBundle = useI18nBundle('@ui5/webcomponents-react');
   const classes = useStyles();
@@ -229,14 +209,7 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
     }
   };
 
-  // TODO remove this block before releasing v0.29.0
-  useEffect(() => {
-    if (alwaysShowHeader) {
-      deprecationNotice('ActionSheet', `The prop 'alwaysShowHeader' is deprecated and will be removed in v0.29.0`);
-    }
-  }, [alwaysShowHeader]);
-
-  const displayHeader = alwaysShowHeader || isPhone();
+  const displayHeader = isPhone();
   return createPortal(
     <ResponsivePopover
       style={style}
@@ -254,7 +227,7 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
       onAfterClose={onAfterClose}
       onBeforeClose={onBeforeClose}
       onBeforeOpen={onBeforeOpen}
-      accessibleName={a11yConfig?.actionSheetMobileContent?.ariaLabel ?? i18nBundle.getText(AVAILABLE_ACTIONS)}
+      accessibleName={i18nBundle.getText(AVAILABLE_ACTIONS)}
       {...rest}
       onAfterOpen={handleAfterOpen}
       ref={componentRef}
@@ -289,7 +262,6 @@ const ActionSheet = forwardRef((props: ActionSheetPropTypes, ref: Ref<Responsive
 
 ActionSheet.defaultProps = {
   showCancelButton: true,
-  alwaysShowHeader: true,
   portalContainer: document.body
 };
 

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -138,10 +138,7 @@ import { DefaultNoDataComponent } from './defaults/NoDataComponent';
     selectionMode: TableSelectionMode.SingleSelect,
     selectionBehavior: TableSelectionBehavior.Row,
     overscanCountHorizontal: 5,
-    visibleRowCountMode: TableVisibleRowCountMode.Fixed,
-    // TODO remove after deprecations have been removed
-    onColumnsReordered: null,
-    onRowSelected: null
+    visibleRowCountMode: TableVisibleRowCountMode.Fixed
   }}
   argTypes={{
     data: { control: { disable: true } },
@@ -982,10 +979,8 @@ The prop expects a function with an optional parameter containing the `row` inst
       infiniteScrollThreshold: { table: { disable: true } },
       onSort: { table: { disable: true } },
       onGroup: { table: { disable: true } },
-      onRowSelected: { table: { disable: true } },
       onRowSelect: { table: { disable: true } },
       onRowExpandChange: { table: { disable: true } },
-      onColumnsReordered: { table: { disable: true } },
       onColumnsReorder: { table: { disable: true } },
       onLoadMore: { table: { disable: true } },
       reactTableOptions: { table: { disable: true } },
@@ -1167,10 +1162,8 @@ By adding the `visibleRowCountMode` prop and setting it to `TableVisibleRowCount
       infiniteScrollThreshold: { table: { disable: true } },
       onSort: { table: { disable: true } },
       onGroup: { table: { disable: true } },
-      onRowSelected: { table: { disable: true } },
       onRowSelect: { table: { disable: true } },
       onRowExpandChange: { table: { disable: true } },
-      onColumnsReordered: { table: { disable: true } },
       onColumnsReorder: { table: { disable: true } },
       onLoadMore: { table: { disable: true } },
       reactTableOptions: { table: { disable: true } },
@@ -1316,10 +1309,8 @@ In the example below you can have a look at this behavior:
       infiniteScrollThreshold: { table: { disable: true } },
       onSort: { table: { disable: true } },
       onGroup: { table: { disable: true } },
-      onRowSelected: { table: { disable: true } },
       onRowSelect: { table: { disable: true } },
       onRowExpandChange: { table: { disable: true } },
-      onColumnsReordered: { table: { disable: true } },
       onColumnsReorder: { table: { disable: true } },
       onLoadMore: { table: { disable: true } },
       reactTableOptions: { table: { disable: true } },

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -1,7 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   debounce,
-  deprecationNotice,
   enrichEventWithDetails,
   useI18nBundle,
   useIsomorphicId,
@@ -473,20 +472,6 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
   onGroup?: (e: CustomEvent<{ column: unknown; groupedColumns: string[] }>) => void;
   /**
    * Fired when a row is selected or unselected.
-   * __Deprecated: Please use `onRowSelect` instead.__
-   *
-   * @deprecated Please use `onRowSelect` instead.
-   */
-  onRowSelected?: (
-    e?: CustomEvent<{
-      allRowsSelected: boolean;
-      row?: Record<string, unknown>;
-      isSelected?: boolean;
-      selectedFlatRows: Record<string, unknown>[] | string[];
-    }>
-  ) => void;
-  /**
-   * Fired when a row is selected or unselected.
    */
   onRowSelect?: (
     e?: CustomEvent<{
@@ -504,14 +489,6 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    * Fired when a row is expanded or collapsed
    */
   onRowExpandChange?: (e?: CustomEvent<{ row: unknown; column: unknown }>) => void;
-  /**
-   * Fired when the columns order is changed.
-   * __Deprecated: Please use `onColumnsReorder` instead.__
-   *
-   * @deprecated Please use `onColumnsReorder` instead.
-   */
-  onColumnsReordered?: (e?: CustomEvent<{ columnsNewOrder: string[]; column: unknown }>) => void;
-
   /**
    * Fired when the columns order is changed.
    */
@@ -602,13 +579,11 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
     visibleRows,
     withNavigationHighlight,
     withRowHighlight,
-    onColumnsReordered,
     onColumnsReorder,
     onGroup,
     onLoadMore,
     onRowClick,
     onRowExpandChange,
-    onRowSelected,
     onRowSelect,
     onSort,
     onTableScroll,
@@ -630,21 +605,6 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
   const isRtl = useIsRTL(analyticalTableRef);
 
   const getSubRows = useCallback((row) => row.subRows || row[subRowsKey] || [], [subRowsKey]);
-
-  // deprecations
-  useEffect(() => {
-    if (typeof onRowSelected === 'function') {
-      deprecationNotice('AnalyticalTable', `'onRowSelected' is deprecated. Please use 'onRowSelect' instead.`);
-    }
-  }, [onRowSelected]);
-  useEffect(() => {
-    if (typeof onColumnsReordered === 'function') {
-      deprecationNotice(
-        'AnalyticalTable',
-        `'onColumnsReordered' is deprecated. Please use 'onColumnsReorder' instead.`
-      );
-    }
-  }, [onColumnsReordered]);
 
   const data = useMemo(() => {
     if (rawData.length === 0) {
@@ -688,7 +648,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
         selectionMode,
         selectionBehavior,
         classes,
-        onRowSelect: onRowSelect ?? onRowSelected,
+        onRowSelect: onRowSelect,
         onRowClick,
         onRowExpandChange,
         isTreeTable,
@@ -928,7 +888,7 @@ const AnalyticalTable = forwardRef((props: AnalyticalTablePropTypes, ref: Ref<HT
   }, [columnOrder]);
 
   const [dragOver, handleDragEnter, handleDragStart, handleDragOver, handleOnDrop, handleOnDragEnd] = useDragAndDrop(
-    onColumnsReorder ?? onColumnsReordered,
+    onColumnsReorder,
     isRtl,
     setColumnOrder,
     tableState.columnOrder,
@@ -1198,7 +1158,6 @@ AnalyticalTable.defaultProps = {
   selectedRowIds: {},
   onGroup: () => {},
   onRowExpandChange: () => {},
-  onColumnsReordered: () => {},
   isTreeTable: false,
   alternateRowColor: false,
   overscanCountHorizontal: 5,

--- a/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
+++ b/packages/main/src/components/DynamicPage/__snapshots__/DynamicPage.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`DynamicPage always show content header 1`] = `
           <div
             class="DynamicPageTitle-content"
             data-component-name="DynamicPageTitleContent"
-            style="padding-left: 0.5rem;"
           >
             <ui5-badge
               color-scheme="1"
@@ -770,7 +769,6 @@ exports[`DynamicPage with content 1`] = `
           <div
             class="DynamicPageTitle-content"
             data-component-name="DynamicPageTitleContent"
-            style="padding-left: 0.5rem;"
           >
             <ui5-badge
               color-scheme="1"
@@ -1765,7 +1763,6 @@ exports[`DynamicPage without content 1`] = `
           <div
             class="DynamicPageTitle-content"
             data-component-name="DynamicPageTitleContent"
-            style="padding-left: 0.5rem;"
           >
             <ui5-badge
               color-scheme="1"

--- a/packages/main/src/components/DynamicPageTitle/DynamicPageTitle.jss.ts
+++ b/packages/main/src/components/DynamicPageTitle/DynamicPageTitle.jss.ts
@@ -56,6 +56,7 @@ export const DynamicPageTitleStyles = {
     fontSize: ThemingParameters.sapFontSize,
     overflowWrap: 'break-word',
     hyphens: 'auto',
+    paddingInlineStart: '0.5rem',
     '& > *': {
       color: ThemingParameters.sapObjectHeader_Subtitle_TextColor,
       fontSize: ThemingParameters.sapFontSize,
@@ -68,7 +69,8 @@ export const DynamicPageTitleStyles = {
   },
   content: {
     display: 'flex',
-    flexShrink: 1.6
+    flexShrink: 1.6,
+    paddingInlineStart: '0.5rem'
   },
   toolbar: {
     flex: '1 1.6 100%',

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -1,4 +1,4 @@
-import { debounce, deprecationNotice, Device, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
+import { debounce, Device, useSyncRef } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
 import React, {
   Children,
@@ -12,14 +12,11 @@ import React, {
   useState
 } from 'react';
 import { createUseStyles } from 'react-jss';
-import { FlexBoxAlignItems } from '../../enums/FlexBoxAlignItems';
-import { FlexBoxJustifyContent } from '../../enums/FlexBoxJustifyContent';
-import { ToolbarDesign } from '../../enums/ToolbarDesign';
-import { ToolbarStyle } from '../../enums/ToolbarStyle';
-import { CommonProps } from '../../interfaces/CommonProps';
+import { FlexBoxAlignItems, FlexBoxJustifyContent, ToolbarDesign, ToolbarStyle } from '../../enums';
+import { CommonProps } from '../../interfaces';
 import { stopPropagation } from '../../internal/stopPropagation';
 import { flattenFragments } from '../../internal/utils';
-import { ButtonPropTypes, PopoverDomRef, ToggleButtonPropTypes } from '../../webComponents';
+import { PopoverDomRef } from '../../webComponents';
 import { FlexBox } from '../FlexBox';
 import { Toolbar, ToolbarPropTypes } from '../Toolbar';
 import { ToolbarSeparator } from '../ToolbarSeparator';
@@ -70,47 +67,6 @@ export interface DynamicPageTitlePropTypes extends CommonProps {
    * Display the `subHeader` on the right instead of below the `header`.
    */
   showSubHeaderRight?: boolean;
-  /**
-   * __deprecated__ - Please use `overflowButton` of the `actionsToolbarProps` instead.
-   *
-   * Defines the button shown when the content of the `actions` goes into overflow.
-   *
-   * __Note:__ If the width of the `DynamicPageTitle` is less than 1280px the `navigationActions` are displayed inside the `actions` toolbar, so only this overflow button is rendered.
-   *
-   * __Note:__ It is strongly recommended that you only use `ToggleButton` in icon only mode in order to preserve the intended design.
-   *
-   * __Note:__ Per default a `ToggleButton` with the `"overflow"` icon and all necessary a11y attributes will be rendered.
-   *
-   * @deprecated Please use `overflowButton` of the `actionsToolbarProps` instead.
-   */
-  actionsOverflowButton?: ReactElement<ToggleButtonPropTypes> | ReactElement<ButtonPropTypes>;
-  /**
-   * __deprecated__ - Please use `overflowButton` of the `navigationActionsToolbarProps` instead.
-   *
-   * Defines the button shown when the content of the `navigationActions` goes into overflow.
-   *
-   * __Note:__ If the width of the `DynamicPageTitle` is less than 1280px the `navigationActions` are displayed inside the `actions` toolbar, so in this case this prop has no effect.
-   *
-   * __Note:__ It is strongly recommended that you only use `ToggleButton` in icon only mode in order to preserve the intended design.
-   *
-   * __Note:__ Per default a `ToggleButton` with the `"overflow"` icon and all necessary a11y attributes will be rendered.
-   *
-   * @deprecated Please use `overflowButton` of the `navigationActionsToolbarProps` instead.
-   */
-  navigationActionsOverflowButton?: ReactElement<ToggleButtonPropTypes> | ReactElement<ButtonPropTypes>;
-  /**
-   * __deprecated__ - Please use `onOverflowChange` of the respective toolbar props object instead (`actionsToolbarProps` or `navigationActionsToolbarProps`)
-   *
-   * Fired when the content of the `actions` or `navigationActions` toolbar overflow popover has been changed.
-   *
-   * @deprecated Please use `onOverflowChange` of the respective toolbar props object instead (`actionsToolbarProps` or `navigationActionsToolbarProps`)
-   */
-  onToolbarOverflowChange?: (event: {
-    toolbarElements: HTMLElement[];
-    overflowElements: HTMLCollection;
-    target: HTMLElement;
-    origin: 'actions' | 'navigationActions';
-  }) => void;
   /**
    * Use this prop to customize the "actions" `Toolbar`.
    *
@@ -164,9 +120,6 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     className,
     style,
     onToggleHeaderContentVisibility,
-    onToolbarOverflowChange,
-    actionsOverflowButton,
-    navigationActionsOverflowButton,
     actionsToolbarProps,
     navigationActionsToolbarProps,
     ...rest
@@ -175,7 +128,6 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
   const classes = useStyles();
   const [componentRef, dynamicPageTitleRef] = useSyncRef<HTMLDivElement>(ref);
   const [showNavigationInTopArea, setShowNavigationInTopArea] = useState(undefined);
-  const isRtl = useIsRTL(dynamicPageTitleRef);
   const isMounted = useRef(false);
   const [isPhone, setIsPhone] = useState(
     Device.getCurrentRange(dynamicPageTitleRef.current?.getBoundingClientRect().width)?.name === 'Phone'
@@ -193,25 +145,6 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
   }, [isMounted]);
 
   const { onClick: _0, ...propsWithoutOmitted } = rest;
-
-  // todo: remove deprecation notice & deprecated props implementation
-  useEffect(() => {
-    if (onToolbarOverflowChange) {
-      deprecationNotice(
-        'onToolbarOverflowChange',
-        '`onToolbarOverflowChange` is deprecated. Please use the respective toolbar props object instead (`actionsToolbarProps` or `navigationActionsToolbarProps`)'
-      );
-    }
-    if (actionsOverflowButton) {
-      deprecationNotice('actionsOverflowButton', 'Please use `overflowButton` of the `actionsToolbarProps` instead.');
-    }
-    if (navigationActionsOverflowButton) {
-      deprecationNotice(
-        'navigationActionsOverflowButton',
-        'Please use `overflowButton` of the `navigationActionsToolbarProps` instead.'
-      );
-    }
-  }, []);
 
   const onHeaderClick = useCallback(
     (e) => {
@@ -250,18 +183,6 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
     };
   }, [dynamicPageTitleRef.current, showNavigationInTopArea, isMounted]);
 
-  const paddingLeftRtl = isRtl ? 'paddingRight' : 'paddingLeft';
-
-  const handleToolbarsOverflowChange = (e) => {
-    if (typeof onToolbarOverflowChange === 'function') {
-      let origin = 'actions';
-      if (e.target.dataset.componentName === 'DynamicPageTitleNavActions') {
-        origin = 'navigationActions';
-      }
-      onToolbarOverflowChange({ ...e, origin });
-    }
-  };
-
   const handleActionsToolbarClick = (e) => {
     stopPropagation(e);
     if (typeof actionsToolbarProps?.onClick === 'function') {
@@ -295,11 +216,11 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
           {showNavigationInTopArea && (
             <Toolbar
               {...navigationActionsToolbarProps}
-              overflowButton={navigationActionsToolbarProps?.overflowButton ?? navigationActionsOverflowButton}
+              overflowButton={navigationActionsToolbarProps?.overflowButton}
               className={clsx(classes.toolbar, navigationActionsToolbarProps?.className)}
               onClick={handleNavigationActionsToolbarClick}
               data-component-name="DynamicPageTitleNavActions"
-              onOverflowChange={navigationActionsToolbarProps?.onOverflowChange ?? handleToolbarsOverflowChange}
+              onOverflowChange={navigationActionsToolbarProps?.onOverflowChange}
               overflowPopoverRef={navActionsOverflowPopoverRef}
               design={ToolbarDesign.Auto}
               toolbarStyle={ToolbarStyle.Clear}
@@ -319,20 +240,12 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
             </div>
           )}
           {subHeader && showSubHeaderRight && (
-            <div
-              className={classes.subTitle}
-              style={{ [paddingLeftRtl]: '0.5rem' }}
-              data-component-name="DynamicPageTitleSubHeader"
-            >
+            <div className={classes.subTitle} data-component-name="DynamicPageTitleSubHeader">
               {subHeader}
             </div>
           )}
           {children && (
-            <div
-              className={classes.content}
-              style={{ [paddingLeftRtl]: '0.5rem' }}
-              data-component-name="DynamicPageTitleContent"
-            >
+            <div className={classes.content} data-component-name="DynamicPageTitleContent">
               {children}
             </div>
           )}
@@ -340,14 +253,14 @@ const DynamicPageTitle = forwardRef((props: DynamicPageTitlePropTypes, ref: Ref<
         {(actions || (!showNavigationInTopArea && navigationActions)) && (
           <Toolbar
             {...actionsToolbarProps}
-            overflowButton={actionsToolbarProps?.overflowButton ?? actionsOverflowButton}
+            overflowButton={actionsToolbarProps?.overflowButton}
             design={ToolbarDesign.Auto}
             toolbarStyle={ToolbarStyle.Clear}
             active
             className={clsx(classes.toolbar, actionsToolbarProps?.className)}
             onClick={handleActionsToolbarClick}
             data-component-name="DynamicPageTitleActions"
-            onOverflowChange={actionsToolbarProps?.onOverflowChange ?? handleToolbarsOverflowChange}
+            onOverflowChange={actionsToolbarProps?.onOverflowChange}
             overflowPopoverRef={actionsOverflowPopoverRef}
           >
             <ActionsSpacer onClick={onHeaderClick} noHover={props?.['data-not-clickable']} />

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -1048,7 +1048,6 @@ exports[`ObjectPage with IllustratedMessage 1`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>
@@ -1126,7 +1125,6 @@ exports[`ObjectPage with anchor-bar 1`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>
@@ -2473,7 +2471,6 @@ exports[`ObjectPage with img 1`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>
@@ -2968,7 +2965,6 @@ exports[`ObjectPage with img 2`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>
@@ -3446,7 +3442,6 @@ exports[`ObjectPage with title 1`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>
@@ -3875,7 +3870,6 @@ exports[`ObjectPage with title, header & footer 1`] = `
             <div
               class="DynamicPageTitle-content"
               data-component-name="DynamicPageTitleContent"
-              style="padding-left: 0.5rem;"
             >
               HeaderTitle
             </div>


### PR DESCRIPTION
BREAKING CHANGE: **ActionSheet**: The prop `alwaysShowHeader` has been removed.
BREAKING CHANGE: **ActionSheet**: The prop `a11yConfig.actionSheetMobileContent.ariaLabel` has been removed. Please use `accessibleName` instead.
BREAKING CHANGE: **AnalyticalTable**: The props `onRowSelected` and `onColumnsReordered` have been removed. Please use `onRowSelect` and `onColumnsReorder` instead.
BREAKING CHANGE: **DynamicPageTitle**: The props `actionsOverflowButton`, `navigationActionsOverflowButton` and `onToolbarOverflowChange` have been removed. Please use the `overflowButton` and `onOverflowChange` properties of the `actionsToolbarProps` and `navigationActionsToolbarProps` props instead. More details can be found in our [Migration Guide](https://sap.github.io/ui5-webcomponents-react/?path=/docs/migration-guide--page).
