### PR TITLE
fix(Toolbar): Fix onOverflowChange debounce init when the prop is not provided

### DIFF
--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -307,10 +307,12 @@ const Toolbar = forwardRef<HTMLDivElement, ToolbarPropTypes>((props, ref) => {
   };
 
   const prevChildren = useRef(flatChildren);
-  const debouncedOverflowChange = useRef(debounce(onOverflowChange, 60));
+  const debouncedOverflowChange = useRef();
 
   useEffect(() => {
-    debouncedOverflowChange.current = debounce(onOverflowChange, 60);
+    if(onOverflowChange){
+      debouncedOverflowChange.current = debounce(onOverflowChange, 60);
+    }
   }, [onOverflowChange]);
 
   useEffect(() => {
@@ -333,7 +335,9 @@ const Toolbar = forwardRef<HTMLDivElement, ToolbarPropTypes>((props, ref) => {
       });
     }
     return () => {
-      debouncedOverflowChange.current.cancel();
+      if(debouncedOverflowChange.current){
+        debouncedOverflowChange.current.cancel();
+      }
     };
   }, [lastVisibleIndex, flatChildren.length, isPopoverMounted]);
 


### PR DESCRIPTION
Fix #4661
