### PR TITLE
chore: increase ts target to ES2021

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "target": "ES2015",
-    "lib": ["es2019", "dom"],
+    "target": "ES2021",
+    "lib": ["ES2021", "dom"],
     "jsx": "react",
     "baseUrl": ".",
     "composite": true,


### PR DESCRIPTION
UI5 Web Components are also building for ES2021, so we should do the same.
Browser Support is given in all our supported browsers: https://kangax.github.io/compat-table/es2016plus/