### PR TITLE
fix(typescript): don't include `ref` in all component props

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback } from 'react';
+import React, { CSSProperties, forwardRef, Ref, useCallback } from 'react';
 import {
   Bar,
   BarChart as BarChartLib,
@@ -124,7 +124,7 @@ export interface BarChartProps extends IChartBaseProps {
 /**
  * A `BarChart` is a data visualization where each category is represented by a rectangle, with the width of the rectangle being proportional to the values being plotted.
  */
-const BarChart: FC<BarChartProps> = forwardRef((props: BarChartProps, ref: Ref<HTMLDivElement>) => {
+const BarChart = forwardRef((props: BarChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/BulletChart/BulletChart.tsx
+++ b/packages/charts/src/components/BulletChart/BulletChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
+import React, { CSSProperties, forwardRef, Ref, useCallback, useMemo } from 'react';
 import {
   Bar,
   Brush,
@@ -118,7 +118,7 @@ type AvailableChartTypes = 'primary' | 'comparison' | 'additional' | string;
  * The `BulletChart` is used to compare primary and secondary (comparison) values. The primary and additional values
  * are rendered as a stacked Bar Chart while the comparison value is displayed as a line above.
  */
-const BulletChart: FC<BulletChartProps> = forwardRef((props: BulletChartProps, ref: Ref<HTMLDivElement>) => {
+const BulletChart = forwardRef((props: BulletChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/ColumnChart/ColumnChart.tsx
+++ b/packages/charts/src/components/ColumnChart/ColumnChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback } from 'react';
+import React, { CSSProperties, forwardRef, Ref, useCallback } from 'react';
 import {
   Bar as Column,
   BarChart as ColumnChartLib,
@@ -122,7 +122,7 @@ const valueAccessor =
 /**
  * A `ColumnChart` is a data visualization where each category is represented by a rectangle, with the height of the rectangle being proportional to the values being plotted.
  */
-const ColumnChart: FC<ColumnChartProps> = forwardRef((props: ColumnChartProps, ref: Ref<HTMLDivElement>) => {
+const ColumnChart = forwardRef((props: ColumnChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
+++ b/packages/charts/src/components/ColumnChartWithTrend/ColumnChartWithTrend.tsx
@@ -1,5 +1,5 @@
 import { ThemingParameters, useIsomorphicId } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref } from 'react';
+import React, { CSSProperties, forwardRef, Ref } from 'react';
 import { TooltipProps } from 'recharts';
 import { useLongestYAxisLabel } from '../../hooks/useLongestYAxisLabel';
 import { usePrepareDimensionsAndMeasures } from '../../hooks/usePrepareDimensionsAndMeasures';
@@ -100,122 +100,120 @@ type AvailableChartTypes = 'line' | 'bar' | string;
 /**
  * A `ColumnChartWithTrend` is a data visualization where each category is represented by a rectangle, with the height of the rectangle being proportional to the values being plotted amd a trend line which is displayed above the column chart.
  */
-const ColumnChartWithTrend: FC<ColumnChartWithTrendProps> = forwardRef(
-  (props: ColumnChartWithTrendProps, ref: Ref<HTMLDivElement>) => {
-    const {
-      loading,
-      dataset,
-      style,
-      className,
-      slot,
-      onClick,
-      noLegend,
-      noAnimation,
-      onDataPointClick,
-      onLegendClick,
-      ChartPlaceholder,
-      ...rest
-    } = props;
+const ColumnChartWithTrend = forwardRef((props: ColumnChartWithTrendProps, ref: Ref<HTMLDivElement>) => {
+  const {
+    loading,
+    dataset,
+    style,
+    className,
+    slot,
+    onClick,
+    noLegend,
+    noAnimation,
+    onDataPointClick,
+    onLegendClick,
+    ChartPlaceholder,
+    ...rest
+  } = props;
 
-    const syncId = useIsomorphicId();
+  const syncId = useIsomorphicId();
 
-    const chartConfig = {
-      yAxisVisible: false,
-      xAxisVisible: true,
-      gridStroke: ThemingParameters.sapList_BorderColor,
-      gridHorizontal: true,
-      gridVertical: false,
-      legendPosition: 'bottom',
-      legendHorizontalAlign: 'left',
-      barGap: 3,
-      zoomingTool: false,
-      resizeDebounce: 250,
-      ...props.chartConfig
-    };
+  const chartConfig = {
+    yAxisVisible: false,
+    xAxisVisible: true,
+    gridStroke: ThemingParameters.sapList_BorderColor,
+    gridHorizontal: true,
+    gridVertical: false,
+    legendPosition: 'bottom',
+    legendHorizontalAlign: 'left',
+    barGap: 3,
+    zoomingTool: false,
+    resizeDebounce: 250,
+    ...props.chartConfig
+  };
 
-    const { dimensions, measures } = usePrepareDimensionsAndMeasures(
-      props.dimensions,
-      props.measures,
-      dimensionDefaults,
-      measureDefaults
-    );
+  const { dimensions, measures } = usePrepareDimensionsAndMeasures(
+    props.dimensions,
+    props.measures,
+    dimensionDefaults,
+    measureDefaults
+  );
 
-    const { lineMeasures, columnMeasures, columnDataset } = usePrepareTrendMeasures(measures, dataset);
-    const [yAxisWidth] = useLongestYAxisLabel(columnDataset, columnMeasures);
+  const { lineMeasures, columnMeasures, columnDataset } = usePrepareTrendMeasures(measures, dataset);
+  const [yAxisWidth] = useLongestYAxisLabel(columnDataset, columnMeasures);
 
-    const columnTooltipConfig = {
-      formatter: (value, name, tooltipProps) => {
-        const line = lineMeasures.find(
-          (currLine) => currLine.type === 'line' && currLine.accessor === tooltipProps.dataKey
-        );
-        if (line) {
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          return line.formatter(tooltipProps.payload[`__${line.accessor}`]);
-        }
-        const column = columnMeasures.find((currLine) => currLine.accessor === tooltipProps.dataKey);
-        return column.formatter(value, name, tooltipProps);
+  const columnTooltipConfig = {
+    formatter: (value, name, tooltipProps) => {
+      const line = lineMeasures.find(
+        (currLine) => currLine.type === 'line' && currLine.accessor === tooltipProps.dataKey
+      );
+      if (line) {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        return line.formatter(tooltipProps.payload[`__${line.accessor}`]);
       }
-    } as TooltipProps<any, any>;
+      const column = columnMeasures.find((currLine) => currLine.accessor === tooltipProps.dataKey);
+      return column.formatter(value, name, tooltipProps);
+    }
+  } as TooltipProps<any, any>;
 
-    const { chartConfig: _0, dimensions: _1, measures: _2, tooltipConfig: _3, ...propsWithoutOmitted } = rest;
+  const { chartConfig: _0, dimensions: _1, measures: _2, tooltipConfig: _3, ...propsWithoutOmitted } = rest;
 
-    return (
-      <div
-        ref={ref}
-        style={{ display: 'flex', flexDirection: 'column', height: style?.height, width: style?.width, ...style }}
-        className={className}
-        slot={slot}
-        {...propsWithoutOmitted}
-      >
-        {dataset?.length !== 0 && (
-          <ComposedChart
-            className={
-              typeof onDataPointClick === 'function' || typeof onClick === 'function' ? 'has-click-handler' : undefined
-            }
-            tooltipConfig={lineTooltipConfig}
-            noAnimation={noAnimation}
-            loading={loading}
-            onClick={onClick}
-            syncId={syncId}
-            style={{ ...style, height: `calc(${style?.height} * 0.2)` }}
-            dataset={dataset}
-            measures={lineMeasures}
-            dimensions={dimensions}
-            noLegend
-            onDataPointClick={onDataPointClick}
-            chartConfig={{
-              xAxisVisible: false,
-              yAxisVisible: false,
-              yAxisTicksVisible: false,
-              gridHorizontal: false,
-              yAxisLabelsVisible: false,
-              yAxisWidth
-            }}
-          />
-        )}
+  return (
+    <div
+      ref={ref}
+      style={{ display: 'flex', flexDirection: 'column', height: style?.height, width: style?.width, ...style }}
+      className={className}
+      slot={slot}
+      {...propsWithoutOmitted}
+    >
+      {dataset?.length !== 0 && (
         <ComposedChart
-          onLegendClick={onLegendClick}
-          tooltipConfig={columnTooltipConfig}
-          noAnimation={noAnimation}
-          noLegend={noLegend}
-          loading={loading}
-          onClick={onClick}
-          onDataPointClick={onDataPointClick}
-          syncId={syncId}
-          ChartPlaceholder={ChartPlaceholder ?? ColumnChartWithTrendPlaceholder}
-          dataset={columnDataset}
-          measures={columnMeasures}
-          dimensions={dimensions}
-          chartConfig={chartConfig}
-          style={{ ...style, height: `calc(${style?.height} * ${dataset?.length !== 0 ? 0.8 : 1})` }}
           className={
             typeof onDataPointClick === 'function' || typeof onClick === 'function' ? 'has-click-handler' : undefined
           }
+          tooltipConfig={lineTooltipConfig}
+          noAnimation={noAnimation}
+          loading={loading}
+          onClick={onClick}
+          syncId={syncId}
+          style={{ ...style, height: `calc(${style?.height} * 0.2)` }}
+          dataset={dataset}
+          measures={lineMeasures}
+          dimensions={dimensions}
+          noLegend
+          onDataPointClick={onDataPointClick}
+          chartConfig={{
+            xAxisVisible: false,
+            yAxisVisible: false,
+            yAxisTicksVisible: false,
+            gridHorizontal: false,
+            yAxisLabelsVisible: false,
+            yAxisWidth
+          }}
         />
-      </div>
-    );
-  }
-);
+      )}
+      <ComposedChart
+        onLegendClick={onLegendClick}
+        tooltipConfig={columnTooltipConfig}
+        noAnimation={noAnimation}
+        noLegend={noLegend}
+        loading={loading}
+        onClick={onClick}
+        onDataPointClick={onDataPointClick}
+        syncId={syncId}
+        ChartPlaceholder={ChartPlaceholder ?? ColumnChartWithTrendPlaceholder}
+        dataset={columnDataset}
+        measures={columnMeasures}
+        dimensions={dimensions}
+        chartConfig={chartConfig}
+        style={{ ...style, height: `calc(${style?.height} * ${dataset?.length !== 0 ? 0.8 : 1})` }}
+        className={
+          typeof onDataPointClick === 'function' || typeof onClick === 'function' ? 'has-click-handler' : undefined
+        }
+      />
+    </div>
+  );
+});
 
 ColumnChartWithTrend.defaultProps = {
   noLegend: false,

--- a/packages/charts/src/components/ComposedChart/index.tsx
+++ b/packages/charts/src/components/ComposedChart/index.tsx
@@ -132,7 +132,7 @@ type AvailableChartTypes = 'line' | 'bar' | 'area' | string;
 /**
  * The `ComposedChart` enables you to combine different chart types in one chart, e.g. showing bars together with lines.
  */
-const ComposedChart: FC<ComposedChartProps> = forwardRef((props: ComposedChartProps, ref: Ref<HTMLDivElement>) => {
+const ComposedChart = forwardRef((props: ComposedChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/DonutChart/DonutChart.tsx
+++ b/packages/charts/src/components/DonutChart/DonutChart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, forwardRef } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { PieChart, PieChartProps } from '../PieChart/PieChart';
 
 /**
@@ -6,7 +6,7 @@ import { PieChart, PieChartProps } from '../PieChart/PieChart';
  * The pieces of the graph are proportional to the fraction of the whole in each category.
  * A `DonutChart` is basically a `PieChart` with a hole.
  */
-const DonutChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref) => {
+const DonutChart = forwardRef((props: PieChartProps, ref: Ref<HTMLDivElement>) => {
   const chartConfig = {
     legendPosition: 'bottom',
     paddingAngle: 0,

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
-import React, { FC, forwardRef, Ref, useCallback, useRef } from 'react';
+import React, { forwardRef, Ref, useCallback, useRef } from 'react';
 import {
   Brush,
   CartesianGrid,
@@ -101,7 +101,7 @@ const measureDefaults = {
 /**
  * A `LineChart` is a type of chart used to show information that changes over time - it connects multiple dots.
  */
-const LineChart: FC<LineChartProps> = forwardRef((props: LineChartProps, ref: Ref<HTMLDivElement>) => {
+const LineChart = forwardRef((props: LineChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     dataset,
     loading,

--- a/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
+++ b/packages/charts/src/components/MicroBarChart/MicroBarChart.tsx
@@ -1,6 +1,6 @@
 import { enrichEventWithDetails, ThemingParameters } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useMemo } from 'react';
+import React, { CSSProperties, forwardRef, Ref, useCallback, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { IChartBaseProps } from '../../interfaces/IChartBaseProps';
@@ -138,7 +138,7 @@ const useStyles = createUseStyles(MicroBarChartStyles, { name: 'MicroBarChart' }
 /**
  * The `MicroBarChart` compares different values of the same category to each other by displaying them in a compact way.
  */
-const MicroBarChart: FC<MicroBarChartProps> = forwardRef((props: MicroBarChartProps, ref: Ref<HTMLDivElement>) => {
+const MicroBarChart = forwardRef((props: MicroBarChartProps, ref: Ref<HTMLDivElement>) => {
   const { loading, dataset, onDataPointClick, style, className, slot, ChartPlaceholder, ...rest } = props;
 
   const classes = useStyles();

--- a/packages/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/charts/src/components/PieChart/PieChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails } from '@ui5/webcomponents-react-base';
-import React, { cloneElement, CSSProperties, FC, forwardRef, isValidElement, Ref, useCallback, useMemo } from 'react';
+import React, { cloneElement, CSSProperties, forwardRef, isValidElement, Ref, useCallback, useMemo } from 'react';
 import { Cell, Label, Legend, Pie, PieChart as PieChartLib, Sector, Text, Tooltip } from 'recharts';
 import { getValueByDataKey } from 'recharts/lib/util/ChartUtils';
 import { useLegendItemClick } from '../../hooks/useLegendItemClick';
@@ -74,7 +74,7 @@ const tooltipItemDefaultStyle = { color: 'var (--sapTextColor)' };
  * In other words, each slice of the pie is relative to the size of that category in the group as a whole.
  * The entire “pie” represents 100 percent of a whole, while the pie “slices” represent portions of the whole.
  */
-const PieChart: FC<PieChartProps> = forwardRef((props: PieChartProps, ref: Ref<HTMLDivElement>) => {
+const PieChart = forwardRef((props: PieChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters } from '@ui5/webcomponents-react-base';
-import React, { FC, forwardRef, Ref, useCallback, useRef } from 'react';
+import React, { forwardRef, Ref, useCallback, useRef } from 'react';
 import {
   Legend,
   PolarAngleAxis,
@@ -74,7 +74,7 @@ const measureDefaults = {
 /**
  * A radar or spider or web chart is a two-dimensional chart type designed to plot one or more series of values over multiple quantitative variables.
  */
-const RadarChart: FC<RadarChartProps> = forwardRef((props: RadarChartProps, ref: Ref<HTMLDivElement>) => {
+const RadarChart = forwardRef((props: RadarChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     loading,
     dataset,

--- a/packages/charts/src/components/RadialChart/RadialChart.tsx
+++ b/packages/charts/src/components/RadialChart/RadialChart.tsx
@@ -1,6 +1,6 @@
 import { CommonProps } from '@ui5/webcomponents-react';
 import { enrichEventWithDetails, ThemingParameters } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref } from 'react';
+import React, { CSSProperties, forwardRef, Ref } from 'react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import { useOnClickInternal } from '../../hooks/useOnClickInternal';
 import { ChartContainer } from '../../internal/ChartContainer';
@@ -87,7 +87,7 @@ const defaultDisplayValueStyles = {
  * Displays a ring chart highlighting a current status.
  * The status can be emphasized by using the `color` prop.
  */
-const RadialChart: FC<RadialChartProps> = forwardRef((props: RadialChartProps, ref: Ref<HTMLDivElement>) => {
+const RadialChart = forwardRef((props: RadialChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     maxValue,
     value,

--- a/packages/charts/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/src/components/ScatterChart/ScatterChart.tsx
@@ -1,5 +1,5 @@
 import { enrichEventWithDetails, ThemingParameters, useIsRTL, useSyncRef } from '@ui5/webcomponents-react-base';
-import React, { CSSProperties, FC, forwardRef, Ref, useCallback, useRef } from 'react';
+import React, { CSSProperties, forwardRef, Ref, useCallback, useRef } from 'react';
 import {
   CartesianGrid,
   Legend,
@@ -126,7 +126,7 @@ const measureDefaults = {
  * Most commonly, a scatter chart displays the values of three numeric variables,where each observation's data is
  * shown by a circle, while the horizontal and vertical positions of the bubble show the values of two other variables.
  */
-const ScatterChart: FC<ScatterChartProps> = forwardRef((props: ScatterChartProps, ref: Ref<HTMLDivElement>) => {
+const ScatterChart = forwardRef((props: ScatterChartProps, ref: Ref<HTMLDivElement>) => {
   const {
     dataset,
     loading,

--- a/packages/charts/src/internal/ChartContainer.tsx
+++ b/packages/charts/src/internal/ChartContainer.tsx
@@ -1,7 +1,7 @@
 import { type CommonProps, Label, Loader } from '@ui5/webcomponents-react';
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { ComponentType, CSSProperties, FC, forwardRef, ReactElement, ReactNode, Ref } from 'react';
+import React, { ComponentType, CSSProperties, forwardRef, ReactElement, ReactNode, Ref } from 'react';
 import { createUseStyles } from 'react-jss';
 import { ResponsiveContainer } from 'recharts';
 
@@ -67,7 +67,7 @@ class ErrorBoundary extends React.Component<{ children: ReactNode }, { errorCoun
   }
 }
 
-const ChartContainer: FC<ContainerProps> = forwardRef((props: ContainerProps, ref: Ref<any>) => {
+const ChartContainer = forwardRef((props: ContainerProps, ref: Ref<any>) => {
   const { Placeholder, loading = false, dataset, className, slot, children, resizeDebounce, ...rest } = props;
   const classes = useStyles();
 

--- a/packages/charts/src/internal/ChartDataLabel.tsx
+++ b/packages/charts/src/internal/ChartDataLabel.tsx
@@ -1,5 +1,5 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
-import React, { createElement, FC } from 'react';
+import React, { createElement } from 'react';
 import { Label } from 'recharts';
 import { IChartMeasure } from '../interfaces/IChartMeasure';
 import { getTextWidth } from '../internal/Utils';
@@ -13,7 +13,7 @@ interface CustomDataLabelProps {
   children?: any;
 }
 
-export const ChartDataLabel: FC<CustomDataLabelProps> = (props: CustomDataLabelProps) => {
+export const ChartDataLabel = (props: CustomDataLabelProps) => {
   const { config, chartType, viewBox } = props;
   if (config.hideDataLabel) {
     return null;

--- a/packages/charts/src/internal/XAxisTicks.tsx
+++ b/packages/charts/src/internal/XAxisTicks.tsx
@@ -1,5 +1,5 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
-import React, { FC } from 'react';
+import React from 'react';
 import { IChartMeasure } from '../interfaces/IChartMeasure';
 import { getTextWidth, truncateLongLabel } from './Utils';
 
@@ -15,7 +15,7 @@ interface XAxisTicksProps {
   };
 }
 
-export const XAxisTicks: FC<XAxisTicksProps> = (props: XAxisTicksProps) => {
+export const XAxisTicks = (props: XAxisTicksProps) => {
   const { x, y, payload, config, visibleTicksCount, width, secondYAxisConfig } = props;
 
   const bandWidth = width / visibleTicksCount;

--- a/packages/charts/src/internal/YAxisTicks.tsx
+++ b/packages/charts/src/internal/YAxisTicks.tsx
@@ -1,5 +1,5 @@
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
-import React, { FC } from 'react';
+import React from 'react';
 import { IChartMeasure } from '../interfaces/IChartMeasure';
 import { defaultMaxYAxisWidth } from './defaults';
 import { getTextWidth, truncateLongLabel } from './Utils';
@@ -14,7 +14,7 @@ interface YAxisTicksProps {
   };
 }
 
-export const YAxisTicks: FC<YAxisTicksProps> = (props: YAxisTicksProps) => {
+export const YAxisTicks = (props: YAxisTicksProps) => {
   const { x, y, payload, config, secondYAxisConfig } = props;
 
   const formattedValue = config.formatter(payload.value);

--- a/packages/main/src/components/SelectDialog/index.tsx
+++ b/packages/main/src/components/SelectDialog/index.tsx
@@ -220,7 +220,7 @@ const SelectDialog = forwardRef((props: SelectDialogPropTypes, ref: Ref<DialogDo
   const [searchValue, setSearchValue] = useState('');
   const [selectedItems, setSelectedItems] = useState([]);
   const [componentRef, selectDialogRef] = useSyncRef(ref);
-  const [listComponentRef, listRef] = useSyncRef<ListDomRefWithPrivateAPIs>(listProps.ref);
+  const [listComponentRef, listRef] = useSyncRef<ListDomRefWithPrivateAPIs>((listProps as any).ref);
 
   const handleBeforeOpen = (e) => {
     if (typeof onBeforeOpen === 'function') {

--- a/packages/main/src/interfaces/CommonProps.ts
+++ b/packages/main/src/interfaces/CommonProps.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, Ref, HTMLAttributes } from 'react';
+import { CSSProperties, HTMLAttributes } from 'react';
 
 export interface CommonProps extends HTMLAttributes<HTMLElement> {
   /**
@@ -11,5 +11,4 @@ export interface CommonProps extends HTMLAttributes<HTMLElement> {
    * Use this prop carefully, overwriting CSS rules might break the component.
    */
   className?: string;
-  ref?: Ref<any>;
 }

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -51,7 +51,7 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
     const eventRegistry = useRef<Record<string, EventHandler>>({});
     const tagNameSuffix: string = getEffectiveScopingSuffixForTag(tagName);
     const Component = (tagNameSuffix ? `${tagName}-${tagNameSuffix}` : tagName) as unknown as ComponentType<
-      CommonProps & { class: string }
+      CommonProps & { class?: string; ref?: Ref<any> }
     >;
 
     const [isDefined, setIsDefined] = useState(definedWebComponents.has(Component));


### PR DESCRIPTION
The `ref` prop will automatically be added by the `forwardRef` function, there is no need to specify this manually. This also leads to way simpler types and looses the coupling to specific `@types/react` versions.
