### PR TITLE
fix(translations): fix "default" translation in Portuguese

### DIFF
--- a/packages/main/src/i18n/messagebundle_pt.properties
+++ b/packages/main/src/i18n/messagebundle_pt.properties
@@ -103,7 +103,7 @@ APPLY_AUTOMATICALLY=Aplicar automaticamente
 
 SHARING=Compartilhamento
 
-DEFAULT=Default
+DEFAULT=Padrão
 
 CREATED_BY=Criado por
 


### PR DESCRIPTION
fixes #4789