### PR TITLE
fix(Toolbar): return correct value for `overflowElements` in `onOverflowChange`

### DIFF
--- a/packages/main/src/components/Toolbar/OverflowPopover.tsx
+++ b/packages/main/src/components/Toolbar/OverflowPopover.tsx
@@ -1,7 +1,7 @@
 import iconOverflow from '@ui5/webcomponents-icons/dist/overflow.js';
 import { Device, useSyncRef } from '@ui5/webcomponents-react-base';
 import { clsx } from 'clsx';
-import type { FC, ReactElement, ReactNode, Ref } from 'react';
+import type { Dispatch, FC, ReactElement, ReactNode, Ref, SetStateAction } from 'react';
 import React, { cloneElement, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ButtonDesign, PopoverPlacementType } from '../../enums/index.js';
@@ -27,6 +27,7 @@ interface OverflowPopoverProps {
   showMoreText: string;
   overflowPopoverRef?: Ref<PopoverDomRef>;
   overflowButton?: ReactElement<ToggleButtonPropTypes> | ReactElement<ButtonPropTypes>;
+  setIsMounted: Dispatch<SetStateAction<boolean>>;
 }
 
 const isPhone = Device.isPhone();
@@ -40,12 +41,20 @@ export const OverflowPopover: FC<OverflowPopoverProps> = (props: OverflowPopover
     overflowContentRef,
     numberOfAlwaysVisibleItems,
     showMoreText,
+    overflowButton,
     overflowPopoverRef,
-    overflowButton
+    setIsMounted
   } = props;
   const [pressed, setPressed] = useState(false);
   const toggleBtnRef = useRef<ToggleButtonDomRef>(null);
   const [componentRef, popoverRef] = useSyncRef(overflowPopoverRef);
+
+  useEffect(() => {
+    setIsMounted(true);
+    return () => {
+      setIsMounted(false);
+    };
+  }, []);
 
   const handleToggleButtonClick = (e) => {
     e.stopPropagation();

--- a/packages/main/src/components/Toolbar/Toolbar.cy.tsx
+++ b/packages/main/src/components/Toolbar/Toolbar.cy.tsx
@@ -30,6 +30,16 @@ const OverflowTestComponent = (props: PropTypes) => {
   const { onOverflowChange } = props;
   const [width, setWidth] = useState(undefined);
   const [additionalChildren, setAdditionalChildren] = useState([]);
+  const [eventProperties, setEventProperties] = useState({
+    toolbarElements: [],
+    overflowElements: undefined,
+    target: undefined
+  });
+
+  const handleOverflowChange = (e) => {
+    onOverflowChange(e);
+    setEventProperties(e);
+  };
   return (
     <>
       <Input
@@ -62,7 +72,7 @@ const OverflowTestComponent = (props: PropTypes) => {
       </Button>
       <Toolbar
         data-testid="toolbar"
-        onOverflowChange={onOverflowChange}
+        onOverflowChange={handleOverflowChange}
         style={width ? { width: `${width}px`, maxWidth: 'none' } : undefined}
       >
         <Text data-testid="toolbar-item" style={{ width: '200px' }}>
@@ -79,6 +89,9 @@ const OverflowTestComponent = (props: PropTypes) => {
         {additionalChildren}
         <ToolbarSeparator data-testid="separator" />
       </Toolbar>
+      <br />
+      toolbarElements: <span data-testid="toolbarElements">{eventProperties.toolbarElements.length}</span>
+      overflowElements: <span data-testid="overflowElements">{eventProperties.overflowElements?.length}</span>
     </>
   );
 };
@@ -128,6 +141,8 @@ describe('Toolbar', () => {
     cy.viewport(300, 500);
     cy.mount(<OverflowTestComponent onOverflowChange={onOverflowChange} />);
     cy.get('@overflowChangeSpy').should('have.been.calledOnce');
+    cy.findByTestId('toolbarElements').should('have.text', 2);
+    cy.findByTestId('overflowElements').should('have.text', 4);
     cy.findByText('Item1').should('be.visible');
     cy.get('[data-testid="toolbar-item2"]').should('not.be.visible');
     cy.get('[data-testid="toolbar-item3"]').should('not.be.visible');
@@ -146,12 +161,16 @@ describe('Toolbar', () => {
     cy.get('[ui5-popover]').should('not.have.attr', 'open');
 
     cy.get('@overflowChangeSpy').should('have.callCount', 2);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 3);
 
     cy.findByTestId('input').shadow().find('input').type('100');
     cy.findByTestId('input').trigger('change');
     cy.findByTestId('input').shadow().find('input').clear({ force: true });
 
     cy.get('@overflowChangeSpy').should('have.callCount', 3);
+    cy.findByTestId('toolbarElements').should('have.text', 0);
+    cy.findByTestId('overflowElements').should('have.text', 6);
 
     cy.get('[data-testid="toolbar-item"]').should('not.be.visible');
     cy.get('[data-testid="toolbar-item2"]').should('not.be.visible');
@@ -161,6 +180,8 @@ describe('Toolbar', () => {
     cy.findByTestId('input').trigger('change');
 
     cy.get('@overflowChangeSpy').should('have.callCount', 4);
+    cy.findByTestId('toolbarElements').should('have.text', 6);
+    cy.findByTestId('overflowElements').should('not.have.text');
 
     cy.get('[data-testid="toolbar-item"]').should('be.visible');
     cy.get('[data-testid="toolbar-item2"]').should('be.visible');
@@ -170,10 +191,14 @@ describe('Toolbar', () => {
     cy.findByTestId('input').trigger('change');
 
     cy.get('@overflowChangeSpy').should('have.callCount', 5);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 3);
 
     cy.findByText('Add').click();
 
     cy.get('@overflowChangeSpy').should('have.callCount', 6);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 4);
 
     cy.findByText('Add').click();
     cy.findByText('Add').click();
@@ -182,10 +207,14 @@ describe('Toolbar', () => {
     cy.findByText('Add').click();
 
     cy.get('@overflowChangeSpy').should('have.callCount', 11);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 9);
 
     cy.findByText('Remove').click();
 
     cy.get('@overflowChangeSpy').should('have.callCount', 12);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 8);
 
     cy.findByText('Remove').click();
     cy.findByText('Remove').click();
@@ -194,6 +223,8 @@ describe('Toolbar', () => {
     cy.findByText('Remove').click();
 
     cy.get('@overflowChangeSpy').should('have.callCount', 17);
+    cy.findByTestId('toolbarElements').should('have.text', 3);
+    cy.findByTestId('overflowElements').should('have.text', 3);
 
     cy.get(`[ui5-toggle-button]`).click();
 

--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -96,7 +96,7 @@ export interface ToolbarPropTypes extends Omit<CommonProps, 'onClick' | 'childre
    */
   onOverflowChange?: (event: {
     toolbarElements: HTMLElement[];
-    overflowElements: HTMLCollection;
+    overflowElements: HTMLCollection | undefined;
     target: HTMLElement;
   }) => void;
 }


### PR DESCRIPTION
This PR also fixes an issue where `onOverflowChange` was called indefinitely.