### PR TITLE
fix(SplitterLayout): allow `SplitterElement`s to shrink

### DIFF
--- a/packages/main/src/components/SplitterElement/index.tsx
+++ b/packages/main/src/components/SplitterElement/index.tsx
@@ -55,8 +55,8 @@ const SplitterElement = forwardRef<HTMLDivElement, SplitterElementPropTypes>((pr
   const { children, style, className, minSize, size, resizable: _0, ...rest } = props;
   const [componentRef, splitterElementRef] = useSyncRef(ref);
   const { vertical, reset } = useContext(SplitterLayoutContext);
-  const safariStyles = Device.isSafari() ? { width: 'min-content', flex: '1 0 auto' } : {};
-  const defaultFlexStyles = size !== 'auto' ? { flex: `0 0 ${size}` } : { flex: '1 0 min-content', ...safariStyles };
+  const safariStyles = Device.isSafari() ? { width: 'min-content', flex: '1 1 auto' } : {};
+  const defaultFlexStyles = size !== 'auto' ? { flex: `0 1 ${size}` } : { flex: '1 0 min-content', ...safariStyles };
   const [flexStyles, setFlexStyles] = useState(defaultFlexStyles);
   const [flexBasisApplied, setFlexBasisApplied] = useState(false);
   const classes = useStyles();
@@ -76,7 +76,7 @@ const SplitterElement = forwardRef<HTMLDivElement, SplitterElementPropTypes>((pr
     if (size === 'auto' && splitterElementRef.current) {
       elementObserver.observe(splitterElementRef.current);
     } else {
-      setFlexStyles({ flex: `0 0 ${size}` });
+      setFlexStyles({ flex: `0 1 ${size}` });
     }
 
     return () => {


### PR DESCRIPTION
Fixes #4156