### PR TITLE
refactor(FlexBox): move defaultProps to es6 defaults

### DIFF
--- a/packages/main/src/components/FlexBox/FlexBox.jss.ts
+++ b/packages/main/src/components/FlexBox/FlexBox.jss.ts
@@ -1,26 +1,61 @@
 export const styles = {
   flexBox: {
-    display: 'flex'
+    display: 'flex',
+
+    [`&:where($fitContainer)`]: { width: '100%', height: '100%' },
+
+    // justify
+    [`&:where($justifyContentStart)`]: {
+      justifyContent: 'flex-start'
+    },
+    [`&:where($justifyContentEnd)`]: {
+      justifyContent: 'flex-end'
+    },
+    [`&:where($justifyContentCenter)`]: {
+      justifyContent: 'center'
+    },
+    [`&:where($justifyContentSpaceAround)`]: {
+      justifyContent: 'space-around'
+    },
+    [`&:where($justifyContentSpaceBetween)`]: {
+      justifyContent: 'space-between'
+    },
+
+    // align
+    [`&:where($alignItemsStart)`]: {
+      alignItems: 'flex-start'
+    },
+    [`&:where($alignItemsEnd)`]: {
+      alignItems: 'flex-end'
+    },
+    [`&:where($alignItemsCenter)`]: {
+      alignItems: 'center'
+    },
+    [`&:where($alignItemsStretch)`]: {
+      alignItems: 'stretch'
+    },
+    [`&:where($alignItemsBaseline)`]: {
+      alignItems: 'baseline'
+    }
   },
-  fitContainer: { width: '100%', height: '100%' },
   flexBoxDisplayInline: {
     display: 'inline-flex'
   },
-  justifyContentStart: {
-    justifyContent: 'flex-start'
-  },
-  justifyContentEnd: {
-    justifyContent: 'flex-end'
-  },
-  justifyContentCenter: {
-    justifyContent: 'center'
-  },
-  justifyContentSpaceAround: {
-    justifyContent: 'space-around'
-  },
-  justifyContentSpaceBetween: {
-    justifyContent: 'space-between'
-  },
+
+  fitContainer: {},
+
+  justifyContentStart: {},
+  justifyContentEnd: {},
+  justifyContentCenter: {},
+  justifyContentSpaceAround: {},
+  justifyContentSpaceBetween: {},
+
+  alignItemsStart: {},
+  alignItemsEnd: {},
+  alignItemsCenter: {},
+  alignItemsStretch: {},
+  alignItemsBaseline: {},
+
   flexBoxDirectionColumn: {
     flexDirection: 'column'
   },
@@ -33,21 +68,7 @@ export const styles = {
   flexBoxDirectionRowReverse: {
     flexDirection: 'row-reverse'
   },
-  alignItemsStart: {
-    alignItems: 'flex-start'
-  },
-  alignItemsEnd: {
-    alignItems: 'flex-end'
-  },
-  alignItemsCenter: {
-    alignItems: 'center'
-  },
-  alignItemsStretch: {
-    alignItems: 'stretch'
-  },
-  alignItemsBaseline: {
-    alignItems: 'baseline'
-  },
+
   flexWrapNoWrap: {
     flexWrap: 'nowrap'
   },

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -57,16 +57,14 @@ export interface FlexBoxPropTypes extends CommonProps {
 const FlexBox = forwardRef<HTMLDivElement, FlexBoxPropTypes>((props, ref) => {
   const {
     children,
-    justifyContent,
-    direction,
-    alignItems,
+    justifyContent = FlexBoxJustifyContent.Start,
+    direction = FlexBoxDirection.Row,
+    alignItems = FlexBoxAlignItems.Stretch,
     displayInline,
-    wrap,
-    style,
+    wrap = FlexBoxWrap.NoWrap,
     className,
     fitContainer,
-    slot,
-    as,
+    as = 'div',
     ...rest
   } = props;
 
@@ -84,21 +82,12 @@ const FlexBox = forwardRef<HTMLDivElement, FlexBoxPropTypes>((props, ref) => {
 
   const CustomTag = as as React.ElementType;
   return (
-    <CustomTag ref={ref} className={flexBoxClasses} style={style} slot={slot} {...rest}>
+    <CustomTag ref={ref} className={flexBoxClasses} data-component-name="FlexBox" {...rest}>
       {children}
     </CustomTag>
   );
 });
 
-FlexBox.defaultProps = {
-  as: 'div',
-  alignItems: FlexBoxAlignItems.Stretch,
-  direction: FlexBoxDirection.Row,
-  displayInline: false,
-  fitContainer: false,
-  justifyContent: FlexBoxJustifyContent.Start,
-  wrap: FlexBoxWrap.NoWrap
-};
 FlexBox.displayName = 'FlexBox';
 
 export { FlexBox };

--- a/packages/main/src/components/FlexBox/index.tsx
+++ b/packages/main/src/components/FlexBox/index.tsx
@@ -82,7 +82,7 @@ const FlexBox = forwardRef<HTMLDivElement, FlexBoxPropTypes>((props, ref) => {
 
   const CustomTag = as as React.ElementType;
   return (
-    <CustomTag ref={ref} className={flexBoxClasses} data-component-name="FlexBox" {...rest}>
+    <CustomTag ref={ref} className={flexBoxClasses} {...rest}>
       {children}
     </CustomTag>
   );


### PR DESCRIPTION
and refactor styling to use `:where` selector.
The `:where` selector has 0 specificity which makes it very easy to apply other styles to the component