### PR TITLE
docs(Popover): add missing `onAfterClose`

### DIFF
--- a/packages/main/src/webComponents/Popover/Popover.stories.mdx
+++ b/packages/main/src/webComponents/Popover/Popover.stories.mdx
@@ -232,6 +232,7 @@ const PopoverComponent = () => {
             {...args}
             opener="openPopoverBtn2"
             open={popoverIsOpen}
+            onAfterClose={handleClose}
             header={
               <Bar endContent={<Icon name="settings" />}>
                 <Title>Popover</Title>


### PR DESCRIPTION
Fixes #4878 