### PR TITLE
docs: outline which props are rendered as `slots`

### DIFF
--- a/packages/main/scripts/create-web-components-wrapper.mjs
+++ b/packages/main/scripts/create-web-components-wrapper.mjs
@@ -236,7 +236,7 @@ const getEventParameters = (name, parameters) => {
   const resolvedEventParameters = parameters.map((property) => {
     return {
       ...property,
-      ...Utils.getTypeDefinitionForProperty(property, true)
+      ...Utils.getTypeDefinitionForProperty(property, { event: true })
     };
   });
 
@@ -548,6 +548,9 @@ const propDescription = (componentSpec, property) => {
   if (property.name !== 'children' && componentSpec?.slots?.some((item) => item.name === property.name)) {
     formattedDescription += `
           *
+          * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (\`slot="${property.name}"\`). 
+          * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+          *
           * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the \`slot\` prop and appends it to the most outer element of your component.
           * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).`;
   }
@@ -603,12 +606,11 @@ allWebComponents
           ...tsType
         };
       });
-
     allComponentProperties.push(
       ...(componentSpec.slots || [])
         .filter((prop) => prop.visibility === 'public' && prop.readonly !== 'true' && prop.static !== true)
         .map((property) => {
-          const tsType = Utils.getTypeDefinitionForProperty(property);
+          const tsType = Utils.getTypeDefinitionForProperty(property, { slot: true });
           if (tsType.importStatement) {
             importStatements.push(tsType.importStatement);
           }

--- a/packages/main/scripts/create-web-components-wrapper.mjs
+++ b/packages/main/scripts/create-web-components-wrapper.mjs
@@ -549,7 +549,7 @@ const propDescription = (componentSpec, property) => {
     formattedDescription += `
           *
           * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (\`slot="${property.name}"\`). 
-          * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+          * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them as part of the component's children, especially when facing problems with the reading order of screen readers.
           *
           * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the \`slot\` prop and appends it to the most outer element of your component.
           * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).`;

--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -1,13 +1,14 @@
 import { isPhone } from '@ui5/webcomponents-base/dist/Device.js';
 import { useI18nBundle, useSyncRef } from '@ui5/webcomponents-react-base';
 import clsx from 'clsx';
-import React, { Children, forwardRef, ReactElement, ReactNode, useReducer, useRef } from 'react';
+import React, { Children, forwardRef, ReactElement, useReducer, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createUseStyles } from 'react-jss';
 import { ButtonDesign } from '../../enums';
 import { AVAILABLE_ACTIONS, CANCEL, X_OF_Y } from '../../i18n/i18n-defaults';
 import { addCustomCSSWithScoping } from '../../internal/addCustomCSSWithScoping';
 import { CustomThemingParameters } from '../../themes/CustomVariables';
+import { UI5WCSlotsNode } from '../../types';
 import {
   Button,
   ButtonPropTypes,
@@ -30,7 +31,7 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the actions of the `ActionSheet`.
    *

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -42,6 +42,7 @@ export * from './components/VariantManagement/VariantItem';
 export * from './internal/withWebComponent';
 export * from './enums';
 export * from './interfaces';
+export * from './types';
 export * from './webComponents';
 
 export { AnalyticalTableHooks };

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -73,7 +73,9 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
     const slots = slotProperties.reduce((acc, name) => {
       const slotValue = rest[name] as ReactElement;
 
-      if (!slotValue) return acc;
+      if (!slotValue) {
+        return acc;
+      }
 
       if (rest[name]?.$$typeof === Symbol.for('react.portal')) {
         console.warn('ReactPortal is not supported for slot props.');

--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -75,6 +75,11 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
 
       if (!slotValue) return acc;
 
+      if (rest[name]?.$$typeof === Symbol.for('react.portal')) {
+        console.warn('ReactPortal is not supported for slot props.');
+        return acc;
+      }
+
       const slottedChildren = [];
       let index = 0;
       const removeFragments = (element) => {

--- a/packages/main/src/types/index.ts
+++ b/packages/main/src/types/index.ts
@@ -1,6 +1,6 @@
 import { ReactFragment, ReactNode, ReactPortal } from 'react';
 
-type ReducedReactNode = Exclude<ReactNode, string | number | ReactPortal | ReactFragment>;
-export type UI5WCSlotsNode = ReducedReactNode | Iterable<ReducedReactNode>;
+type ReducedReactNode = Exclude<ReactNode, string | number | boolean | ReactPortal | ReactFragment>;
+export type UI5WCSlotsNode = ReducedReactNode | Iterable<ReducedReactNode> | false;
 
 export type Nullable<T> = T | null;

--- a/packages/main/src/types/index.ts
+++ b/packages/main/src/types/index.ts
@@ -1,0 +1,5 @@
+import { ReactNode, ReactPortal } from 'react';
+
+export type UI5WCSlotsNode = Exclude<ReactNode, string | number | ReactPortal>;
+
+export type Nullable<T> = T | null;

--- a/packages/main/src/types/index.ts
+++ b/packages/main/src/types/index.ts
@@ -1,5 +1,6 @@
-import { ReactNode, ReactPortal } from 'react';
+import { ReactFragment, ReactNode, ReactPortal } from 'react';
 
-export type UI5WCSlotsNode = Exclude<ReactNode, string | number | ReactPortal>;
+type ReducedReactNode = Exclude<ReactNode, string | number | ReactPortal | ReactFragment>;
+export type UI5WCSlotsNode = ReducedReactNode | Iterable<ReducedReactNode>;
 
 export type Nullable<T> = T | null;

--- a/packages/main/src/webComponents/Avatar/index.tsx
+++ b/packages/main/src/webComponents/Avatar/index.tsx
@@ -4,6 +4,7 @@ import { AvatarColorScheme, AvatarShape, AvatarSize } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface AvatarAttributes {
   /**
@@ -86,10 +87,13 @@ export interface AvatarPropTypes extends AvatarAttributes, CommonProps {
    *     </Badge>
    * </Avatar>
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="badge"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  badge?: ReactNode;
+  badge?: UI5WCSlotsNode;
   /**
    * Receives the desired `<img>` tag **Note:** If you experience flickering of the provided image, you can hide the component until it is being defined with the following CSS:
    *

--- a/packages/main/src/webComponents/AvatarGroup/index.tsx
+++ b/packages/main/src/webComponents/AvatarGroup/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface AvatarGroupAttributes {
   /**
@@ -41,10 +42,13 @@ export interface AvatarGroupPropTypes extends AvatarGroupAttributes, Omit<Common
    *
    * **Note:** If this slot is not used, the component will display the built-in overflow button.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="overflowButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  overflowButton?: ReactNode;
+  overflowButton?: UI5WCSlotsNode;
   /**
    * Fired when the component is activated either with a click/tap or by using the Enter or Space key.
    */

--- a/packages/main/src/webComponents/Badge/index.tsx
+++ b/packages/main/src/webComponents/Badge/index.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface BadgeAttributes {
   /**
@@ -24,10 +25,13 @@ export interface BadgePropTypes extends BadgeAttributes, CommonProps {
   /**
    * Defines the icon to be displayed in the component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode;
+  icon?: UI5WCSlotsNode;
 }
 
 /**

--- a/packages/main/src/webComponents/Bar/index.tsx
+++ b/packages/main/src/webComponents/Bar/index.tsx
@@ -4,6 +4,7 @@ import { BarDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface BarAttributes {
   /**
@@ -29,17 +30,23 @@ export interface BarPropTypes extends BarAttributes, CommonProps {
   /**
    * Defines the content at the end of the bar
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  endContent?: ReactNode | ReactNode[];
-  /**
-   * Defines the content at the start of the bar
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="endContent"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  startContent?: ReactNode | ReactNode[];
+  endContent?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  /**
+   * Defines the content at the start of the bar
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="startContent"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  startContent?: UI5WCSlotsNode | UI5WCSlotsNode[];
 }
 
 /**

--- a/packages/main/src/webComponents/Card/index.tsx
+++ b/packages/main/src/webComponents/Card/index.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface CardAttributes {
   /**
@@ -27,10 +28,13 @@ export interface CardPropTypes extends CardAttributes, CommonProps {
    *
    * **Note:** Use `CardHeader` for the intended design.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
 }
 
 /**

--- a/packages/main/src/webComponents/CardHeader/index.tsx
+++ b/packages/main/src/webComponents/CardHeader/index.tsx
@@ -1,9 +1,9 @@
 import '@ui5/webcomponents/dist/CardHeader.js';
-import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface CardHeaderAttributes {
   /**
@@ -30,17 +30,23 @@ export interface CardHeaderPropTypes extends CardHeaderAttributes, Omit<CommonPr
   /**
    * Defines an action, displayed in the right most part of the header.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  action?: ReactNode | ReactNode[];
-  /**
-   * Defines an avatar image, displayed in the left most part of the header.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="action"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  avatar?: ReactNode | ReactNode[];
+  action?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  /**
+   * Defines an avatar image, displayed in the left most part of the header.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="avatar"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  avatar?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the component is activated by mouse/tap or by using the Enter or Space key.
    *

--- a/packages/main/src/webComponents/ComboBox/index.tsx
+++ b/packages/main/src/webComponents/ComboBox/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ComboBoxAttributes {
   /**
@@ -71,20 +72,26 @@ export interface ComboBoxPropTypes extends ComboBoxAttributes, Omit<CommonProps,
   /**
    * Defines the icon to be displayed in the input field.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode;
+  icon?: UI5WCSlotsNode;
   /**
    * Defines the value state message that will be displayed as pop up under the component.
    *
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the `ComboBox` is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the input operation has finished by pressing Enter, focusout or an item is selected.
    *

--- a/packages/main/src/webComponents/CustomListItem/index.tsx
+++ b/packages/main/src/webComponents/CustomListItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface CustomListItemAttributes {
   /**
@@ -33,10 +34,13 @@ export interface CustomListItemPropTypes extends CustomListItemAttributes, Commo
   /**
    * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="deleteButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  deleteButton?: ReactNode;
+  deleteButton?: UI5WCSlotsNode;
   /**
    * Fired when the user clicks on the detail button when type is `Detail`.
    */

--- a/packages/main/src/webComponents/DatePicker/index.tsx
+++ b/packages/main/src/webComponents/DatePicker/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/DatePicker.js';
-import { ReactNode } from 'react';
 import { ValueState, CalendarType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface DatePickerAttributes {
   /**
@@ -131,10 +131,13 @@ export interface DatePickerPropTypes extends DatePickerAttributes, Omit<CommonPr
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode;
+  valueStateMessage?: UI5WCSlotsNode;
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    *

--- a/packages/main/src/webComponents/DateRangePicker/index.tsx
+++ b/packages/main/src/webComponents/DateRangePicker/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/DateRangePicker.js';
-import { ReactNode } from 'react';
 import { ValueState, CalendarType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface DateRangePickerAttributes {
   /**
@@ -139,10 +139,13 @@ export interface DateRangePickerPropTypes extends DateRangePickerAttributes, Omi
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode;
+  valueStateMessage?: UI5WCSlotsNode;
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    *

--- a/packages/main/src/webComponents/DateTimePicker/index.tsx
+++ b/packages/main/src/webComponents/DateTimePicker/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/DateTimePicker.js';
-import { ReactNode } from 'react';
 import { ValueState, CalendarType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface DateTimePickerAttributes {
   /**
@@ -130,10 +130,13 @@ export interface DateTimePickerPropTypes extends DateTimePickerAttributes, Omit<
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode;
+  valueStateMessage?: UI5WCSlotsNode;
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    *

--- a/packages/main/src/webComponents/Dialog/index.tsx
+++ b/packages/main/src/webComponents/Dialog/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface DialogAttributes {
   /**
@@ -88,19 +89,25 @@ export interface DialogPropTypes extends DialogAttributes, Omit<CommonProps, 'dr
   /**
    * Defines the footer HTML Element.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="footer"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  footer?: ReactNode | ReactNode[];
+  footer?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the header HTML Element.
    *
    * **Note:** If `header` slot is provided, the labelling of the dialog is a responsibility of the application developer. `accessibleName` should be used.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the content of the Popup.
    */

--- a/packages/main/src/webComponents/DynamicSideContent/index.tsx
+++ b/packages/main/src/webComponents/DynamicSideContent/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface DynamicSideContentAttributes {
   /**
@@ -68,10 +69,13 @@ export interface DynamicSideContentPropTypes extends DynamicSideContentAttribute
   /**
    * Defines the side content.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="sideContent"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  sideContent?: ReactNode | ReactNode[];
+  sideContent?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fires when the current breakpoint has been changed.
    */

--- a/packages/main/src/webComponents/FileUploader/index.tsx
+++ b/packages/main/src/webComponents/FileUploader/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface FileUploaderAttributes {
   /**
@@ -75,10 +76,13 @@ export interface FileUploaderPropTypes extends FileUploaderAttributes, Omit<Comm
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Event is fired when the value of the file path has been changed. **Note:** Keep in mind that because of the HTML input element of type file, the event is also fired in Chrome browser when the Cancel button of the uploads window is pressed.
    */

--- a/packages/main/src/webComponents/FilterItem/index.tsx
+++ b/packages/main/src/webComponents/FilterItem/index.tsx
@@ -1,8 +1,8 @@
 import '@ui5/webcomponents-fiori/dist/FilterItem.js';
-import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface FilterItemAttributes {
   /**
@@ -17,10 +17,13 @@ export interface FilterItemPropTypes extends FilterItemAttributes, CommonProps {
   /**
    * Defines the `values` list.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="values"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  values?: ReactNode | ReactNode[];
+  values?: UI5WCSlotsNode | UI5WCSlotsNode[];
 }
 
 /**

--- a/packages/main/src/webComponents/FlexibleColumnLayout/index.tsx
+++ b/packages/main/src/webComponents/FlexibleColumnLayout/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents-fiori/dist/FlexibleColumnLayout.js';
-import { ReactNode } from 'react';
 import { FCLLayout } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface FlexibleColumnLayoutAttributes {
   /**
@@ -86,24 +86,33 @@ export interface FlexibleColumnLayoutPropTypes extends FlexibleColumnLayoutAttri
   /**
    * Defines the content in the end column.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="endColumn"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  endColumn?: ReactNode;
+  endColumn?: UI5WCSlotsNode;
   /**
    * Defines the content in the middle column.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  midColumn?: ReactNode;
-  /**
-   * Defines the content in the start column.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="midColumn"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  startColumn?: ReactNode;
+  midColumn?: UI5WCSlotsNode;
+  /**
+   * Defines the content in the start column.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="startColumn"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  startColumn?: UI5WCSlotsNode;
   /**
    * Fired when the layout changes via user interaction by clicking the arrows or by changing the component size due to resizing.
    */

--- a/packages/main/src/webComponents/IllustratedMessage/index.tsx
+++ b/packages/main/src/webComponents/IllustratedMessage/index.tsx
@@ -4,6 +4,7 @@ import { IllustrationMessageType, IllustrationMessageSize } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface IllustratedMessageAttributes {
   /**
@@ -156,10 +157,13 @@ export interface IllustratedMessagePropTypes extends IllustratedMessageAttribute
    *
    * **Note:** Using this slot, the default subtitle text of illustration and the value of `subtitleText` property will be overwritten.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="subtitle"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  subtitle?: ReactNode;
+  subtitle?: UI5WCSlotsNode;
 }
 
 /**

--- a/packages/main/src/webComponents/Input/index.tsx
+++ b/packages/main/src/webComponents/Input/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface InputAttributes {
   /**
@@ -131,10 +132,13 @@ export interface InputPropTypes extends InputAttributes, Omit<CommonProps, 'onCh
   /**
    * Defines the icon to be displayed in the component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode | ReactNode[];
+  icon?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the value state message that will be displayed as pop up under the component.
    *
@@ -144,10 +148,13 @@ export interface InputPropTypes extends InputAttributes, Omit<CommonProps, 'onCh
    *
    * **Note:** If the component has `suggestionItems`, the `valueStateMessage` would be displayed as part of the same popover, if used on desktop, or dialog - on phone.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    *

--- a/packages/main/src/webComponents/List/index.tsx
+++ b/packages/main/src/webComponents/List/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ListAttributes {
   /**
@@ -89,10 +90,13 @@ export interface ListPropTypes extends ListAttributes, CommonProps {
    *
    * **Note:** When `header` is set, the `headerText` property is ignored.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when an item is activated, unless the item's `type` property is set to `Inactive`.
    */

--- a/packages/main/src/webComponents/MediaGalleryItem/index.tsx
+++ b/packages/main/src/webComponents/MediaGalleryItem/index.tsx
@@ -4,6 +4,7 @@ import { MediaGalleryItemLayout } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface MediaGalleryItemAttributes {
   /**
@@ -35,10 +36,13 @@ export interface MediaGalleryItemPropTypes extends MediaGalleryItemAttributes, C
   /**
    * Defines the content of the thumbnail.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="thumbnail"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  thumbnail?: ReactNode;
+  thumbnail?: UI5WCSlotsNode;
 }
 
 /**

--- a/packages/main/src/webComponents/MessageStrip/index.tsx
+++ b/packages/main/src/webComponents/MessageStrip/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface MessageStripAttributes {
   /**
@@ -39,10 +40,13 @@ export interface MessageStripPropTypes extends MessageStripAttributes, CommonPro
    *
    * See all the available icons in the <ui5-link target="_blank" href="https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode;
+  icon?: UI5WCSlotsNode;
   /**
    * Fired when the close button is pressed either with a click/tap or by using the Enter or Space key.
    */

--- a/packages/main/src/webComponents/MultiComboBox/index.tsx
+++ b/packages/main/src/webComponents/MultiComboBox/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface MultiComboBoxAttributes {
   /**
@@ -82,20 +83,26 @@ export interface MultiComboBoxPropTypes extends MultiComboBoxAttributes, Omit<Co
   /**
    * Defines the icon to be displayed in the component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode;
+  icon?: UI5WCSlotsNode;
   /**
    * Defines the value state message that will be displayed as pop up under the component.
    *
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    *

--- a/packages/main/src/webComponents/MultiInput/index.tsx
+++ b/packages/main/src/webComponents/MultiInput/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface MultiInputAttributes {
   /**
@@ -111,10 +112,13 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
   /**
    * Defines the component tokens.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="tokens"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  tokens?: ReactNode | ReactNode[];
+  tokens?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the suggestion items.
    *
@@ -138,14 +142,17 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
    * `import "@ui5/webcomponents/dist/features/InputSuggestions.js";`
    * automatically imports the `<SuggestionItem>` and `<SuggestionGroupItem>` for your convenience.
    */
-  children?: ReactNode | ReactNode[];
+  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the icon to be displayed in the component.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="icon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  icon?: ReactNode | ReactNode[];
+  icon?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the value state message that will be displayed as pop up under the component.
    *
@@ -155,10 +162,13 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
    *
    * **Note:** If the component has `suggestionItems`, the `valueStateMessage` would be displayed as part of the same popover, if used on desktop, or dialog - on phone.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when a token is about to be deleted.
    */

--- a/packages/main/src/webComponents/MultiInput/index.tsx
+++ b/packages/main/src/webComponents/MultiInput/index.tsx
@@ -142,7 +142,7 @@ export interface MultiInputPropTypes extends MultiInputAttributes, Omit<CommonPr
    * `import "@ui5/webcomponents/dist/features/InputSuggestions.js";`
    * automatically imports the `<SuggestionItem>` and `<SuggestionGroupItem>` for your convenience.
    */
-  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  children?: ReactNode | ReactNode[];
   /**
    * Defines the icon to be displayed in the component.
    *

--- a/packages/main/src/webComponents/NotificationListGroupItem/index.tsx
+++ b/packages/main/src/webComponents/NotificationListGroupItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface NotificationListGroupItemAttributes {
   /**
@@ -64,10 +65,13 @@ export interface NotificationListGroupItemPropTypes extends NotificationListGrou
    *
    * **Note:** use the `NotificationAction` component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="actions"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  actions?: ReactNode | ReactNode[];
+  actions?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the `NotificationListItemBase` is expanded/collapsed by user interaction.
    */

--- a/packages/main/src/webComponents/NotificationListItem/index.tsx
+++ b/packages/main/src/webComponents/NotificationListItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface NotificationListItemAttributes {
   /**
@@ -59,10 +60,13 @@ export interface NotificationListItemPropTypes extends NotificationListItemAttri
    * **Note:** Consider using the `Avatar` to display icons, initials or images.
    * **Note:**In order to be complaint with the UX guidlines and for best experience, we recommend using avatars with 2rem X 2rem in size (32px X 32px). In case you are using the `Avatar` you can set its `size` property to `XS` to get the required size - `<Avatar size="XS"></Avatar>`.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="avatar"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  avatar?: ReactNode;
+  avatar?: UI5WCSlotsNode;
   /**
    * Defines the content of the `NotificationListItem`, usually a description of the notification.
    *
@@ -72,19 +76,25 @@ export interface NotificationListItemPropTypes extends NotificationListItemAttri
   /**
    * Defines the elements, displayed in the footer of the of the component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="footnotes"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  footnotes?: ReactNode | ReactNode[];
+  footnotes?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the actions, displayed in the top-right area.
    *
    * **Note:** use the `NotificationAction` component.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="actions"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  actions?: ReactNode | ReactNode[];
+  actions?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the `Close` button is pressed.
    */

--- a/packages/main/src/webComponents/Page/index.tsx
+++ b/packages/main/src/webComponents/Page/index.tsx
@@ -4,6 +4,7 @@ import { PageBackgroundDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface PageAttributes {
   /**
@@ -44,17 +45,23 @@ export interface PagePropTypes extends PageAttributes, CommonProps {
   /**
    * Defines the footer HTML Element.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  footer?: ReactNode;
-  /**
-   * Defines the header HTML Element.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="footer"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode;
+  footer?: UI5WCSlotsNode;
+  /**
+   * Defines the header HTML Element.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  header?: UI5WCSlotsNode;
 }
 
 /**

--- a/packages/main/src/webComponents/Panel/index.tsx
+++ b/packages/main/src/webComponents/Panel/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface PanelAttributes {
   /**
@@ -53,10 +54,13 @@ export interface PanelPropTypes extends PanelAttributes, CommonProps {
    *
    * **Note:** When a header is provided, the `headerText` property is ignored.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the component is expanded/collapsed by user interaction.
    */

--- a/packages/main/src/webComponents/Popover/index.tsx
+++ b/packages/main/src/webComponents/Popover/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/Popover.js';
-import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface PopoverAttributes {
   /**
@@ -120,21 +120,27 @@ export interface PopoverPropTypes extends PopoverAttributes, CommonProps {
   /**
    * Defines the footer HTML Element.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  footer?: ReactNode | ReactNode[];
-  /**
-   * Defines the header HTML Element.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="footer"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  footer?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  /**
+   * Defines the header HTML Element.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the content of the Popup.
    */
-  children?: ReactNode | ReactNode[];
+  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired after the component is closed. **This event does not bubble.**
    */

--- a/packages/main/src/webComponents/Popover/index.tsx
+++ b/packages/main/src/webComponents/Popover/index.tsx
@@ -1,4 +1,5 @@
 import '@ui5/webcomponents/dist/Popover.js';
+import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
@@ -140,7 +141,7 @@ export interface PopoverPropTypes extends PopoverAttributes, CommonProps {
   /**
    * Defines the content of the Popup.
    */
-  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  children?: ReactNode | ReactNode[];
   /**
    * Fired after the component is closed. **This event does not bubble.**
    */

--- a/packages/main/src/webComponents/ResponsivePopover/index.tsx
+++ b/packages/main/src/webComponents/ResponsivePopover/index.tsx
@@ -1,4 +1,5 @@
 import '@ui5/webcomponents/dist/ResponsivePopover.js';
+import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
@@ -140,7 +141,7 @@ export interface ResponsivePopoverPropTypes extends ResponsivePopoverAttributes,
   /**
    * Defines the content of the Popup.
    */
-  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  children?: ReactNode | ReactNode[];
   /**
    * Fired after the component is closed. **This event does not bubble.**
    */

--- a/packages/main/src/webComponents/ResponsivePopover/index.tsx
+++ b/packages/main/src/webComponents/ResponsivePopover/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/ResponsivePopover.js';
-import { ReactNode } from 'react';
 import { PopoverHorizontalAlign, PopoverPlacementType, PopoverVerticalAlign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ResponsivePopoverAttributes {
   /**
@@ -120,21 +120,27 @@ export interface ResponsivePopoverPropTypes extends ResponsivePopoverAttributes,
   /**
    * Defines the footer HTML Element.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  footer?: ReactNode | ReactNode[];
-  /**
-   * Defines the header HTML Element.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="footer"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  footer?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  /**
+   * Defines the header HTML Element.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the content of the Popup.
    */
-  children?: ReactNode | ReactNode[];
+  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired after the component is closed. **This event does not bubble.**
    */

--- a/packages/main/src/webComponents/Select/index.tsx
+++ b/packages/main/src/webComponents/Select/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface SelectAttributes {
   /**
@@ -69,10 +70,13 @@ export interface SelectPropTypes extends SelectAttributes, Omit<CommonProps, 'on
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the selected option changes.
    */

--- a/packages/main/src/webComponents/ShellBar/index.tsx
+++ b/packages/main/src/webComponents/ShellBar/index.tsx
@@ -4,6 +4,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ShellBarAttributes {
   /**
@@ -86,40 +87,55 @@ export interface ShellBarPropTypes extends ShellBarAttributes, CommonProps {
   /**
    * Defines the logo of the `ShellBar`. For example, you can use `Avatar` or `img` elements as logo.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="logo"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  logo?: ReactNode;
+  logo?: UI5WCSlotsNode;
   /**
    * Defines the items displayed in menu after a click on the primary title.
    *
    * **Note:** You can use the  `StandardListItem` and its ancestors.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="menuItems"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  menuItems?: ReactNode | ReactNode[];
+  menuItems?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * You can pass `Avatar` to set the profile image/icon. If no profile slot is set - profile will be excluded from actions. Note: We recommend not using the `size` attribute of `Avatar` because it should have specific size by design in the context of `ShellBar` profile.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="profile"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  profile?: ReactNode;
+  profile?: UI5WCSlotsNode;
   /**
    * Defines the `Input`, that will be used as a search field.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  searchField?: ReactNode;
-  /**
-   * Defines a `Button` in the bar that will be placed in the beginning. We encourage this slot to be used for a back or home button. It gets overstyled to match ShellBar's styling.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="searchField"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  startButton?: ReactNode;
+  searchField?: UI5WCSlotsNode;
+  /**
+   * Defines a `Button` in the bar that will be placed in the beginning. We encourage this slot to be used for a back or home button. It gets overstyled to match ShellBar's styling.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="startButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  startButton?: UI5WCSlotsNode;
   /**
    * Fired, when the co pilot is activated.
    */

--- a/packages/main/src/webComponents/SideNavigation/index.tsx
+++ b/packages/main/src/webComponents/SideNavigation/index.tsx
@@ -19,7 +19,7 @@ export interface SideNavigationPropTypes extends SideNavigationAttributes, Commo
   /**
    * Defines the main items of the `SideNavigation`. Use the `SideNavigationItem` component for the top-level items, and the `SideNavigationSubItem` component for second-level items, nested inside the items.
    */
-  children?: ReactNode;
+  children?: ReactNode | ReactNode[];
   /**
    * Defines the fixed items at the bottom of the `SideNavigation`. Use the `SideNavigationItem` component for the fixed items, and optionally the `SideNavigationSubItem` component to provide second-level items inside them. **Note:** In order to achieve the best user experience, it is recommended that you keep the fixed items "flat" (do not pass sub-items)
    *

--- a/packages/main/src/webComponents/SideNavigation/index.tsx
+++ b/packages/main/src/webComponents/SideNavigation/index.tsx
@@ -4,6 +4,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface SideNavigationAttributes {
   /**
@@ -18,23 +19,29 @@ export interface SideNavigationPropTypes extends SideNavigationAttributes, Commo
   /**
    * Defines the main items of the `SideNavigation`. Use the `SideNavigationItem` component for the top-level items, and the `SideNavigationSubItem` component for second-level items, nested inside the items.
    */
-  children?: ReactNode | ReactNode[];
+  children?: ReactNode;
   /**
    * Defines the fixed items at the bottom of the `SideNavigation`. Use the `SideNavigationItem` component for the fixed items, and optionally the `SideNavigationSubItem` component to provide second-level items inside them. **Note:** In order to achieve the best user experience, it is recommended that you keep the fixed items "flat" (do not pass sub-items)
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="fixedItems"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  fixedItems?: ReactNode | ReactNode[];
+  fixedItems?: UI5WCSlotsNode;
   /**
    * Defines the header of the `SideNavigation`.
    *
    * **Note:** The header is displayed when the component is expanded - the property `collapsed` is false;
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the selection has changed via user interaction
    */

--- a/packages/main/src/webComponents/StandardListItem/index.tsx
+++ b/packages/main/src/webComponents/StandardListItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface StandardListItemAttributes {
   /**
@@ -66,10 +67,13 @@ export interface StandardListItemPropTypes extends StandardListItemAttributes, C
   /**
    * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="deleteButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  deleteButton?: ReactNode;
+  deleteButton?: UI5WCSlotsNode;
   /**
    * Fired when the user clicks on the detail button when type is `Detail`.
    */

--- a/packages/main/src/webComponents/StepInput/index.tsx
+++ b/packages/main/src/webComponents/StepInput/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/StepInput.js';
-import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface StepInputAttributes {
   /**
@@ -84,10 +84,13 @@ export interface StepInputPropTypes extends StepInputAttributes, Omit<CommonProp
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the component is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode;
+  valueStateMessage?: UI5WCSlotsNode;
   /**
    * Fired when the input operation has finished by pressing Enter or on focusout.
    */

--- a/packages/main/src/webComponents/Tab/index.tsx
+++ b/packages/main/src/webComponents/Tab/index.tsx
@@ -4,6 +4,7 @@ import { SemanticColor } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TabAttributes {
   /**
@@ -61,10 +62,13 @@ export interface TabPropTypes extends TabAttributes, CommonProps {
    *
    * **Note:** Use `Tab` and `TabSeparator` for the intended design.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="subTabs"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  subTabs?: ReactNode | ReactNode[];
+  subTabs?: UI5WCSlotsNode | UI5WCSlotsNode[];
 }
 
 /**

--- a/packages/main/src/webComponents/TabContainer/index.tsx
+++ b/packages/main/src/webComponents/TabContainer/index.tsx
@@ -6,6 +6,8 @@ import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
 import { UI5WCSlotsNode } from '../../types';
+import { TabDomRef } from '../Tab';
+import { TabSeparatorDomRef } from '../TabSeparator';
 
 interface TabContainerAttributes {
   /**
@@ -56,9 +58,21 @@ interface TabContainerAttributes {
 
 export interface TabContainerDomRef extends TabContainerAttributes, Ui5DomRef {
   /**
-   * Returns all slotted tabs and their subTabs in a flattened array. The order of tabs is depth-first. For example, given the following slotted elements: `... ... ... ...` Calling `allItems` on this TabContainer will return the instances in the following order: `[ ui5-tab#First, ui5-tab#Nested, ui5-tab#Second, ui5-tab-separator#sep, ui5-tab#Third ]`
+   * Returns all slotted tabs and their subTabs in a flattened array. The order of tabs is depth-first.
+   * For example, given the following slotted elements:
+   *
+   * ```
+   * <Tab id="tab1">
+   *   <Tab id="sub1" />
+   * </Tab>
+   * <Tab id="tab2" />
+   * <TabSeparator id="separator" />
+   * <Tab id="tab3" />
+   * ```
+   *
+   * Calling `allItems` on this TabContainer will return the instances in the following order: `[ Tab#tab1, Tab#sub1, Tab#tab2, TabSeparator#separator, Tab#tab3 ]`
    */
-  readonly allItems: ReactNode | ReactNode[];
+  readonly allItems?: (TabDomRef | TabSeparatorDomRef)[];
 }
 
 export interface TabContainerPropTypes extends TabContainerAttributes, CommonProps {

--- a/packages/main/src/webComponents/TabContainer/index.tsx
+++ b/packages/main/src/webComponents/TabContainer/index.tsx
@@ -5,8 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-import { TabDomRef } from '../Tab';
-import { TabSeparatorDomRef } from '../TabSeparator';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TabContainerAttributes {
   /**
@@ -57,21 +56,9 @@ interface TabContainerAttributes {
 
 export interface TabContainerDomRef extends TabContainerAttributes, Ui5DomRef {
   /**
-   * Returns all slotted tabs and their subTabs in a flattened array. The order of tabs is depth-first.
-   * For example, given the following slotted elements:
-   *
-   * ```
-   * <Tab id="tab1">
-   *   <Tab id="sub1" />
-   * </Tab>
-   * <Tab id="tab2" />
-   * <TabSeparator id="separator" />
-   * <Tab id="tab3" />
-   * ```
-   *
-   * Calling `allItems` on this TabContainer will return the instances in the following order: `[ Tab#tab1, Tab#sub1, Tab#tab2, TabSeparator#separator, Tab#tab3 ]`
+   * Returns all slotted tabs and their subTabs in a flattened array. The order of tabs is depth-first. For example, given the following slotted elements: `... ... ... ...` Calling `allItems` on this TabContainer will return the instances in the following order: `[ ui5-tab#First, ui5-tab#Nested, ui5-tab#Second, ui5-tab-separator#sep, ui5-tab#Third ]`
    */
-  readonly allItems?: (TabDomRef | TabSeparatorDomRef)[];
+  readonly allItems: ReactNode | ReactNode[];
 }
 
 export interface TabContainerPropTypes extends TabContainerAttributes, CommonProps {
@@ -84,17 +71,23 @@ export interface TabContainerPropTypes extends TabContainerAttributes, CommonPro
   /**
    * Defines the button which will open the overflow menu. If nothing is provided to this slot, the default button will be used.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  overflowButton?: ReactNode;
-  /**
-   * Defines the button which will open the start overflow menu if available. If nothing is provided to this slot, the default button will be used.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="overflowButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  startOverflowButton?: ReactNode;
+  overflowButton?: UI5WCSlotsNode;
+  /**
+   * Defines the button which will open the start overflow menu if available. If nothing is provided to this slot, the default button will be used.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="startOverflowButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  startOverflowButton?: UI5WCSlotsNode;
   /**
    * Fired when a tab is selected.
    */

--- a/packages/main/src/webComponents/Table/index.tsx
+++ b/packages/main/src/webComponents/Table/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TableAttributes {
   /**
@@ -89,10 +90,13 @@ export interface TablePropTypes extends TableAttributes, CommonProps {
    *
    * **Note:** Use `TableColumn` for the intended design.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="columns"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  columns?: ReactNode | ReactNode[];
+  columns?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the component rows.
    *

--- a/packages/main/src/webComponents/TextArea/index.tsx
+++ b/packages/main/src/webComponents/TextArea/index.tsx
@@ -1,13 +1,10 @@
 import '@ui5/webcomponents/dist/TextArea.js';
-import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-
-//todo add to script?
-type Nullable<T> = T | null;
+import { UI5WCSlotsNode, Nullable } from '../../types';
 
 interface TextAreaAttributes {
   /**
@@ -105,10 +102,13 @@ export interface TextAreaPropTypes extends TextAreaAttributes, Omit<CommonProps,
    *
    * **Note:** The `valueStateMessage` would be displayed if the component has `valueState` of type `Information`, `Warning` or `Error`.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode | ReactNode[];
+  valueStateMessage?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the text has changed and the focus leaves the component.
    *

--- a/packages/main/src/webComponents/TimePicker/index.tsx
+++ b/packages/main/src/webComponents/TimePicker/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/TimePicker.js';
-import { ReactNode } from 'react';
 import { ValueState } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TimePickerAttributes {
   /**
@@ -85,10 +85,13 @@ export interface TimePickerPropTypes extends TimePickerAttributes, Omit<CommonPr
    * **Note:** If not specified, a default text (in the respective language) will be displayed.
    * **Note:** The `valueStateMessage` would be displayed, when the `TimePicker` is in `Information`, `Warning` or `Error` value state.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="valueStateMessage"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  valueStateMessage?: ReactNode;
+  valueStateMessage?: UI5WCSlotsNode;
   /**
    * Fired when the input operation has finished by clicking the "OK" button or when the text in the input field has changed and the focus leaves the input field.
    *

--- a/packages/main/src/webComponents/ToggleButton/index.tsx
+++ b/packages/main/src/webComponents/ToggleButton/index.tsx
@@ -1,9 +1,10 @@
 import '@ui5/webcomponents/dist/ToggleButton.js';
-import { ReactNode, MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ToggleButtonAttributes {
   /**
@@ -82,7 +83,7 @@ export interface ToggleButtonPropTypes extends ToggleButtonAttributes, Omit<Comm
    *
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
-  children?: ReactNode | ReactNode[];
+  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when the component is activated either with a mouse/tap or by using the Enter or Space key.
    *

--- a/packages/main/src/webComponents/ToggleButton/index.tsx
+++ b/packages/main/src/webComponents/ToggleButton/index.tsx
@@ -1,10 +1,9 @@
 import '@ui5/webcomponents/dist/ToggleButton.js';
-import { MouseEventHandler } from 'react';
+import { ReactNode, MouseEventHandler } from 'react';
 import { ButtonDesign } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
-import { UI5WCSlotsNode } from '../../types';
 
 interface ToggleButtonAttributes {
   /**
@@ -83,7 +82,7 @@ export interface ToggleButtonPropTypes extends ToggleButtonAttributes, Omit<Comm
    *
    * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
    */
-  children?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  children?: ReactNode | ReactNode[];
   /**
    * Fired when the component is activated either with a mouse/tap or by using the Enter or Space key.
    *

--- a/packages/main/src/webComponents/Token/index.tsx
+++ b/packages/main/src/webComponents/Token/index.tsx
@@ -1,9 +1,9 @@
 import '@ui5/webcomponents/dist/Token.js';
-import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TokenAttributes {
   /**
@@ -28,10 +28,13 @@ export interface TokenPropTypes extends TokenAttributes, Omit<CommonProps, 'onSe
   /**
    * Defines the close icon for the token. If nothing is provided to this slot, the default close icon will be used. Accepts `Icon`.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="closeIcon"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  closeIcon?: ReactNode;
+  closeIcon?: UI5WCSlotsNode;
   /**
    * Fired when the the component is selected by user interaction with mouse or by clicking space.
    */

--- a/packages/main/src/webComponents/Tree/index.tsx
+++ b/packages/main/src/webComponents/Tree/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TreeAttributes {
   /**
@@ -64,10 +65,13 @@ export interface TreePropTypes extends TreeAttributes, CommonProps {
    *
    * **Note:** When the `header` slot is set, the `headerText` property is ignored.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when a tree item is activated.
    */

--- a/packages/main/src/webComponents/TreeItem/index.tsx
+++ b/packages/main/src/webComponents/TreeItem/index.tsx
@@ -52,10 +52,6 @@ interface TreeItemAttributes {
    */
   indeterminate?: boolean;
   /**
-   * Used to duck-type TreeItem elements without using instanceof
-   */
-  isTreeItem?: boolean;
-  /**
    * Defines the visual indication and behavior of the list items. Available options are `Active` (by default), `Inactive` and `Detail`.
    *
    * **Note:** When set to `Active`, the item will provide visual response upon press and hover, while with type `Inactive` and `Detail` - will not.
@@ -108,7 +104,7 @@ export interface TreeItemPropTypes extends TreeItemAttributes, CommonProps {
 const TreeItem = withWebComponent<TreeItemPropTypes, TreeItemDomRef>(
   'ui5-tree-item',
   ['additionalText', 'additionalTextState', 'text', 'accessibleName', 'icon', 'type'],
-  ['expanded', 'hasChildren', 'indeterminate', 'isTreeItem', 'selected'],
+  ['expanded', 'hasChildren', 'indeterminate', 'selected'],
   ['deleteButton'],
   ['detail-click']
 );

--- a/packages/main/src/webComponents/TreeItem/index.tsx
+++ b/packages/main/src/webComponents/TreeItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TreeItemAttributes {
   /**
@@ -51,6 +52,10 @@ interface TreeItemAttributes {
    */
   indeterminate?: boolean;
   /**
+   * Used to duck-type TreeItem elements without using instanceof
+   */
+  isTreeItem?: boolean;
+  /**
    * Defines the visual indication and behavior of the list items. Available options are `Active` (by default), `Inactive` and `Detail`.
    *
    * **Note:** When set to `Active`, the item will provide visual response upon press and hover, while with type `Inactive` and `Detail` - will not.
@@ -79,10 +84,13 @@ export interface TreeItemPropTypes extends TreeItemAttributes, CommonProps {
   /**
    * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="deleteButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  deleteButton?: ReactNode;
+  deleteButton?: UI5WCSlotsNode;
   /**
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
@@ -100,7 +108,7 @@ export interface TreeItemPropTypes extends TreeItemAttributes, CommonProps {
 const TreeItem = withWebComponent<TreeItemPropTypes, TreeItemDomRef>(
   'ui5-tree-item',
   ['additionalText', 'additionalTextState', 'text', 'accessibleName', 'icon', 'type'],
-  ['expanded', 'hasChildren', 'indeterminate', 'selected'],
+  ['expanded', 'hasChildren', 'indeterminate', 'isTreeItem', 'selected'],
   ['deleteButton'],
   ['detail-click']
 );

--- a/packages/main/src/webComponents/TreeItemCustom/index.tsx
+++ b/packages/main/src/webComponents/TreeItemCustom/index.tsx
@@ -48,10 +48,6 @@ interface TreeItemCustomAttributes {
    */
   indeterminate?: boolean;
   /**
-   * Used to duck-type TreeItem elements without using instanceof
-   */
-  isTreeItem?: boolean;
-  /**
    * Defines the visual indication and behavior of the list items. Available options are `Active` (by default), `Inactive` and `Detail`.
    *
    * **Note:** When set to `Active`, the item will provide visual response upon press and hover, while with type `Inactive` and `Detail` - will not.
@@ -114,7 +110,7 @@ export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, Commo
 const TreeItemCustom = withWebComponent<TreeItemCustomPropTypes, TreeItemCustomDomRef>(
   'ui5-tree-item-custom',
   ['accessibleName', 'additionalTextState', 'icon', 'type'],
-  ['hideSelectionElement', 'expanded', 'hasChildren', 'indeterminate', 'isTreeItem', 'selected'],
+  ['hideSelectionElement', 'expanded', 'hasChildren', 'indeterminate', 'selected'],
   ['content', 'deleteButton'],
   ['detail-click']
 );

--- a/packages/main/src/webComponents/TreeItemCustom/index.tsx
+++ b/packages/main/src/webComponents/TreeItemCustom/index.tsx
@@ -1,4 +1,5 @@
 import '@ui5/webcomponents/dist/TreeItemCustom.js';
+import { ReactNode } from 'react';
 import { ValueState, ListItemType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
@@ -85,7 +86,7 @@ export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, Commo
    *
    * **Note:** Use `TreeItem` or `TreeItemCustom`
    */
-  children?: UI5WCSlotsNode;
+  children?: ReactNode;
   /**
    * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
    *

--- a/packages/main/src/webComponents/TreeItemCustom/index.tsx
+++ b/packages/main/src/webComponents/TreeItemCustom/index.tsx
@@ -1,10 +1,10 @@
 import '@ui5/webcomponents/dist/TreeItemCustom.js';
-import { ReactNode } from 'react';
 import { ValueState, ListItemType } from '../../enums';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface TreeItemCustomAttributes {
   /**
@@ -47,6 +47,10 @@ interface TreeItemCustomAttributes {
    */
   indeterminate?: boolean;
   /**
+   * Used to duck-type TreeItem elements without using instanceof
+   */
+  isTreeItem?: boolean;
+  /**
    * Defines the visual indication and behavior of the list items. Available options are `Active` (by default), `Inactive` and `Detail`.
    *
    * **Note:** When set to `Active`, the item will provide visual response upon press and hover, while with type `Inactive` and `Detail` - will not.
@@ -69,23 +73,29 @@ export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, Commo
   /**
    * Defines the content of the `TreeItem`.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="content"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  content?: ReactNode | ReactNode[];
+  content?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Defines the items of the component.
    *
    * **Note:** Use `TreeItem` or `TreeItemCustom`
    */
-  children?: ReactNode;
+  children?: UI5WCSlotsNode;
   /**
    * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="deleteButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  deleteButton?: ReactNode;
+  deleteButton?: UI5WCSlotsNode;
   /**
    * Fired when the user clicks on the detail button when type is `Detail`.
    */
@@ -103,7 +113,7 @@ export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, Commo
 const TreeItemCustom = withWebComponent<TreeItemCustomPropTypes, TreeItemCustomDomRef>(
   'ui5-tree-item-custom',
   ['accessibleName', 'additionalTextState', 'icon', 'type'],
-  ['hideSelectionElement', 'expanded', 'hasChildren', 'indeterminate', 'selected'],
+  ['hideSelectionElement', 'expanded', 'hasChildren', 'indeterminate', 'isTreeItem', 'selected'],
   ['content', 'deleteButton'],
   ['detail-click']
 );

--- a/packages/main/src/webComponents/UploadCollection/index.tsx
+++ b/packages/main/src/webComponents/UploadCollection/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface UploadCollectionAttributes {
   /**
@@ -51,10 +52,13 @@ export interface UploadCollectionPropTypes extends UploadCollectionAttributes, O
    *
    * **Note:** If `header` slot is provided, the labelling of the `UploadCollection` is a responsibility of the application developer. `accessibleName` should be used.
    *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="header"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  header?: ReactNode | ReactNode[];
+  header?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired when an element is dropped inside the drag and drop overlay.
    *

--- a/packages/main/src/webComponents/UploadCollectionItem/index.tsx
+++ b/packages/main/src/webComponents/UploadCollectionItem/index.tsx
@@ -5,6 +5,7 @@ import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode, Nullable } from '../../types';
 
 interface UploadCollectionItemAttributes {
   /**
@@ -14,7 +15,7 @@ interface UploadCollectionItemAttributes {
   /**
    * Holds an instance of `File` associated with this item.
    */
-  file?: File;
+  file?: Nullable<File>;
   /**
    * The name of the file.
    */
@@ -65,17 +66,23 @@ export interface UploadCollectionItemPropTypes extends UploadCollectionItemAttri
    *
    * **Note:** Use `Icon` or `img` for the intended design.
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  thumbnail?: ReactNode;
-  /**
-   * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="thumbnail"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  deleteButton?: ReactNode;
+  thumbnail?: UI5WCSlotsNode;
+  /**
+   * Defines the delete button, displayed in "Delete" mode. **Note:** While the slot allows custom buttons, to match design guidelines, please use the `Button` component. **Note:** When the slot is not present, a built-in delete button will be displayed.
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="deleteButton"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  deleteButton?: UI5WCSlotsNode;
   /**
    * Fired when the file name is clicked.
    *

--- a/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
+++ b/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
@@ -1,9 +1,9 @@
 import '@ui5/webcomponents-fiori/dist/ViewSettingsDialog.js';
-import { ReactNode } from 'react';
 import { CommonProps } from '../../interfaces/CommonProps';
 import { Ui5CustomEvent } from '../../interfaces/Ui5CustomEvent';
 import { Ui5DomRef } from '../../interfaces/Ui5DomRef';
 import { withWebComponent } from '../../internal/withWebComponent';
+import { UI5WCSlotsNode } from '../../types';
 
 interface ViewSettingsDialogAttributes {
   /**
@@ -14,11 +14,8 @@ interface ViewSettingsDialogAttributes {
 
 export interface ViewSettingsDialogDomRef extends ViewSettingsDialogAttributes, Ui5DomRef {
   /**
-   * Sets a JavaScript object, as settings to the `ViewSettingsDialog`. This method can be used after the dialog is initially open, as the dialog need to set its initial settings. The `ViewSettingsDialog` throws an event called "before-open", this can be used as trigger point. The object should have the following format: `{sortOrder: "Ascending", sortBy: "Name", filters: [{Filter 1: ["Some filter 1", "Some filter 2"]}, {Filter 2: ["Some filter 4"]}]}`
-   * @param {Object} settings - predefined settings.
-   * @param {string} settings.sortOrder - sort order
-   * @param {string} settings.sortBy - sort by
-   * @param {Array.<Object>} settings.filters - filters
+   * Sets a JavaScript object, as settings to the `ui5-view-settings-dialog`. This method can be used after the dialog is initially open, as the dialog need to set its initial settings. The `ui5-view-settings-dialog` throws an event called "before-open", this can be used as trigger point. The object should have the following format: `{sortOrder: "Ascending", sortBy: "Name", filters: [{"Filter 1": ["Some filter 1", "Some filter 2"]}, {"Filter 2": ["Some filter 4"]}]}`
+   * @param {Record<string, unknown>} settings - predefined settings.
    */
   setConfirmedSettings: (settings: Record<string, unknown>) => void;
   /**
@@ -31,17 +28,23 @@ export interface ViewSettingsDialogPropTypes extends ViewSettingsDialogAttribute
   /**
    * Defines the `filterItems` list. **Note:** If you want to use this slot, you need to import used item: `import "@ui5/webcomponents-fiori/dist/FilterItem";`
    *
-   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
-   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
-   */
-  filterItems?: ReactNode | ReactNode[];
-  /**
-   * Defines the list of items against which the user could sort data. **Note:** If you want to use this slot, you need to import used item: `import "@ui5/webcomponents-fiori/dist/SortItem";`
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="filterItems"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
    *
    * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
    * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
    */
-  sortItems?: ReactNode | ReactNode[];
+  filterItems?: UI5WCSlotsNode | UI5WCSlotsNode[];
+  /**
+   * Defines the list of items against which the user could sort data. **Note:** If you want to use this slot, you need to import used item: `import "@ui5/webcomponents-fiori/dist/SortItem";`
+   *
+   * __Note:__ This prop will be rendered as [slot](https://www.w3schools.com/tags/tag_slot.asp) (`slot="sortItems"`).
+   * Since you can't change the DOM order of slots when declaring them within a prop, it might prove beneficial to manually mount them in the body of the component, especially when facing problems with the reading order of screen readers.
+   *
+   * __Note:__ When passing a custom React component to this prop, you have to make sure your component reads the `slot` prop and appends it to the most outer element of your component.
+   * Learn more about it [here](https://sap.github.io/ui5-webcomponents-react/?path=/docs/knowledge-base-handling-slots--page).
+   */
+  sortItems?: UI5WCSlotsNode | UI5WCSlotsNode[];
   /**
    * Fired before the component is opened. **This event does not bubble.**
    */

--- a/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
+++ b/packages/main/src/webComponents/ViewSettingsDialog/index.tsx
@@ -14,8 +14,11 @@ interface ViewSettingsDialogAttributes {
 
 export interface ViewSettingsDialogDomRef extends ViewSettingsDialogAttributes, Ui5DomRef {
   /**
-   * Sets a JavaScript object, as settings to the `ui5-view-settings-dialog`. This method can be used after the dialog is initially open, as the dialog need to set its initial settings. The `ui5-view-settings-dialog` throws an event called "before-open", this can be used as trigger point. The object should have the following format: `{sortOrder: "Ascending", sortBy: "Name", filters: [{"Filter 1": ["Some filter 1", "Some filter 2"]}, {"Filter 2": ["Some filter 4"]}]}`
-   * @param {Record<string, unknown>} settings - predefined settings.
+   * Sets a JavaScript object, as settings to the `ViewSettingsDialog`. This method can be used after the dialog is initially open, as the dialog need to set its initial settings. The `ViewSettingsDialog` throws an event called "before-open", this can be used as trigger point. The object should have the following format: `{sortOrder: "Ascending", sortBy: "Name", filters: [{Filter 1: ["Some filter 1", "Some filter 2"]}, {Filter 2: ["Some filter 4"]}]}`
+   * @param {Object} settings - predefined settings.
+   * @param {string} settings.sortOrder - sort order
+   * @param {string} settings.sortBy - sort by
+   * @param {Array.<Object>} settings.filters - filters
    */
   setConfirmedSettings: (settings: Record<string, unknown>) => void;
   /**

--- a/scripts/web-component-wrappers/utils.js
+++ b/scripts/web-component-wrappers/utils.js
@@ -25,14 +25,15 @@ const eslint = new ESLint({
 });
 
 export const getTypeDefinitionForProperty = (property, options = {}) => {
+  const isSlot = options.slot && property.name !== 'default' && property.name !== 'children';
   const canBeNull = property.defaultValue === 'null';
   const importStatementCanBeNull = canBeNull ? "import { Nullable } from '../../types'" : null;
 
-  const reactNodeType = options.slot && property.name !== 'default' ? 'UI5WCSlotsNode' : 'ReactNode';
-  const importStatementReactNodeType =
-    options.slot && property.name !== 'default'
-      ? "import { UI5WCSlotsNode } from '../../types'"
-      : "import { ReactNode } from 'react';";
+  const reactNodeType = isSlot ? 'UI5WCSlotsNode' : 'ReactNode';
+  const importStatementReactNodeType = isSlot
+    ? "import { UI5WCSlotsNode } from '../../types'"
+    : "import { ReactNode } from 'react';";
+
   const interfaces = new Set([
     ...JSON.parse(
       fs.readFileSync(path.join(PATHS.root, 'scripts', 'web-component-wrappers', 'interfaces.json')).toString()


### PR DESCRIPTION
Fixes #4012