### PR TITLE
fix(TypeScript): slot props support React v17 & v16

### DIFF
--- a/packages/main/src/types/index.ts
+++ b/packages/main/src/types/index.ts
@@ -1,6 +1,6 @@
-import { ReactFragment, ReactNode, ReactPortal } from 'react';
+import { ReactElement, ReactFragment, ReactNode, ReactPortal } from 'react';
 
 type ReducedReactNode = Exclude<ReactNode, string | number | boolean | ReactPortal | ReactFragment>;
-export type UI5WCSlotsNode = ReducedReactNode | Iterable<ReducedReactNode> | false;
+export type UI5WCSlotsNode = ReducedReactNode | Iterable<ReducedReactNode> | false | ReactElement;
 
 export type Nullable<T> = T | null;


### PR DESCRIPTION
The types for `ReactNode` differ for v18, v17 and v16. This PR adds `ReactElement` for the v17 and v16 types as well.

- ReactNode v18: `type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;`

- ReactNode v17 & v16: `type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;`