### PR TITLE
fix(AnalyticalTable): remove default prop for `alwaysShowSubComponent`

### DIFF
--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -1311,8 +1311,7 @@ AnalyticalTable.defaultProps = {
   isTreeTable: false,
   alternateRowColor: false,
   overscanCountHorizontal: 5,
-  visibleRowCountMode: AnalyticalTableVisibleRowCountMode.Fixed,
-  alwaysShowSubComponent: false
+  visibleRowCountMode: AnalyticalTableVisibleRowCountMode.Fixed
 };
 
 export { AnalyticalTable };


### PR DESCRIPTION
This causes the deprecation warning to always show up