### PR TITLE
feat(AnalyticalTable): add `headerLabel` column property

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
@@ -53,7 +53,8 @@ const columns = [
   },
   {
     Header: () => <span>Friend Age</span>, // Custom header components!
-    accessor: 'friend.age'
+    accessor: 'friend.age',
+    headerLabel: 'Custom Label'
   }
 ];
 const data = [
@@ -1742,7 +1743,7 @@ describe('AnalyticalTable', () => {
     cy.findByText('Selected: {"0":true,"1":true,"2":true,"3":true}').should('be.visible');
   });
 
-  it('a11y: grouped, filtered, sorted', () => {
+  it('a11y: grouped, filtered, sorted, headerLabel', () => {
     cy.mount(<AnalyticalTable columns={columns} data={data} groupable filterable sortable />);
     cy.findByText('Name').click();
     cy.findByText('Sort Ascending').shadow().findByRole('listitem').click({ force: true });
@@ -1767,24 +1768,32 @@ describe('AnalyticalTable', () => {
     cy.get('[data-visible-row-index="1"][data-visible-column-index="0"]').should(
       'have.attr',
       'aria-label',
-      'Grouped, To expand the row, press the spacebar'
+      'Name Grouped, To expand the row, press the spacebar'
     );
     cy.get('[name="navigation-right-arrow"]').click();
     cy.get('[data-visible-row-index="1"][data-visible-column-index="0"]').should(
       'have.attr',
       'aria-label',
-      'Grouped, To collapse the row, press the spacebar'
+      'Name Grouped, To collapse the row, press the spacebar'
     );
     cy.findByText('Name').click();
     cy.findByText('Ungroup').shadow().findByRole('listitem').click({ force: true });
-    cy.get('[data-visible-row-index="1"][data-visible-column-index="0"]').should('not.have.attr', 'aria-label');
+    cy.get('[data-visible-row-index="1"][data-visible-column-index="0"]').should('have.attr', 'aria-label', 'Name ');
     cy.get('[data-column-id="name"]')
       .should('have.attr', 'aria-sort', 'descending')
       .and('have.attr', 'aria-label', 'Filtered');
 
     cy.findByText('Name').click();
     cy.findByText('Sort Ascending').shadow().get('[ui5-input]').typeIntoUi5Input('{selectall}{backspace}{enter}');
-    cy.get('[data-column-id="name"]').should('have.attr', 'aria-sort', 'descending').and('not.have.attr', 'aria-label');
+    cy.get('[data-column-id="name"]').should('have.attr', 'aria-sort', 'descending').and('have.attr', 'aria-label', '');
+
+    cy.get('[data-column-id="friend.age"]').should('have.attr', 'aria-label', 'Custom Label ');
+    cy.realPress('ArrowDown');
+    cy.get('[data-visible-row-index="1"][data-visible-column-index="3"]').should(
+      'have.attr',
+      'aria-label',
+      'Custom Label '
+    );
   });
 
   it("Expandable: don't scroll when expanded/collapsed", () => {

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
@@ -1259,8 +1259,9 @@ describe('AnalyticalTable', () => {
     });
   });
   it('columns drag & drop', () => {
-    columns.pop();
-    const updatedCols = [...columns, { accessor: 'friend.age', Header: 'Friend Age', disableDragAndDrop: true }];
+    const localCols = [...columns];
+    localCols.pop();
+    const updatedCols = [...localCols, { accessor: 'friend.age', Header: 'Friend Age', disableDragAndDrop: true }];
     const reorder = cy.spy().as('reorder');
     ['ltr', 'rtl'].forEach((dir) => {
       cy.mount(<AnalyticalTable dir={dir} data={data} columns={updatedCols} onColumnsReorder={reorder} />);
@@ -1787,11 +1788,7 @@ describe('AnalyticalTable', () => {
     cy.findByText('Sort Ascending').shadow().get('[ui5-input]').typeIntoUi5Input('{selectall}{backspace}{enter}');
     cy.get('[data-column-id="name"]').should('have.attr', 'aria-sort', 'descending').and('have.attr', 'aria-label', '');
 
-    cy.get('[data-visible-row-index="0"][data-visible-column-index="3"]').should(
-      'have.attr',
-      'aria-label',
-      'Custom Label '
-    );
+    cy.get('[data-column-id="friend.age"]').should('have.attr', 'aria-label', 'Custom Label ');
     cy.realPress('ArrowDown');
     cy.get('[data-visible-row-index="1"][data-visible-column-index="3"]').should(
       'have.attr',
@@ -2247,7 +2244,7 @@ describe('AnalyticalTable', () => {
     cy.focused().should('have.attr', 'data-row-index', '0').should('have.attr', 'data-column-index', '0');
 
     cy.realPress('End');
-    cy.focused().should('have.attr', 'data-row-index', '0').should('have.attr', 'data-column-index', '2');
+    cy.focused().should('have.attr', 'data-row-index', '0').should('have.attr', 'data-column-index', '3');
     cy.realPress('Home');
     cy.focused().should('have.attr', 'data-row-index', '0').should('have.attr', 'data-column-index', '0');
 

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
@@ -1787,7 +1787,11 @@ describe('AnalyticalTable', () => {
     cy.findByText('Sort Ascending').shadow().get('[ui5-input]').typeIntoUi5Input('{selectall}{backspace}{enter}');
     cy.get('[data-column-id="name"]').should('have.attr', 'aria-sort', 'descending').and('have.attr', 'aria-label', '');
 
-    cy.get('[data-column-id="friend.age"]').should('have.attr', 'aria-label', 'Custom Label ');
+    cy.get('[data-visible-row-index="0"][data-visible-column-index="3"]').should(
+      'have.attr',
+      'aria-label',
+      'Custom Label '
+    );
     cy.realPress('ArrowDown');
     cy.get('[data-visible-row-index="1"][data-visible-column-index="3"]').should(
       'have.attr',

--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.stories.tsx
@@ -63,6 +63,7 @@ const meta = {
       },
       {
         Header: () => <span>Friend Age</span>,
+        headerLabel: 'Friend Age',
         accessor: 'friend.age',
         hAlign: TextAlign.End,
         filter: (rows, accessor, filterValue) => {

--- a/packages/main/src/components/AnalyticalTable/hooks/useA11y.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useA11y.ts
@@ -8,7 +8,8 @@ interface UpdatedCellProptypes {
   'aria-colindex'?: number;
 }
 
-const setCellProps = (cellProps, { cell: { column, row, value }, instance }) => {
+const setCellProps = (cellProps, { cell, instance }) => {
+  const { column, row, value } = cell;
   const columnIndex = instance.visibleColumns.findIndex(({ id }) => id === column.id);
   const { alwaysShowSubComponent, renderRowSubComponent, translatableTexts, selectionMode, selectionBehavior } =
     instance.webComponentsReactProperties;
@@ -26,6 +27,10 @@ const setCellProps = (cellProps, { cell: { column, row, value }, instance }) => 
 
   const isFirstUserCol = userCols[0]?.id === column.id || userCols[0]?.accessor === column.accessor;
   updatedCellProps['data-is-first-column'] = isFirstUserCol;
+  updatedCellProps['aria-label'] = column.headerLabel || (typeof column.Header === 'string' ? column.Header : '');
+  if (updatedCellProps['aria-label']) {
+    updatedCellProps['aria-label'] += ' ';
+  }
 
   if ((isFirstUserCol && rowIsExpandable) || (row.isGrouped && row.canExpand)) {
     updatedCellProps.onKeyDown = row.getToggleRowExpandedProps?.()?.onKeyDown;
@@ -40,7 +45,7 @@ const setCellProps = (cellProps, { cell: { column, row, value }, instance }) => 
       updatedCellProps['aria-expanded'] = 'false';
       ariaLabel += ` ${translatableTexts.expandA11yText}`;
     }
-    updatedCellProps['aria-label'] = ariaLabel;
+    updatedCellProps['aria-label'] += ariaLabel;
   } else if (
     (selectionMode !== AnalyticalTableSelectionMode.None &&
       selectionBehavior !== AnalyticalTableSelectionBehavior.RowSelector &&
@@ -49,13 +54,12 @@ const setCellProps = (cellProps, { cell: { column, row, value }, instance }) => 
   ) {
     if (row.isSelected) {
       updatedCellProps['aria-selected'] = 'true';
-      updatedCellProps['aria-label'] = `${value ?? ''} ${translatableTexts.unselectA11yText}`;
+      updatedCellProps['aria-label'] += `${value ?? ''} ${translatableTexts.unselectA11yText}`;
     } else {
       updatedCellProps['aria-selected'] = 'false';
-      updatedCellProps['aria-label'] = `${value ?? ''} ${translatableTexts.selectA11yText}`;
+      updatedCellProps['aria-label'] += `${value ?? ''} ${translatableTexts.selectA11yText}`;
     }
   }
-
   return [cellProps, updatedCellProps];
 };
 
@@ -68,17 +72,22 @@ const setHeaderProps = (headerProps, { column, instance }) => {
   const isFiltered = column?.filterValue && column?.filterValue.length > 0;
 
   const updatedProps = {};
+  updatedProps['aria-label'] = column.headerLabel ??= '';
+  if (updatedProps['aria-label']) {
+    updatedProps['aria-label'] += ' ';
+  }
+
   if (column.isSorted) {
     updatedProps['aria-sort'] = column.isSortedDesc ? 'descending' : 'ascending';
   }
   if (isFiltered) {
-    updatedProps['aria-label'] = translatableTexts.filteredA11yText;
+    updatedProps['aria-label'] += translatableTexts.filteredA11yText;
   }
   if (column.isGrouped) {
     if (updatedProps['aria-label']) {
       updatedProps['aria-label'] += ` ${translatableTexts.groupedA11yText}`;
     } else {
-      updatedProps['aria-label'] = translatableTexts.groupedA11yText;
+      updatedProps['aria-label'] += translatableTexts.groupedA11yText;
     }
   }
 

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -105,6 +105,14 @@ export interface AnalyticalTableColumnDefinition {
    */
   Header?: string | ComponentType<any> | ((props?: any) => ReactNode);
   /**
+   * Defines the `aria-label` for the whole column read by screen readers.
+   *
+   * __Note:__ This prop is mandatory if you pass anything else than `string` to the `Header` property. In this case the `headerLabel` should at least contain the column name.
+   *
+   * __Note:__ If `headerLabel` is defined, screen readers will always read the passed string, even when `Header` is a `string`.
+   */
+  headerLabel?: string;
+  /**
    * Tooltip for the column header. If not set, the display text will be the same as the Header if it is a `string`.
    */
   headerTooltip?: string;


### PR DESCRIPTION
This PR adds the `headerLabel` column offering a way to define a label for custom headers.

Fixes #3121
Fixes #3189