### PR TITLE
fix(ObjectPage): adjust responsive padding of tab-bar to header padding

### DIFF
--- a/packages/base/src/hooks/useResponsiveContentPadding.ts
+++ b/packages/base/src/hooks/useResponsiveContentPadding.ts
@@ -12,17 +12,17 @@ const useStyles = createUseStyles(
   { name: 'StdExtPadding' }
 );
 
+export function useResponsiveContentPadding(element: HTMLElement, returnRangeString?: boolean): string;
+export function useResponsiveContentPadding(element: HTMLElement, returnRangeString: true): [string, string];
+
 /**
  * Hook for creating a style class, which sets `padding-left` and `padding-right` depending on the width of the element.
  *
  * @param {HTMLElement} element The element the calculation is based on.
- * @param {boolean} [returnRangeString=false] If set to `true`, returns an array with the class name and range.
- * @returns {(string|Array)} If `returnRangeString` is `true`, the hook returns an array with the class name on first and the range string on second position. Otherwise, only the class name string is returned.
+ * @param {boolean} [returnRangeString=false] If set to `true`, returns a tuple with the class name and range.
+ * @returns {(string|Array)} If `returnRangeString` is `true`, the hook returns a tuple with the class name on first and the range string on second position. Otherwise, only the class name string is returned.
  */
-export const useResponsiveContentPadding = (
-  element: HTMLElement,
-  returnRangeString = false
-): string | [string, string] => {
+export function useResponsiveContentPadding(element: HTMLElement, returnRangeString = false) {
   const [currentRange, setCurrentRange] = useState(() => getCurrentRange()?.name ?? 'Desktop');
   const classes = useStyles();
   const requestAnimationFrameRef = useRef<number | undefined>();
@@ -48,4 +48,4 @@ export const useResponsiveContentPadding = (
   }
 
   return classes[currentRange];
-};
+}

--- a/packages/base/src/hooks/useResponsiveContentPadding.ts
+++ b/packages/base/src/hooks/useResponsiveContentPadding.ts
@@ -15,9 +15,14 @@ const useStyles = createUseStyles(
 /**
  * Hook for creating a style class, which sets `padding-left` and `padding-right` depending on the width of the element.
  *
- * @param {HTMLElement} element
+ * @param {HTMLElement} element The element the calculation is based on.
+ * @param {boolean} [returnRangeString=false] If set to `true`, returns an array with the class name and range.
+ * @returns {(string|Array)} If `returnRangeString` is `true`, the hook returns an array with the class name on first and the range string on second position. Otherwise, only the class name string is returned.
  */
-export const useResponsiveContentPadding = (element: HTMLElement) => {
+export const useResponsiveContentPadding = (
+  element: HTMLElement,
+  returnRangeString = false
+): string | [string, string] => {
   const [currentRange, setCurrentRange] = useState(() => getCurrentRange()?.name ?? 'Desktop');
   const classes = useStyles();
   const requestAnimationFrameRef = useRef<number | undefined>();
@@ -37,6 +42,10 @@ export const useResponsiveContentPadding = (element: HTMLElement) => {
       cancelAnimationFrame(requestAnimationFrameRef.current);
     };
   }, [element]);
+
+  if (returnRangeString) {
+    return [classes[currentRange], currentRange];
+  }
 
   return classes[currentRange];
 };

--- a/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
+++ b/packages/main/src/components/ObjectPage/ObjectPage.jss.ts
@@ -5,12 +5,14 @@ export const ObjectPageCssVariables = {
   anchorFloat: '--_ui5wcr_ObjectPage_actions_float',
   anchorLeft: '--_ui5wcr_ObjectPage_actions_left',
   anchorRight: '--_ui5wcr_ObjectPage_actions_right',
-  lastSectionMargin: '--_ui5wcr_ObjectPage_last_section_margin_bottom'
+  lastSectionMargin: '--_ui5wcr_ObjectPage_last_section_margin_bottom',
+  tabBarPaddingInline: '--_ui5wcr_ObjectPage_tab_bar_inline_padding'
 };
 
 export const styles = {
   objectPage: {
     [DynamicPageCssVariables.headerDisplay]: 'block',
+    [ObjectPageCssVariables.tabBarPaddingInline]: '1rem',
     boxSizing: 'border-box',
     width: '100%',
     height: '100%',
@@ -35,6 +37,11 @@ export const styles = {
       marginBottom: `var(${ObjectPageCssVariables.lastSectionMargin})`
     }
   },
+  // each tab has inline padding of 1rem, so it needs to be subtracted from the default responsive padding
+  Phone: { [ObjectPageCssVariables.tabBarPaddingInline]: 0 },
+  Tablet: { [ObjectPageCssVariables.tabBarPaddingInline]: '1rem' },
+  Desktop: { [ObjectPageCssVariables.tabBarPaddingInline]: '1rem' },
+  LargeDesktop: { [ObjectPageCssVariables.tabBarPaddingInline]: '2rem' },
   '@global html': {
     [ObjectPageCssVariables.anchorFloat]: 'right',
     [ObjectPageCssVariables.anchorRight]: '1.25rem',

--- a/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
+++ b/packages/main/src/components/ObjectPage/__snapshots__/ObjectPage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ObjectPage Default with Sections 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -169,7 +169,7 @@ exports[`ObjectPage Default with Sections 1`] = `
 exports[`ObjectPage Default with SubSections 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -574,7 +574,7 @@ exports[`ObjectPage Default with SubSections 1`] = `
 exports[`ObjectPage IconTabBar Mode 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar ObjectPage-iconTabBarMode"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop ObjectPage-iconTabBarMode"
     data-component-name="ObjectPage"
   >
     <header
@@ -865,7 +865,7 @@ exports[`ObjectPage Not crashing with 0 sections 1`] = `
 exports[`ObjectPage Not crashing with 1 section - Default Mode 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -943,7 +943,7 @@ exports[`ObjectPage Not crashing with 1 section - Default Mode 1`] = `
 exports[`ObjectPage Not crashing with 1 section - IconTabBar Mode 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar ObjectPage-iconTabBarMode"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop ObjectPage-iconTabBarMode"
     data-component-name="ObjectPage"
   >
     <header
@@ -1021,7 +1021,7 @@ exports[`ObjectPage Not crashing with 1 section - IconTabBar Mode 1`] = `
 exports[`ObjectPage with IllustratedMessage 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -1097,7 +1097,7 @@ exports[`ObjectPage with IllustratedMessage 1`] = `
 exports[`ObjectPage with anchor-bar 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -1580,7 +1580,7 @@ exports[`ObjectPage with anchor-bar 1`] = `
 exports[`ObjectPage with footer 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -2005,7 +2005,7 @@ exports[`ObjectPage with footer 1`] = `
 exports[`ObjectPage with header 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -2425,7 +2425,7 @@ exports[`ObjectPage with header 1`] = `
 exports[`ObjectPage with img 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -2907,7 +2907,7 @@ exports[`ObjectPage with img 1`] = `
 exports[`ObjectPage with img 2`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -3384,7 +3384,7 @@ exports[`ObjectPage with img 2`] = `
 exports[`ObjectPage with title 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header
@@ -3811,7 +3811,7 @@ exports[`ObjectPage with title 1`] = `
 exports[`ObjectPage with title, header & footer 1`] = `
 <DocumentFragment>
   <div
-    class="ObjectPage-objectPage sapScrollBar"
+    class="ObjectPage-objectPage sapScrollBar ObjectPage-Desktop"
     data-component-name="ObjectPage"
   >
     <header

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -25,8 +25,11 @@ import { extractSectionIdFromHtmlId, getLastObjectPageSection, getSectionById } 
 
 addCustomCSSWithScoping(
   'ui5-tabcontainer',
+  // padding-inline is used here to ensure the same responsive padding behavior as for the rest of the component
   `
   :host([data-component-name="ObjectPageTabContainer"]) .ui5-tc__header {
+    padding: 0;
+    padding-inline: var(--_ui5wcr_ObjectPage_tab_bar_inline_padding);
     box-shadow: inset 0 -0.0625rem ${ThemingParameters.sapPageHeader_BorderColor}, 0 0.125rem 0.25rem 0 rgb(0 0 0 / 8%);
   }
   `
@@ -204,7 +207,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
   }, []);
 
   const isRTL = useIsRTL(objectPageRef);
-  const responsivePaddingClass = useResponsiveContentPadding(objectPageRef.current);
+  const [responsivePaddingClass, responsiveRange] = useResponsiveContentPadding(objectPageRef.current, true);
 
   const [headerCollapsedInternal, setHeaderCollapsedInternal] = useState<undefined | boolean>(undefined);
   // observe heights of header parts
@@ -486,6 +489,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
   const objectPageClasses = clsx(
     classes.objectPage,
     GlobalStyleClasses.sapScrollBar,
+    classes[responsiveRange],
     className,
     mode === ObjectPageMode.IconTabBar && classes.iconTabBarMode
   );


### PR DESCRIPTION
The responsive padding of the `TabContainer` does not include the scrollbar, whereas the header and content section of the ObjectPage do. This resulted in discrepancy of the padding. This PR applies the same padding used for the rest of the ObjectPage to the TabContainer as well.

Fixes #3551