### PR TITLE
fix(AnalyticalTable): center align select checkboxes

### DIFF
--- a/packages/main/src/components/ActionSheet/index.tsx
+++ b/packages/main/src/components/ActionSheet/index.tsx
@@ -10,7 +10,7 @@ import { ButtonDesign } from '../../enums';
 import { AVAILABLE_ACTIONS, CANCEL, X_OF_Y } from '../../i18n/i18n-defaults';
 import { addCustomCSSWithScoping } from '../../internal/addCustomCSSWithScoping';
 import { useCanRenderPortal } from '../../internal/ssr';
-import { flattenFragments, isSSR } from '../../internal/utils';
+import { flattenFragments } from '../../internal/utils';
 import { CustomThemingParameters } from '../../themes/CustomVariables';
 import { UI5WCSlotsNode } from '../../types';
 import {
@@ -66,7 +66,7 @@ export interface ActionSheetPropTypes extends Omit<ResponsivePopoverPropTypes, '
 
 const useStyles = createUseStyles(styles, { name: 'ActionSheet' });
 
-if (!isSSR() && isPhone()) {
+if (isPhone()) {
   addCustomCSSWithScoping(
     'ui5-responsive-popover',
     `

--- a/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/ColumnHeader/index.tsx
@@ -4,6 +4,7 @@ import iconGroup from '@ui5/webcomponents-icons/dist/group-2.js';
 import iconSortAscending from '@ui5/webcomponents-icons/dist/sort-ascending.js';
 import iconSortDescending from '@ui5/webcomponents-icons/dist/sort-descending.js';
 import { ThemingParameters } from '@ui5/webcomponents-react-base';
+import { clsx } from 'clsx';
 import React, {
   CSSProperties,
   DragEventHandler,
@@ -80,6 +81,10 @@ const styles = {
     display: 'inline-block',
     position: 'absolute',
     color: ThemingParameters.sapContent_IconColor
+  },
+  selectAllCheckBoxContainer: {
+    display: 'flex',
+    justifyContent: 'center'
   }
 };
 
@@ -185,7 +190,6 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
       setPopoverOpen(true);
     }
   };
-
   if (!column) return null;
   return (
     <div
@@ -237,7 +241,10 @@ export const ColumnHeader: FC<ColumnHeaderProps> = (props: ColumnHeaderProps) =>
             title={tooltip}
             wrapping={false}
             style={textStyle}
-            className={classes.text}
+            className={clsx(
+              classes.text,
+              id === '__ui5wcr__internal_selection_column' && classes.selectAllCheckBoxContainer
+            )}
             data-component-name={`AnalyticalTableHeaderHeaderContentContainer-${id}`}
           >
             {children}

--- a/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
+++ b/packages/main/src/components/AnalyticalTable/__snapshots__/AnalyticalTable.test.tsx.snap
@@ -3559,7 +3559,7 @@ exports[`AnalyticalTable RTL: with highlight row 1`] = `
                   class="TableColumnHeader-header"
                 >
                   <span
-                    class="Text-text Text-noWrap TableColumnHeader-text"
+                    class="Text-text Text-noWrap TableColumnHeader-text TableColumnHeader-selectAllCheckBoxContainer"
                     data-component-name="AnalyticalTableHeaderHeaderContentContainer-__ui5wcr__internal_selection_column"
                   />
                   <div
@@ -4627,17 +4627,18 @@ exports[`AnalyticalTable Tree Table 1`] = `
               draggable="false"
               id="__ui5wcr__internal_selection_column"
               role="columnheader"
-              style="position: relative; cursor: pointer; width: 47px; padding: 0px;"
+              style="position: relative; cursor: pointer; display: flex; justify-content: center; width: 47px; padding: 0px;"
               tabindex="-1"
             >
               <div
                 class="TableColumnHeader-header"
               >
                 <span
-                  class="Text-text Text-noWrap TableColumnHeader-text"
+                  class="Text-text Text-noWrap TableColumnHeader-text TableColumnHeader-selectAllCheckBoxContainer"
                   data-component-name="AnalyticalTableHeaderHeaderContentContainer-__ui5wcr__internal_selection_column"
                 >
                   <ui5-checkbox
+                    data-at-checkbox="true"
                     style="vertical-align: middle; pointer-events: none;"
                     tabindex="-1"
                     title="Toggle All Rows Selected"
@@ -4854,6 +4855,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
                 tabindex="-1"
               >
                 <ui5-checkbox
+                  data-at-checkbox="true"
                   data-name="internal_selection_column"
                   style="vertical-align: middle; pointer-events: none;"
                   tabindex="-1"
@@ -4995,6 +4997,7 @@ exports[`AnalyticalTable Tree Table 1`] = `
                 tabindex="-1"
               >
                 <ui5-checkbox
+                  data-at-checkbox="true"
                   data-name="internal_selection_column"
                   style="vertical-align: middle; pointer-events: none;"
                   tabindex="-1"
@@ -5352,7 +5355,7 @@ exports[`AnalyticalTable highlight row with custom row key 1`] = `
                 class="TableColumnHeader-header"
               >
                 <span
-                  class="Text-text Text-noWrap TableColumnHeader-text"
+                  class="Text-text Text-noWrap TableColumnHeader-text TableColumnHeader-selectAllCheckBoxContainer"
                   data-component-name="AnalyticalTableHeaderHeaderContentContainer-__ui5wcr__internal_selection_column"
                 />
                 <div
@@ -6472,14 +6475,14 @@ exports[`AnalyticalTable plugin hook: useRowDisableSelection 1`] = `
               draggable="false"
               id="__ui5wcr__internal_selection_column"
               role="columnheader"
-              style="position: relative; cursor: auto; width: 47px; padding: 0px;"
+              style="position: relative; cursor: auto; display: flex; justify-content: center; width: 47px; padding: 0px;"
               tabindex="-1"
             >
               <div
                 class="TableColumnHeader-header"
               >
                 <span
-                  class="Text-text Text-noWrap TableColumnHeader-text"
+                  class="Text-text Text-noWrap TableColumnHeader-text TableColumnHeader-selectAllCheckBoxContainer"
                   data-component-name="AnalyticalTableHeaderHeaderContentContainer-__ui5wcr__internal_selection_column"
                 />
                 <div
@@ -6691,6 +6694,7 @@ exports[`AnalyticalTable plugin hook: useRowDisableSelection 1`] = `
                 tabindex="-1"
               >
                 <ui5-checkbox
+                  data-at-checkbox="true"
                   data-name="internal_selection_column"
                   disabled="true"
                   style="vertical-align: middle;"
@@ -6802,6 +6806,7 @@ exports[`AnalyticalTable plugin hook: useRowDisableSelection 1`] = `
                 tabindex="-1"
               >
                 <ui5-checkbox
+                  data-at-checkbox="true"
                   data-name="internal_selection_column"
                   style="vertical-align: middle; pointer-events: none;"
                   tabindex="-1"
@@ -10227,7 +10232,7 @@ exports[`AnalyticalTable with highlight row 1`] = `
                 class="TableColumnHeader-header"
               >
                 <span
-                  class="Text-text Text-noWrap TableColumnHeader-text"
+                  class="Text-text Text-noWrap TableColumnHeader-text TableColumnHeader-selectAllCheckBoxContainer"
                   data-component-name="AnalyticalTableHeaderHeaderContentContainer-__ui5wcr__internal_selection_column"
                 />
                 <div

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -2,7 +2,23 @@ import { CssSizeVariablesNames, enrichEventWithDetails } from '@ui5/webcomponent
 import React from 'react';
 import { AnalyticalTableSelectionBehavior } from '../../../enums/AnalyticalTableSelectionBehavior';
 import { AnalyticalTableSelectionMode } from '../../../enums/AnalyticalTableSelectionMode';
+import { addCustomCSSWithScoping } from '../../../internal/addCustomCSSWithScoping';
 import { CheckBox } from '../../../webComponents/CheckBox';
+
+addCustomCSSWithScoping(
+  'ui5-checkbox',
+  `
+    :host([data-at-checkbox]) .ui5-checkbox-root {
+      display: flex;
+      width: unset;
+      height: unset;
+      justify-content: center;
+      min-height: unset;
+      min-width: unset;
+      padding: 0;
+    }
+  `
+);
 
 const customCheckBoxStyling = {
   verticalAlign: 'middle',
@@ -64,7 +80,7 @@ const headerProps = (
     }
   }
 ) => {
-  const style = { ...props.style, cursor: 'pointer' };
+  const style = { ...props.style, cursor: 'pointer', display: 'flex', justifyContent: 'center' };
   if (
     props.key === 'header___ui5wcr__internal_selection_column' &&
     selectionMode === AnalyticalTableSelectionMode.MultiSelect
@@ -162,9 +178,19 @@ const getCellProps = (props, { cell }) => {
   return props;
 };
 
+// remove padding, width, etc. with addCustomCSS from checkboxes by leveraging the data attribute
+const setToggleAllRowsSelectedProps = (props) => {
+  return [props, { 'data-at-checkbox': true }];
+};
+const setToggleRowSelectedProps = (props) => {
+  return [props, { 'data-at-checkbox': true }];
+};
+
 export const useRowSelectionColumn = (hooks) => {
   hooks.getCellProps.push(getCellProps);
   hooks.getHeaderProps.push(headerProps);
+  hooks.getToggleRowSelectedProps.push(setToggleRowSelectedProps);
+  hooks.getToggleAllRowsSelectedProps.push(setToggleAllRowsSelectedProps);
   hooks.columns.push(columns);
   hooks.columnsDeps.push(columnDeps);
   hooks.visibleColumnsDeps.push(visibleColumnsDeps);

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -5,6 +5,7 @@ import { AnalyticalTableSelectionMode } from '../../../enums/AnalyticalTableSele
 import { addCustomCSSWithScoping } from '../../../internal/addCustomCSSWithScoping';
 import { CheckBox } from '../../../webComponents/CheckBox';
 
+// todo use ::part instead, when available (https://github.com/SAP/ui5-webcomponents/issues/6461)
 addCustomCSSWithScoping(
   'ui5-checkbox',
   `


### PR DESCRIPTION
Currently there is no `::part` support for the `CheckBox`, therefore we have to use `addCustomCSS`. --> https://github.com/SAP/ui5-webcomponents/issues/6461

Fixes #3732 