### PR TITLE
docs: fix import statements

### DIFF
--- a/.storybook/components/Import.tsx
+++ b/.storybook/components/Import.tsx
@@ -12,7 +12,7 @@ interface ImportStatementPropTypes {
   packagePath: string;
 }
 
-export const ImportStatement = ({ moduleName, packagePath }: any) => {
+export const ImportStatement = ({ moduleName, packagePath }: ImportStatementPropTypes) => {
   return (
     <pre
       style={{

--- a/.storybook/components/Import.tsx
+++ b/.storybook/components/Import.tsx
@@ -1,17 +1,43 @@
 import { DocsContext } from '@storybook/addon-docs';
 import React, { useContext } from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import { googlecode } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
-export const ImportStatement = ({ children }: { children: string }) => {
+interface ImportStatementPropTypes {
+  /**
+   * Name of module/component (e.g. "Button")
+   */
+  moduleName: string;
+  /**
+   * Package name (e.g. "@ui5/webcomponents-react")
+   */
+  packagePath: string;
+}
+
+export const ImportStatement = ({ moduleName, packagePath }: any) => {
   return (
-    <SyntaxHighlighter
-      customStyle={{ whiteSpace: 'pre-wrap', fontSize: 14, padding: 0, margin: 0 }}
-      language="javascript"
-      style={googlecode}
+    <pre
+      style={{
+        display: 'block',
+        overflowX: 'auto',
+        padding: '0px',
+        background: 'white',
+        color: 'black',
+        whiteSpace: 'pre-wrap',
+        fontSize: '14px',
+        margin: '0px'
+      }}
     >
-      {children}
-    </SyntaxHighlighter>
+      <code style={{ whiteSpace: 'pre' }}>
+        <span style={{ color: 'rgb(0, 0, 136)' }}>import</span>
+        <span>
+          {' '}
+          {'{'} {moduleName} {'}'}{' '}
+        </span>
+        <span style={{ color: 'rgb(0, 0, 136)' }}>from</span>
+        <span> </span>
+        <span style={{ color: 'rgb(0, 136, 0)' }}>{packagePath}</span>
+        <span>;</span>
+      </code>
+    </pre>
   );
 };
 
@@ -22,9 +48,7 @@ export const Import = () => {
   const moduleName = groups[groups.length - 1].trim();
 
   return (
-    <ImportStatement>
-      {`import { ${moduleName} } from '@ui5/webcomponents-react${isChart ? '-charts' : ''}';`}
-    </ImportStatement>
+    <ImportStatement moduleName={moduleName} packagePath={`'@ui5/webcomponents-react${isChart ? '-charts' : ''}'`} />
   );
 };
 

--- a/.storybook/components/Import.tsx
+++ b/.storybook/components/Import.tsx
@@ -9,10 +9,10 @@ interface ImportStatementPropTypes {
   /**
    * Package name (e.g. "@ui5/webcomponents-react")
    */
-  packagePath: string;
+  packageName: string;
 }
 
-export const ImportStatement = ({ moduleName, packagePath }: ImportStatementPropTypes) => {
+export const ImportStatement = ({ moduleName, packageName }: ImportStatementPropTypes) => {
   return (
     <pre
       style={{
@@ -34,7 +34,7 @@ export const ImportStatement = ({ moduleName, packagePath }: ImportStatementProp
         </span>
         <span style={{ color: 'rgb(0, 0, 136)' }}>from</span>
         <span> </span>
-        <span style={{ color: 'rgb(0, 136, 0)' }}>{packagePath}</span>
+        <span style={{ color: 'rgb(0, 136, 0)' }}>{packageName}</span>
         <span>;</span>
       </code>
     </pre>
@@ -48,7 +48,7 @@ export const Import = () => {
   const moduleName = groups[groups.length - 1].trim();
 
   return (
-    <ImportStatement moduleName={moduleName} packagePath={`'@ui5/webcomponents-react${isChart ? '-charts' : ''}'`} />
+    <ImportStatement moduleName={moduleName} packageName={`'@ui5/webcomponents-react${isChart ? '-charts' : ''}'`} />
   );
 };
 

--- a/docs/5-Public-Utils.stories.mdx
+++ b/docs/5-Public-Utils.stories.mdx
@@ -23,7 +23,7 @@ The `@ui5/webcomponents-react-base` package is providing a couple of utils, whic
 
 ## Device
 
-<ImportStatement moduleName="Device" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="Device" packageName="'@ui5/webcomponents-react-base'" />
 
 The `Device` allows you to detect information about the environment where your app is running:
 
@@ -72,7 +72,7 @@ The `Device` allows you to detect information about the environment where your a
 
 ## Theming Parameters
 
-<ImportStatement moduleName="ThemingParameters" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="ThemingParameters" packageName="'@ui5/webcomponents-react-base'" />
 
 By using our `ThemingParameters`, you can define the look and feel of your application without the need to hard-code any
 colors. You can e.g. set `ThemingParameters.sapBackgroundColor` as a `background-color` and you'll always get the correct
@@ -82,7 +82,7 @@ background color for your current theme.
 
 ## Spacing
 
-<ImportStatement moduleName="spacing" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="spacing" packageName="'@ui5/webcomponents-react-base'" />
 
 The `spacing` file is containing all standard margins and paddings that are used in SAP Applications.
 You can explore them via the [UI5 Standard Margins Demo Kit](https://ui5.sap.com/#/entity/sap.ui.core.StandardMargins)
@@ -92,21 +92,21 @@ and the [UI5 Standard Paddings Demo Kit](https://ui5.sap.com/#/entity/sap.ui.cor
 
 ### `useI18nBundle`
 
-<ImportStatement moduleName="useI18nBundle" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="useI18nBundle" packageName="'@ui5/webcomponents-react-base'" />
 
 The `useI18nBundle` hook can be used for adding internationalization to your application. Learn more about it in our
 [Internationalization Guide](?path=/docs/internationalization--page).
 
 ### `useViewportRange`
 
-<ImportStatement moduleName="useViewportRange" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="useViewportRange" packageName="'@ui5/webcomponents-react-base'" />
 
 The `useViewportRange` hook is a utility hook based on the `Device.getCurrentRange()` and `Device.attachMediaHandler` API.
 It will always return a string with the name of the currently active range.
 
 ### `useResponsiveContentPadding`
 
-<ImportStatement moduleName="useResponsiveContentPadding" packagePath="'@ui5/webcomponents-react-base'" />
+<ImportStatement moduleName="useResponsiveContentPadding" packageName="'@ui5/webcomponents-react-base'" />
 
 The `useResponsiveContentPadding` hook is a hook generating a style class or a tuple containing the style class and the current range if `returnRangeString` is set to `true`.
 It adds `padding-left` and `padding-right` corresponding to the range (retrieved with `Device.getCurrentRange()`) of the element.

--- a/docs/5-Public-Utils.stories.mdx
+++ b/docs/5-Public-Utils.stories.mdx
@@ -23,7 +23,7 @@ The `@ui5/webcomponents-react-base` package is providing a couple of utils, whic
 
 ## Device
 
-<ImportStatement>{`import { Device } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="Device" packagePath="'@ui5/webcomponents-react-base'" />
 
 The `Device` allows you to detect information about the environment where your app is running:
 
@@ -72,7 +72,7 @@ The `Device` allows you to detect information about the environment where your a
 
 ## Theming Parameters
 
-<ImportStatement>{`import { ThemingParameters } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="ThemingParameters" packagePath="'@ui5/webcomponents-react-base'" />
 
 By using our `ThemingParameters`, you can define the look and feel of your application without the need to hard-code any
 colors. You can e.g. set `ThemingParameters.sapBackgroundColor` as a `background-color` and you'll always get the correct
@@ -82,7 +82,7 @@ background color for your current theme.
 
 ## Spacing
 
-<ImportStatement>{`import { spacing } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="spacing" packagePath="'@ui5/webcomponents-react-base'" />
 
 The `spacing` file is containing all standard margins and paddings that are used in SAP Applications.
 You can explore them via the [UI5 Standard Margins Demo Kit](https://ui5.sap.com/#/entity/sap.ui.core.StandardMargins)
@@ -92,21 +92,21 @@ and the [UI5 Standard Paddings Demo Kit](https://ui5.sap.com/#/entity/sap.ui.cor
 
 ### `useI18nBundle`
 
-<ImportStatement>{`import { useI18nBundle } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="useI18nBundle" packagePath="'@ui5/webcomponents-react-base'" />
 
 The `useI18nBundle` hook can be used for adding internationalization to your application. Learn more about it in our
 [Internationalization Guide](?path=/docs/internationalization--page).
 
 ### `useViewportRange`
 
-<ImportStatement>{`import { useViewportRange } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="useViewportRange" packagePath="'@ui5/webcomponents-react-base'" />
 
 The `useViewportRange` hook is a utility hook based on the `Device.getCurrentRange()` and `Device.attachMediaHandler` API.
 It will always return a string with the name of the currently active range.
 
 ### `useResponsiveContentPadding`
 
-<ImportStatement>{`import { useResponsiveContentPadding } from '@ui5/webcomponents-react-base';`}</ImportStatement>
+<ImportStatement moduleName="useResponsiveContentPadding" packagePath="'@ui5/webcomponents-react-base'" />
 
 The `useResponsiveContentPadding` hook is a hook generating a style class or a tuple containing the style class and the current range if `returnRangeString` is set to `true`.
 It adds `padding-left` and `padding-right` corresponding to the range (retrieved with `Device.getCurrentRange()`) of the element.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@ui5/webcomponents-icons": "1.10.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-syntax-highlighter": "^15.2.1",
     "tocbot": "^4.12.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13748,15 +13748,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fault@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "fault@npm:1.0.4"
-  dependencies:
-    format: ^0.2.0
-  checksum: 5ac610d8b09424e0f2fa8cf913064372f2ee7140a203a79957f73ed557c0e79b1a3d096064d7f40bde8132a69204c1fe25ec23634c05c6da2da2039cff26c4e7
-  languageName: node
-  linkType: hard
-
 "fb-watchman@npm:^2.0.0":
   version: 2.0.2
   resolution: "fb-watchman@npm:2.0.2"
@@ -14106,13 +14097,6 @@ __metadata:
     combined-stream: ^1.0.6
     mime-types: ^2.1.12
   checksum: 10c1780fa13dbe1ff3100114c2ce1f9307f8be10b14bf16e103815356ff567b6be39d70fc4a40f8990b9660012dc24b0f5e1dde1b6426166eb23a445ba068ca3
-  languageName: node
-  linkType: hard
-
-"format@npm:^0.2.0":
-  version: 0.2.2
-  resolution: "format@npm:0.2.2"
-  checksum: 646a60e1336250d802509cf24fb801e43bd4a70a07510c816fa133aa42cdbc9c21e66e9cc0801bb183c5b031c9d68be62e7fbb6877756e52357850f92aa28799
   languageName: node
   linkType: hard
 
@@ -15220,13 +15204,6 @@ __metadata:
   version: 1.1.0
   resolution: "hex-color-regex@npm:1.1.0"
   checksum: 44fa1b7a26d745012f3bfeeab8015f60514f72d2fcf10dce33068352456b8d71a2e6bc5a17f933ab470da2c5ab1e3e04b05caf3fefe3c1cabd7e02e516fc8784
-  languageName: node
-  linkType: hard
-
-"highlight.js@npm:^10.4.1, highlight.js@npm:~10.7.0":
-  version: 10.7.3
-  resolution: "highlight.js@npm:10.7.3"
-  checksum: defeafcd546b535d710d8efb8e650af9e3b369ef53e28c3dc7893eacfe263200bba4c5fcf43524ae66d5c0c296b1af0870523ceae3e3104d24b7abf6374a4fea
   languageName: node
   linkType: hard
 
@@ -18831,16 +18808,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lowlight@npm:^1.17.0":
-  version: 1.20.0
-  resolution: "lowlight@npm:1.20.0"
-  dependencies:
-    fault: ^1.0.0
-    highlight.js: ~10.7.0
-  checksum: 14a1815d6bae202ddee313fc60f06d46e5235c02fa483a77950b401d85b4c1e12290145ccd17a716b07f9328bd5864aa2d402b6a819ff3be7c833d9748ff8ba7
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -22184,20 +22151,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.27.0":
-  version: 1.29.0
-  resolution: "prismjs@npm:1.29.0"
-  checksum: 007a8869d4456ff8049dc59404e32d5666a07d99c3b0e30a18bd3b7676dfa07d1daae9d0f407f20983865fd8da56de91d09cb08e6aa61f5bc420a27c0beeaf93
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^2.0.0, proc-log@npm:^2.0.1":
   version: 2.0.1
   resolution: "proc-log@npm:2.0.1"
@@ -22939,21 +22892,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-syntax-highlighter@npm:^15.2.1":
-  version: 15.5.0
-  resolution: "react-syntax-highlighter@npm:15.5.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    highlight.js: ^10.4.1
-    lowlight: ^1.17.0
-    prismjs: ^1.27.0
-    refractor: ^3.6.0
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: c082b48f30f8ba8d0c55ed1d761910630860077c7ff5793c4c912adcb5760df06436ed0ad62be0de28113aac9ad2af55eccd995f8eee98df53382e4ced2072fb
-  languageName: node
-  linkType: hard
-
 "react-table@npm:7.8.0":
   version: 7.8.0
   resolution: "react-table@npm:7.8.0"
@@ -23239,17 +23177,6 @@ __metadata:
     css-unit-converter: ^1.1.1
     postcss-value-parser: ^3.3.0
   checksum: 8fd27c06c4b443b84749a69a8b97d10e6ec7d142b625b41923a8807abb22b9e37e44df14e26cc606a802957be07bdce5e8ee2976a6952a7b438a7727007101e9
-  languageName: node
-  linkType: hard
-
-"refractor@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "refractor@npm:3.6.0"
-  dependencies:
-    hastscript: ^6.0.0
-    parse-entities: ^2.0.0
-    prismjs: ~1.27.0
-  checksum: 39b01c4168c77c5c8486f9bf8907bbb05f257f15026057ba5728535815a2d90eed620468a4bfbb2b8ceefbb3ce3931a1be8b17152dbdbc8b0eef92450ff750a2
   languageName: node
   linkType: hard
 
@@ -26217,7 +26144,6 @@ __metadata:
     react-dom: 18.2.0
     react-dom-16: "npm:react-dom@^16.14.0"
     react-dom-17: "npm:react-dom@^17.0.2"
-    react-syntax-highlighter: ^15.2.1
     resize-observer-polyfill: 1.5.1
     rimraf: ^4.0.4
     tocbot: ^4.12.0


### PR DESCRIPTION
In some cases the `react-syntax-highlighter` failed to return a string, resulting in `[object Object]` to be displayed in stories. With this PR the dependency is removed and the appropriate styles are implemented with plain CSS and HTML.

Fixes #4035