### PR TITLE
fix(AnalyticalTable): fix scrollbars for Firefox and Safari

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
+++ b/packages/main/src/components/AnalyticalTable/AnayticalTable.jss.ts
@@ -102,7 +102,7 @@ const styles = {
     position: 'relative',
     overflowX: 'hidden',
     overflowY: 'auto',
-    scrollBarWidth: 'none !important',
+    scrollbarWidth: 'none',
     borderBlockEnd: `1px solid ${ThemingParameters.sapList_TableFooterBorder}`,
     '-ms-overflow-style': 'none',
     '&::-webkit-scrollbar': {

--- a/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
+++ b/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
@@ -33,7 +33,8 @@ const styles = {
     borderInlineEnd: CustomThemingParameters.AnalyticalTableOuterBorderInline,
     borderBlockEnd: `1px solid ${ThemingParameters.sapList_TableFooterBorder}`,
     borderInlineStart: `1px solid ${ThemingParameters.sapList_BorderColor}`,
-    marginInlineStart: '-1px'
+    marginInlineStart: '-1px',
+    width: ThemingParameters.sapScrollBar_Dimension
   },
   bottomSection: {
     flexGrow: 1,

--- a/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
+++ b/packages/main/src/components/AnalyticalTable/scrollbars/VerticalScrollbar.tsx
@@ -26,15 +26,15 @@ const styles = {
     borderBlockEnd: `${CustomThemingParameters.AnalyticalTableHeaderBorderWidth} solid ${ThemingParameters.sapList_HeaderBorderColor}`,
     backgroundColor: ThemingParameters.sapList_HeaderBackground,
     borderInlineStart: `1px solid ${ThemingParameters.sapList_BorderColor}`,
-    marginInlineStart: '-1px'
+    marginInlineStart: '-1px',
+    width: `calc(${ThemingParameters.sapScrollBar_Dimension} + 2px)`
   },
   scrollbar: {
     overflowY: 'auto',
     borderInlineEnd: CustomThemingParameters.AnalyticalTableOuterBorderInline,
     borderBlockEnd: `1px solid ${ThemingParameters.sapList_TableFooterBorder}`,
     borderInlineStart: `1px solid ${ThemingParameters.sapList_BorderColor}`,
-    marginInlineStart: '-1px',
-    width: ThemingParameters.sapScrollBar_Dimension
+    marginInlineStart: '-1px'
   },
   bottomSection: {
     flexGrow: 1,


### PR DESCRIPTION
Note: Firefox lacks capabilities for customizing scrollbars, that's why there might be discrepancies noticeable between browsers.

Fixes #4379