### PR TITLE
fix(DynamicPage & ObjectPage): prevent empty area on top of content when scrolling

### DIFF
--- a/packages/main/src/internal/useObserveHeights.ts
+++ b/packages/main/src/internal/useObserveHeights.ts
@@ -31,7 +31,11 @@ export const useObserveHeights = (
       if (scrollDown && e.target.scrollTop >= headerContentHeight && !headerCollapsed) {
         setIsIntersecting(false);
         setHeaderCollapsed(true);
-      } else if (!scrollDown && e.target.scrollTop <= topHeaderHeight && headerCollapsed) {
+      } else if (
+        !scrollDown &&
+        e.target.scrollTop <= topHeaderHeight + Math.max(0, headerContentHeight - topHeaderHeight) &&
+        headerCollapsed
+      ) {
         setIsIntersecting(true);
         setHeaderCollapsed(false);
       }


### PR DESCRIPTION
Fixes #4364