### PR TITLE
docs(DynamicPageHeader & DynamicPageTitle): outline mandatory passing through props

### DIFF
--- a/packages/main/src/components/DynamicPage/index.tsx
+++ b/packages/main/src/components/DynamicPage/index.tsx
@@ -33,18 +33,23 @@ export interface DynamicPagePropTypes extends Omit<CommonProps, 'title' | 'child
    * Defines the upper, always static, title section of the `DynamicPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageTitle` in order to preserve the intended design.
+   *
+   * __Note:__ When the `DynamicPageTitle` is rendered inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
    */
   headerTitle?: ReactElement;
   /**
    * Defines the dynamic header section of the `DynamicPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageHeader` in order to preserve the intended design.
+   *
+   * __Note:__ When the `DynamicPageHeader` is rendered inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
    */
   headerContent?: ReactElement;
   /**
    * React element which defines the footer content.
    *
    * __Note:__ To preserve the intended design, please use only non-content based `height` values (`px`, `rem`, `vh`, etc.) as height of the `DynamicPage`.
+   *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `Bar` with `design={BarDesign.FloatingFooter}` in order to preserve the intended design.
    */
   footer?: ReactElement;

--- a/packages/main/src/components/DynamicPageHeader/index.tsx
+++ b/packages/main/src/components/DynamicPageHeader/index.tsx
@@ -28,8 +28,10 @@ interface InternalProps extends DynamicPageHeaderPropTypes {
 const useStyles = createUseStyles(DynamicPageHeaderStyles, { name: 'DynamicPageHeader' });
 
 /**
- * The dynamic page header contains the header content of the dynamic page.
+ * The `DynamicPageHeader` component is part of the `DynamicPage` family and is used to serve as header section of the `DynamicPage` and `ObjectPage`.
  * This component can be collapsed and pinned by the anchorbar.
+ *
+ * __Note:__ When used inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
  */
 const DynamicPageHeader = forwardRef<HTMLDivElement, InternalProps>((props, ref) => {
   const { children, headerPinned, topHeaderHeight, className, style, ...rest } = props;

--- a/packages/main/src/components/DynamicPageTitle/index.tsx
+++ b/packages/main/src/components/DynamicPageTitle/index.tsx
@@ -133,6 +133,8 @@ const enhanceActionsWithClick = (actions, ref: MutableRefObject<PopoverDomRef>) 
 /**
  * The `DynamicPageTitle` component is part of the `DynamicPage` family and is used to serve as title of the `DynamicPage` and `ObjectPage`.
  * It can contain Breadcrumbs, Title, Subtitle, Content, KPIs and Actions.
+ *
+ * __Note:__ When used inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
  */
 const DynamicPageTitle = forwardRef<HTMLDivElement, DynamicPageTitlePropTypes>((props, ref) => {
   const {

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -48,13 +48,18 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    * Defines the upper, always static, title section of the `ObjectPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageTitle` in order to preserve the intended design.
+   *
    * __Note:__ If not defined otherwise the prop `showSubHeaderRight` of the `DynamicPageTitle` is set to `true` by default.
+   *
+   * __Note:__ When the `DynamicPageTitle` is rendered inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
    */
   headerTitle?: ReactElement;
   /**
    * Defines the dynamic header section of the `ObjectPage`.
    *
    * __Note:__ Although this prop accepts all HTML Elements, it is strongly recommended that you only use `DynamicPageHeader` in order to preserve the intended design.
+   *
+   * __Note:__ When the `DynamicPageHeader` is rendered inside a custom component, it's essential to pass through all props, as otherwise the component won't function as intended!
    */
   headerContent?: ReactElement;
   /**


### PR DESCRIPTION
Fixes #5492