### PR TITLE
fix(Toolbar): only fire `onClick` on SPACE/ENTER if toolbar is focused

### DIFF
--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -29,6 +29,7 @@ import {
   ObjectStatus,
   PageBackgroundDesign,
   Panel,
+  Input,
   Title,
   ToggleButton,
   ValueState,
@@ -67,6 +68,7 @@ import { SpacingSpan } from './CodeGen';
       <DynamicPageTitle
         actions={
           <>
+            <Input />
             <Button key={'edit'} design={ButtonDesign.Emphasized}>
               Edit
             </Button>

--- a/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
+++ b/packages/main/src/components/DynamicPage/DynamicPage.stories.mdx
@@ -29,7 +29,6 @@ import {
   ObjectStatus,
   PageBackgroundDesign,
   Panel,
-  Input,
   Title,
   ToggleButton,
   ValueState,
@@ -68,7 +67,6 @@ import { SpacingSpan } from './CodeGen';
       <DynamicPageTitle
         actions={
           <>
-            <Input />
             <Button key={'edit'} design={ButtonDesign.Emphasized}>
               Edit
             </Button>

--- a/packages/main/src/components/Toolbar/Toolbar.cy.tsx
+++ b/packages/main/src/components/Toolbar/Toolbar.cy.tsx
@@ -213,6 +213,7 @@ describe('Toolbar', () => {
     cy.mount(
       <Toolbar active data-testid="tb" onClick={click}>
         Text
+        <input data-testid="input" />
       </Toolbar>
     );
     cy.findByTestId('tb').click();
@@ -222,6 +223,10 @@ describe('Toolbar', () => {
     cy.get('@onClickSpy').should('have.been.calledTwice');
 
     cy.findByTestId('tb').type(' ', { force: true });
+    cy.get('@onClickSpy').should('have.been.calledThrice');
+
+    cy.findByTestId('input').trigger('keydown', { code: 'Enter' });
+    cy.findByTestId('input').trigger('keydown', { code: 'Space' });
     cy.get('@onClickSpy').should('have.been.calledThrice');
 
     cy.mount(

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -265,6 +265,9 @@ const Toolbar = forwardRef<HTMLDivElement, ToolbarPropTypes>((props, ref) => {
   const handleToolbarClick = (e) => {
     if (active && typeof onClick === 'function') {
       const isSpaceEnterDown = e.type === 'keydown' && (e.code === 'Enter' || e.code === 'Space');
+      if (isSpaceEnterDown && e.target !== e.currentTarget) {
+        return;
+      }
       if (e.type === 'click' || isSpaceEnterDown) {
         e.preventDefault();
         onClick(enrichEventWithDetails(e));

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  debounce,
-  enrichEventWithDetails,
-  useI18nBundle,
-  useIsomorphicLayoutEffect,
-  useSyncRef
-} from '@ui5/webcomponents-react-base';
+import { debounce, useI18nBundle, useIsomorphicLayoutEffect, useSyncRef } from '@ui5/webcomponents-react-base';
 import { clsx } from 'clsx';
 import React, {
   Children,
@@ -270,7 +264,7 @@ const Toolbar = forwardRef<HTMLDivElement, ToolbarPropTypes>((props, ref) => {
       }
       if (e.type === 'click' || isSpaceEnterDown) {
         e.preventDefault();
-        onClick(enrichEventWithDetails(e));
+        onClick(e);
       }
     }
   };


### PR DESCRIPTION
Fixes #4190