### PR TITLE
fix(cypress-commands): add main entrypoint

### DIFF
--- a/packages/cypress-commands/package.json
+++ b/packages/cypress-commands/package.json
@@ -6,11 +6,13 @@
   "version": "1.19.0",
   "type": "module",
   "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some tools like `eslint-plugin-import` rely on the presence of the `main` field in the package.json.

Fixes #5049
