### PR TITLE
fix(MessageViewButton - TypeScript): omit inherited `submits` prop

### DIFF
--- a/packages/main/src/components/MessageViewButton/index.tsx
+++ b/packages/main/src/components/MessageViewButton/index.tsx
@@ -60,7 +60,7 @@ const useStyles = createUseStyles(
 );
 
 export interface MessageViewButtonProptypes
-  extends Omit<ButtonPropTypes, 'design' | 'icon' | 'iconEnd' | 'children' | 'type'> {
+  extends Omit<ButtonPropTypes, 'design' | 'icon' | 'iconEnd' | 'children' | 'type' | 'submits'> {
   /**
    * Specifies the type of the button.
    */


### PR DESCRIPTION
The `MessageViewButton` shouldn't be used as submit button of a form, that's why we should omit the deprecated `submits` prop of the `Button` from inheritance. 