### PR TITLE
fix(ObjectStatus): fix border issue of None variant of inverted ObjectStatus

### DIFF
--- a/packages/main/src/components/ObjectStatus/ObjectStatus.jss.ts
+++ b/packages/main/src/components/ObjectStatus/ObjectStatus.jss.ts
@@ -268,7 +268,7 @@ const styles = {
       ...createInvertedValueStateStyles('sapButton_Neutral', true),
       background: ThemingParameters.sapNeutralBackground,
       color: ThemingParameters.sapTextColor,
-      border: ThemingParameters.sapNeutralBorderColor,
+      border: `0.0625rem solid ${ThemingParameters.sapNeutralBorderColor}`,
       '&$active:active': {
         ...createInvertedValueStateStyles('sapButton_Neutral', true)['&$active:active'],
         color: ThemingParameters.sapButton_Active_TextColor,


### PR DESCRIPTION
Before change:
<img width="109" alt="image" src="https://github.com/SAP/ui5-webcomponents-react/assets/1751846/3004afeb-bc0f-4682-9c56-ce5374e7957c">

After change:
<img width="102" alt="image" src="https://github.com/SAP/ui5-webcomponents-react/assets/1751846/496c14ed-24dd-490b-bf5d-72b004ad329e">

