### PR TITLE
chore(eslint): remove rules-of-hooks for stories

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -141,4 +141,3 @@ overrides:
       'react/prop-types': 'off' # inline custom components within stories don't need prop types
       '@typescript-eslint/no-unused-vars': 'warn' # some samples can include unused vars to show the API / signature
       'react/no-unescaped-entities': 'off'
-      'react-hooks/rules-of-hooks': 'off' # the CSF-3 render() functions are not detected as react components


### PR DESCRIPTION
the storybook recommended config contains this rule since 0.7.0
