### PR TITLE
test(chromatic): increase threshold or ignore flaky AnalyticalTable stories

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.tsx
@@ -156,6 +156,9 @@ export const Default: Story = {};
 
 export const PluginDisableRowSelection: Story = {
   name: 'Plugin: useRowDisableSelection',
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   args: {
     data: dataLarge.map((item) => ({ ...item, disableSelection: Math.random() < 0.5 })),
     selectionMode: AnalyticalTableSelectionMode.MultiSelect
@@ -230,6 +233,9 @@ export const PluginIndeterminateRowSelection: Story = {
 
 export const PluginManualRowSelect: Story = {
   name: 'Plugin: useManualRowSelect',
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   args: {
     data: dataManualSelect
   },
@@ -337,6 +343,9 @@ export const TreeTable: Story = {
 };
 
 export const InfiniteScrolling: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   render: (args) => {
     const [data, setData] = useState(args.data.slice(0, 50));
     const [loading, setLoading] = useState(false);

--- a/packages/main/src/components/SplitterLayout/SplitterLayout.stories.tsx
+++ b/packages/main/src/components/SplitterLayout/SplitterLayout.stories.tsx
@@ -21,6 +21,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  parameters: {
+    chromatic: { diffThreshold: 0.6 }
+  },
   render(args) {
     return (
       <SplitterLayout {...args}>


### PR DESCRIPTION
I tested the threshold via [this page](https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out) and for the ignored stories, the threshold would have to be set to over 0.8 and therefore the snapshot is useless.