### PR TITLE
docs(AnalyticalTable - useIndeterminateRowSelection): add performance warning to story

### DIFF
--- a/packages/main/src/components/AnalyticalTable/PluginIndeterminateRowSelection.mdx
+++ b/packages/main/src/components/AnalyticalTable/PluginIndeterminateRowSelection.mdx
@@ -13,6 +13,8 @@ import * as ComponentStories from './AnalyticalTable.stories';
 The `useIndeterminateRowSelection` plugin hook allows marking parent rows as indeterminate when a child row is selected.
 When using this hook, it is recommended to also select all sub-rows when selecting a row. (`reactTableOptions={{ selectSubRows: true }}`)
 
+**Note:** This hook has to traverse the whole data tree on each selection, which can lead to performance degradation with large datasets. Please use with caution!
+
 <MessageStrip
   hideCloseButton
   children={


### PR DESCRIPTION
Plugin hooks don't get their story description via JSDoc.