### PR TITLE
fix(Toolbar): only prevent keydown default actions in `onClick`

### DIFF
--- a/packages/main/src/components/Toolbar/index.tsx
+++ b/packages/main/src/components/Toolbar/index.tsx
@@ -300,7 +300,9 @@ const Toolbar = forwardRef<HTMLDivElement, ToolbarPropTypes>((props, ref) => {
         return;
       }
       if (e.type === 'click' || isSpaceEnterDown) {
-        e.preventDefault();
+        if (isSpaceEnterDown) {
+          e.preventDefault();
+        }
         onClick(e);
       }
     }


### PR DESCRIPTION
Fixes #4687