### PR TITLE
fix(Toolbar): fix overflow popover margins

### DIFF
--- a/packages/main/src/components/Toolbar/Toolbar.jss.ts
+++ b/packages/main/src/components/Toolbar/Toolbar.jss.ts
@@ -97,7 +97,7 @@ export const styles = {
     '& >[ui5-button]::part(button) ,& >[ui5-toggle-button]::part(button)': {
       justifyContent: 'start'
     },
-    '& >[ui5-button][icon-only]::part(button), & > [ui5-toggle-button][icon-only]::part(button)': {
+    '& >[ui5-button][icon-only]::part(button), & >[ui5-toggle-button][icon-only]::part(button)': {
       padding: 'revert'
     },
     '& >:last-child': {

--- a/packages/main/src/components/Toolbar/Toolbar.jss.ts
+++ b/packages/main/src/components/Toolbar/Toolbar.jss.ts
@@ -102,6 +102,9 @@ export const styles = {
     },
     '& >:last-child': {
       marginBlockEnd: 0
+    },
+    '& >:first-child': {
+      marginBlockStart: 0
     }
   },
   childContainer: { display: 'flex' }

--- a/packages/main/src/components/Toolbar/Toolbar.jss.ts
+++ b/packages/main/src/components/Toolbar/Toolbar.jss.ts
@@ -12,7 +12,7 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    borderBottom: `solid 0.0625rem ${ThemingParameters.sapGroup_TitleBorderColor}`
+    borderBlockEnd: `solid 0.0625rem ${ThemingParameters.sapGroup_TitleBorderColor}`
   },
   hasOverflow: {
     '& $toolbar': {
@@ -20,7 +20,7 @@ export const styles = {
     }
   },
   clear: {
-    borderBottom: 'none'
+    borderBlockEnd: 'none'
   },
   active: {
     cursor: 'pointer',
@@ -85,23 +85,23 @@ export const styles = {
   popoverPhone: {
     width: 'calc(100% - 10px)',
     maxWidth: 'calc(100% - 10px)',
-    left: '5px !important'
+    insetInlineStart: '5px !important'
   },
   popoverContent: {
     padding: CssSizeVariables.ui5WcrToolbarPopoverContentPadding,
     display: 'flex',
     flexDirection: 'column',
-    '& [ui5-toggle-button], & [ui5-button]': {
-      marginBottom: '0.25rem'
+    '& >[ui5-toggle-button], & >[ui5-button]': {
+      marginBlock: '0.25rem'
     },
-    '& [ui5-button]::part(button) ,& [ui5-toggle-button]::part(button)': {
+    '& >[ui5-button]::part(button) ,& >[ui5-toggle-button]::part(button)': {
       justifyContent: 'start'
     },
-    '& [ui5-button][icon-only]::part(button), & [ui5-toggle-button][icon-only]::part(button)': {
+    '& >[ui5-button][icon-only]::part(button), & > [ui5-toggle-button][icon-only]::part(button)': {
       padding: 'revert'
     },
-    '& :last-child': {
-      marginBottom: 0
+    '& >:last-child': {
+      marginBlockEnd: 0
     }
   },
   childContainer: { display: 'flex' }

--- a/packages/main/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/main/src/components/Toolbar/Toolbar.stories.tsx
@@ -49,9 +49,6 @@ export const Default: Story = {
         <Input />
         <DatePicker />
         <Switch />
-        <Text>Hello there</Text>
-        <Text>Hello there</Text>
-        <Text>Hello there</Text>
       </Toolbar>
     );
   }

--- a/packages/main/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/main/src/components/Toolbar/Toolbar.stories.tsx
@@ -49,6 +49,9 @@ export const Default: Story = {
         <Input />
         <DatePicker />
         <Switch />
+        <Text>Hello there</Text>
+        <Text>Hello there</Text>
+        <Text>Hello there</Text>
       </Toolbar>
     );
   }


### PR DESCRIPTION
- Only apply styles to immediate children in overflow popover
- Use correct margin for buttons
- Replace physical with logical CSS properties