### PR TITLE
fix(FilterBar): don't fire bubbled up selection-change event of `Table`

### DIFF
--- a/packages/main/src/components/FilterBar/FilterBar.stories.mdx
+++ b/packages/main/src/components/FilterBar/FilterBar.stories.mdx
@@ -127,7 +127,11 @@ import { useState } from 'react';
             </MultiComboBox>
           </FilterGroupItem>
           <FilterGroupItem label="ComboBox w/o initial selected" groupName="Group 2">
-            <ComboBox>
+            <ComboBox
+              onSelectionChange={(e) => {
+                e.stopPropagation();
+              }}
+            >
               <ComboBoxItem text="ComboBoxItem 1" />
               <ComboBoxItem text="ComboBoxItem 2" />
               <ComboBoxItem text="ComboBoxItem 3" />
@@ -550,7 +554,11 @@ the page is then responsible for the different views.
                   </Select>
                 </FilterGroupItem>
                 <FilterGroupItem label="MultBox w/ initial selected" groupName="Group 1" visibleInFilterBar={false}>
-                  <MultiComboBox>
+                  <MultiComboBox
+                    onSelectionChange={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
                     <MultiComboBoxItem text="MultiComboBoxItem 1" />
                     <MultiComboBoxItem selected text="MultiComboBoxItem 2" />
                     <MultiComboBoxItem text="MultiComboBoxItem 3" />
@@ -558,7 +566,11 @@ the page is then responsible for the different views.
                   </MultiComboBox>
                 </FilterGroupItem>
                 <FilterGroupItem label="ComboBox w/o initial selected" groupName="Group 2" visibleInFilterBar={false}>
-                  <ComboBox>
+                  <ComboBox
+                    onSelectionChange={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
                     <ComboBoxItem text="ComboBoxItem 1" />
                     <ComboBoxItem text="ComboBoxItem 2" />
                     <ComboBoxItem text="ComboBoxItem 3" />

--- a/packages/main/src/components/FilterBar/FilterBar.stories.mdx
+++ b/packages/main/src/components/FilterBar/FilterBar.stories.mdx
@@ -115,7 +115,11 @@ import { useState } from 'react';
             </Select>
           </FilterGroupItem>
           <FilterGroupItem label="MultBox w/ initial selected" groupName="Group 1">
-            <MultiComboBox>
+            <MultiComboBox
+              onSelectionChange={(e) => {
+                e.stopPropagation();
+              }}
+            >
               <MultiComboBoxItem text="MultiComboBoxItem 1" />
               <MultiComboBoxItem selected text="MultiComboBoxItem 2" />
               <MultiComboBoxItem text="MultiComboBoxItem 3" />

--- a/packages/main/src/components/FilterBar/FilterBar.stories.mdx
+++ b/packages/main/src/components/FilterBar/FilterBar.stories.mdx
@@ -115,11 +115,7 @@ import { useState } from 'react';
             </Select>
           </FilterGroupItem>
           <FilterGroupItem label="MultBox w/ initial selected" groupName="Group 1">
-            <MultiComboBox
-              onSelectionChange={(e) => {
-                e.stopPropagation();
-              }}
-            >
+            <MultiComboBox>
               <MultiComboBoxItem text="MultiComboBoxItem 1" />
               <MultiComboBoxItem selected text="MultiComboBoxItem 2" />
               <MultiComboBoxItem text="MultiComboBoxItem 3" />
@@ -127,11 +123,7 @@ import { useState } from 'react';
             </MultiComboBox>
           </FilterGroupItem>
           <FilterGroupItem label="ComboBox w/o initial selected" groupName="Group 2">
-            <ComboBox
-              onSelectionChange={(e) => {
-                e.stopPropagation();
-              }}
-            >
+            <ComboBox>
               <ComboBoxItem text="ComboBoxItem 1" />
               <ComboBoxItem text="ComboBoxItem 2" />
               <ComboBoxItem text="ComboBoxItem 3" />
@@ -554,11 +546,7 @@ the page is then responsible for the different views.
                   </Select>
                 </FilterGroupItem>
                 <FilterGroupItem label="MultBox w/ initial selected" groupName="Group 1" visibleInFilterBar={false}>
-                  <MultiComboBox
-                    onSelectionChange={(e) => {
-                      e.stopPropagation();
-                    }}
-                  >
+                  <MultiComboBox>
                     <MultiComboBoxItem text="MultiComboBoxItem 1" />
                     <MultiComboBoxItem selected text="MultiComboBoxItem 2" />
                     <MultiComboBoxItem text="MultiComboBoxItem 3" />
@@ -566,11 +554,7 @@ the page is then responsible for the different views.
                   </MultiComboBox>
                 </FilterGroupItem>
                 <FilterGroupItem label="ComboBox w/o initial selected" groupName="Group 2" visibleInFilterBar={false}>
-                  <ComboBox
-                    onSelectionChange={(e) => {
-                      e.stopPropagation();
-                    }}
-                  >
+                  <ComboBox>
                     <ComboBoxItem text="ComboBoxItem 1" />
                     <ComboBoxItem text="ComboBoxItem 2" />
                     <ComboBoxItem text="ComboBoxItem 3" />

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -70,15 +70,14 @@ addCustomCSSWithScoping(
 }
 /* don't display border of panel table */
 :host([data-component-name="FilterBarDialogPanelTable"]) table {
-  table-layout: fixed;
   border-collapse: unset;
 }
 
-/* don't allow table cells to grow */
-:host([data-component-name="FilterBarDialogPanelTable"]) table,
+/* don't allow table cells to grow
+todo: FilterBarDialogPanelTable
+*/
 :host([data-component-name="FilterBarDialogTable"]) table{
   table-layout: fixed;
-  border-collapse: unset;
 }
 
 :host([data-component-name="FilterBarDialogPanelTable"]) .ui5-table-root {
@@ -286,7 +285,7 @@ export const FilterDialog = (props: FilterDialogPropTypes) => {
   const handleCheckBoxChange = (e) => {
     e.preventDefault();
 
-    // could be unwanted behavior: https://github.com/SAP/ui5-webcomponents-react/issues/3928
+    // todo: could be unwanted behavior: https://github.com/SAP/ui5-webcomponents-react/issues/3928
     if (!e.target.getAttribute('ui5-table')) {
       return;
     }

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -70,6 +70,14 @@ addCustomCSSWithScoping(
 }
 /* don't display border of panel table */
 :host([data-component-name="FilterBarDialogPanelTable"]) table {
+  table-layout: fixed;
+  border-collapse: unset;
+}
+
+/* don't allow table cells to grow */
+:host([data-component-name="FilterBarDialogPanelTable"]) table,
+:host([data-component-name="FilterBarDialogTable"]) table{
+  table-layout: fixed;
   border-collapse: unset;
 }
 
@@ -277,6 +285,11 @@ export const FilterDialog = (props: FilterDialogPropTypes) => {
 
   const handleCheckBoxChange = (e) => {
     e.preventDefault();
+
+    // could be unwanted behavior: https://github.com/SAP/ui5-webcomponents-react/issues/3928
+    if (!e.target.getAttribute('ui5-table')) {
+      return;
+    }
     const prevRowsByKey = e.detail.previouslySelectedRows.reduce(
       (acc, prevSelRow) => ({ ...acc, [prevSelRow.dataset.reactKey]: prevSelRow }),
       {}

--- a/packages/main/src/components/FilterBar/FilterDialog.tsx
+++ b/packages/main/src/components/FilterBar/FilterDialog.tsx
@@ -286,7 +286,7 @@ export const FilterDialog = (props: FilterDialogPropTypes) => {
     e.preventDefault();
 
     // todo: could be unwanted behavior: https://github.com/SAP/ui5-webcomponents-react/issues/3928
-    if (!e.target.getAttribute('ui5-table')) {
+    if (!e.target.hasAttribute('ui5-table')) {
       return;
     }
     const prevRowsByKey = e.detail.previouslySelectedRows.reduce(


### PR DESCRIPTION
The `selection-change` events are bubbling up to the `Table` component, leading to an error. 
This PR fixes this, by checking for the target of the event. If it's not invoked by the table, then it's ignored.