### PR TITLE
fix: add browser condition to package exports

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": "./dist/index.js",
       "node": "./ssr/index.js",
       "default": "./dist/index.js"
     },


### PR DESCRIPTION
This should fix #4676.

Jest prefers the `browser` condition when using the `jsdom` environment: https://jestjs.io/docs/configuration#testenvironmentoptions-object