### PR TITLE
fix(TreeItemCustom - TypeScript): omit content HTMLAttribute from PropTypes

### DIFF
--- a/packages/main/scripts/create-web-components-wrapper.mjs
+++ b/packages/main/scripts/create-web-components-wrapper.mjs
@@ -17,6 +17,7 @@ import { renderComponentWrapper, renderTest } from '../../../scripts/web-compone
 import * as Utils from '../../../scripts/web-component-wrappers/utils.js';
 import {
   formatDemoDescription,
+  getCommonPropsToBeOmitted,
   getDomRefGetters,
   getDomRefMethods,
   getDomRefObjects
@@ -283,6 +284,7 @@ const createWebComponentWrapper = async (
   const attributesToBeOmitted = [...regularProps, ...booleanProps]
     .filter((attribute) => KNOWN_ATTRIBUTES.has(attribute))
     .map((a) => `'${a}'`);
+  const commonPropsToBeOmitted = getCommonPropsToBeOmitted(componentSpec.module);
 
   let domRefExtends = 'Ui5DomRef';
   if (attributesToBeOmitted.length > 0) {
@@ -290,8 +292,12 @@ const createWebComponentWrapper = async (
   }
 
   let tsExtendsStatement = 'CommonProps';
-  if (eventsToBeOmitted.length > 0 || attributesToBeOmitted.length > 0) {
-    tsExtendsStatement = `Omit<CommonProps, ${[...attributesToBeOmitted, ...eventsToBeOmitted].join(' | ')}>`;
+  if (eventsToBeOmitted.length > 0 || attributesToBeOmitted.length > 0 || commonPropsToBeOmitted.length > 0) {
+    tsExtendsStatement = `Omit<CommonProps, ${[
+      ...attributesToBeOmitted,
+      ...eventsToBeOmitted,
+      ...commonPropsToBeOmitted
+    ].join(' | ')}>`;
   }
   let componentDescription;
   try {

--- a/packages/main/src/webComponents/TreeItemCustom/index.tsx
+++ b/packages/main/src/webComponents/TreeItemCustom/index.tsx
@@ -72,7 +72,7 @@ export interface TreeItemCustomDomRef extends TreeItemCustomAttributes, Ui5DomRe
   toggle: () => void;
 }
 
-export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, CommonProps {
+export interface TreeItemCustomPropTypes extends TreeItemCustomAttributes, Omit<CommonProps, 'content'> {
   /**
    * Defines the content of the `TreeItem`.
    *

--- a/scripts/web-component-wrappers/utils.js
+++ b/scripts/web-component-wrappers/utils.js
@@ -418,3 +418,12 @@ export const formatDemoDescription = (description, componentSpec, replaceHeading
 
   return prettier.format(formattedDescription, { ...prettierConfigRaw, parser: 'markdown' });
 };
+
+export function getCommonPropsToBeOmitted(moduleName) {
+  switch (moduleName) {
+    case 'TreeItemCustom':
+      return ["'content'"];
+    default:
+      return [];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4805,13 +4805,13 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^18.0.6":
-  version: 18.0.31
-  resolution: "@types/react@npm:18.0.31"
+  version: 18.0.34
+  resolution: "@types/react@npm:18.0.34"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 6befbd5587e266905b50fd6bbd7c1cacd557bddf99e6a9862ca2f1d06df3dca71b9d485a37d010479730f021aab93b852d417c714de5efc2f41be0ff4c09b4db
+  checksum: 60d2766e7644ec480075bbb154bf8fb8476089466b643662ef59964e27cae2d8c71fd9c717a4dfa9627c3e050fa2ae866d10d16f66b4509058d1bfe2a564b18c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR also updates [@types/react to v18.0.34](https://github.com/SAP/ui5-webcomponents-react/commit/fb280ac297f6709f9c167e7fc687950ccc3d407c)