### PR TITLE
refactor(TypeScript): replace all public `ReactElement` types with `ReactNode`

### DIFF
--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -1,7 +1,7 @@
 import { isPhone } from '@ui5/webcomponents-base/dist/Device.js';
 import { useI18nBundle, useSyncRef } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { Children, forwardRef, ReactElement, ReactNode, useReducer, useRef } from 'react';
+import React, { Children, forwardRef, ReactNode, useReducer, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { ButtonDesign } from '../../enums';
@@ -36,7 +36,7 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
    *
    * __Note:__ Although this slot accepts all HTML Elements, it is strongly recommended that you only use `Buttons` in order to preserve the intended design.
    */
-  children?: ReactElement<ButtonPropTypes> | ReactElement<ButtonPropTypes>[];
+  children?: ReactNode | ReactNode[];
   /**
    * Displays a cancel button below the action buttons on mobile devices. No cancel button will be shown on desktop and tablet devices.
    */

--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -6,7 +6,7 @@ import {
   useSyncRef
 } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { cloneElement, forwardRef, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, forwardRef, ReactNode, useEffect, useRef, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { GlobalStyleClasses, PageBackgroundDesign } from '../../enums';
 import { CommonProps } from '../../interfaces';
@@ -37,20 +37,20 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title'> {
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageTitle` in order to preserve the intended design.
    */
-  headerTitle?: ReactElement;
+  headerTitle?: ReactNode;
   /**
    * Defines the dynamic header section of the `DynamicPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageHeader` in order to preserve the intended design.
    */
-  headerContent?: ReactElement;
+  headerContent?: ReactNode;
   /**
    * React element which defines the footer content.
    *
    * __Note:__ To preserve the intended design, please use only non-content based `height` values (`px`, `rem`, `vh`, etc.) as height of the `DynamicPage`.
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `Bar` with `design={BarDesign.FloatingFooter}` in order to preserve the intended design.
    */
-  footer?: ReactElement;
+  footer?: ReactNode;
   /**
    * React element or node array which defines the content.
    */

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -4,7 +4,6 @@ import React, {
   Children,
   forwardRef,
   MutableRefObject,
-  ReactElement,
   ReactNode,
   useCallback,
   useEffect,
@@ -29,7 +28,7 @@ export interface DynamicPageTitlePropTypes extends CommonProps {
    *
    * __Note:__ When clicking on an action in the overflow popover it closes the popover. You can use `event.preventDefault()` to prevent this.
    */
-  actions?: ReactElement | ReactElement[];
+  actions?: ReactNode | ReactNode[];
 
   /**
    * The `breadcrumbs` displayed in the `DynamicPageTitle` top-left area.
@@ -62,7 +61,7 @@ export interface DynamicPageTitlePropTypes extends CommonProps {
    *
    * __Note:__ When clicking on an action in the overflow popover it closes the popover. You can use `event.preventDefault()` to prevent this.
    */
-  navigationActions?: ReactElement | ReactElement[];
+  navigationActions?: ReactNode | ReactNode[];
   /**
    * Display the `subHeader` on the right instead of below the `header`.
    */

--- a/packages/main/src/components/FilterBar/index.tsx
+++ b/packages/main/src/components/FilterBar/index.tsx
@@ -15,7 +15,7 @@ import { createUseStyles } from 'react-jss';
 import { ButtonDesign, ToolbarStyle } from '../../enums';
 import { ADAPT_FILTERS, CLEAR, FILTERS, GO, HIDE_FILTER_BAR, RESTORE, SHOW_FILTER_BAR } from '../../i18n/i18n-defaults';
 import { CommonProps, Ui5CustomEvent } from '../../interfaces';
-import { Button, ButtonDomRef, DialogDomRef, InputPropTypes, TableDomRef, TableRowDomRef } from '../../webComponents';
+import { Button, ButtonDomRef, DialogDomRef, TableDomRef, TableRowDomRef } from '../../webComponents';
 import { FilterGroupItemPropTypes } from '../FilterGroupItem';
 import { Toolbar } from '../Toolbar';
 import { ToolbarSeparator } from '../ToolbarSeparator';
@@ -37,9 +37,10 @@ export interface FilterBarPropTypes extends CommonProps {
   /**
    * Defines the search field next to the header of the `FilterBar`.
    *
+   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use the `Input` component in order to preserve the intended design.
    * __Note:__ If `hideToolbar` is `true` this prop has no effect.
    */
-  search?: ReactElement<InputPropTypes>;
+  search?: ReactNode;
   /**
    * Specifies header text or variant management that is shown in the toolbar on the first position
    *

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -41,29 +41,31 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageTitle` in order to preserve the intended design.
    * __Note:__ If not defined otherwise the prop `showSubHeaderRight` of the `DynamicPageTitle` is set to `true` by default.
    */
-  headerTitle?: ReactElement;
+  headerTitle?: ReactNode;
   /**
    * Defines the dynamic header section of the `ObjectPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageHeader` in order to preserve the intended design.
    */
-  headerContent?: ReactElement;
+  headerContent?: ReactNode;
   /**
    * React element which defines the footer content.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `Bar` with `design={BarDesign.FloatingFooter}` in order to preserve the intended design.
    */
-  footer?: ReactElement;
+  footer?: ReactNode;
   /**
    * Defines the image of the `ObjectPage`. You can pass a path to an image or an `Avatar` component.
+   *
+   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use a path to an image as `string` or the `Avatar` component.
    */
-  image?: string | ReactElement;
+  image?: ReactNode;
   /**
    * Defines the content area of the `ObjectPage`. It consists of sections and subsections.
    *
-   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `ObjectPageSection` and `ObjectPageSubSection` in order to preserve the intended design.
+   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `ObjectPageSection` in order to preserve the intended design.
    */
-  children?: ReactElement<ObjectPageSectionPropTypes> | ReactElement<ObjectPageSectionPropTypes>[];
+  children?: ReactNode | ReactNode[];
   /**
    * Defines the ID of the currently `ObjectPageSection` section.
    */

--- a/packages/main/src/components/SplitterLayout/index.tsx
+++ b/packages/main/src/components/SplitterLayout/index.tsx
@@ -2,11 +2,10 @@ import '@ui5/webcomponents-icons/dist/horizontal-grip.js';
 import '@ui5/webcomponents-icons/dist/vertical-grip.js';
 import { debounce, useSyncRef } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { CSSProperties, DependencyList, forwardRef, ReactElement, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, DependencyList, forwardRef, ReactNode, useEffect, useRef, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { SplitterLayoutContext } from '../../internal/SplitterLayoutContext';
-import { SplitterElementPropTypes } from '../SplitterElement';
 import { styles } from './SplitterLayout.jss';
 import { useConcatSplitterElements } from './useConcatSplitterElements';
 
@@ -36,8 +35,10 @@ export interface SplitterLayoutPropTypes extends CommonProps {
   vertical?: boolean;
   /**
    * The content areas (optional) to be split. The control will show n-1 splitter bars between n controls in this aggregation.
+   *
+   * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `SplitterElement` in order to preserve the intended design.
    */
-  children?: ReactElement<SplitterElementPropTypes> | ReactElement<SplitterElementPropTypes>[];
+  children?: ReactNode | ReactNode[];
   /**
    * Defines options to customize the behavior of the SplitterLayout.
    */

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -24,7 +24,7 @@ import { ToolbarDesign, ToolbarStyle } from '../../enums';
 import { SHOW_MORE } from '../../i18n/i18n-defaults';
 import { CommonProps } from '../../interfaces';
 import { flattenFragments } from '../../internal/utils';
-import { ButtonPropTypes, PopoverDomRef, ToggleButtonPropTypes } from '../../webComponents';
+import { PopoverDomRef } from '../../webComponents';
 import { OverflowPopover } from './OverflowPopover';
 import { styles } from './Toolbar.jss';
 
@@ -44,7 +44,7 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick' | 'childre
    *
    * __Note:__ Per default a `ToggleButton` with the `"overflow"` icon and all necessary a11y attributes will be rendered.
    */
-  overflowButton?: ReactElement<ToggleButtonPropTypes> | ReactElement<ButtonPropTypes>;
+  overflowButton?: ReactNode;
   /**
    * Defines the visual style of the `Toolbar`.
    *


### PR DESCRIPTION
`ReactElement` has no real advantage over `ReactNode` and makes it even harder to type some structures of children.



```tsx
export interface ObjectPageSectionPropTypes {
  id: string;
}

interface ObjectPagePropTypes {
  children?: ReactElement<ObjectPageSectionPropTypes> | ReactElement<ObjectPageSectionPropTypes>[];
}

const TestComp = (props: ObjectPagePropTypes) => {
  return <>{props.children}</>
}

const TestComp2 = (props: ObjectPageSectionPropTypes) => {
  return <></>
}

const TestComp3 = () => {
  return (
    <>
      <TestComp>
      {/* shouldn't throw ts-error, but does*/}
        <TestComp2 id="1" />
        {[<TestComp2 id="2" />,<TestComp2 id="3" />].map(item=> item)}
      </TestComp>
      <TestComp>
      {/* should throw ts-error, but doesn't */}
        <div />
      </TestComp>
    </>
  );
}
```