### PR TITLE
docs(AnalyticalTable): Remove typo, add info about `autoResetResize`

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.mdx
@@ -763,7 +763,8 @@ React.useEffect(() => {
     autoResetSelectedRows: !skipPageResetRef.current,
     autoResetSortBy: !skipPageResetRef.current,
     autoResetFilters: !skipPageResetRef.current,
-    autoResetRowState: !skipPageResetRef.current
+    autoResetRowState: !skipPageResetRef.current,
+    autoResetResize: !skipPageResetRef.current
   }}
 />
 ```

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -510,7 +510,7 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    */
   NoDataComponent?: ComponentType<any>;
   /**
-   * Component that will be rendered when the table is loading and has no data.
+   * Component that will be rendered when the table is loading and has data.
    */
   LoadingComponent?: ComponentType<any>;
 


### PR DESCRIPTION
`autoResetResize` is available even though it's not mentioned in the react-table docs.