### PR TITLE
feat(AnalyticalTable): show `noDataText` if table is filtered and no rows are returned

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
@@ -1312,7 +1312,15 @@ describe('AnalyticalTable', () => {
     cy.mount(<AnalyticalTable data={data} columns={columns} loading />);
     cy.get('[data-component-name="Loader"]').should('be.visible');
     cy.mount(<AnalyticalTable data={[]} columns={columns} />);
-    cy.findByText('No Data').should('be.visible');
+    cy.findByText('No data').should('be.visible');
+    cy.mount(<AnalyticalTable data={data} columns={columns} filterable globalFilterValue="test123" />);
+    cy.findByText('No data found. Try adjusting the filter settings.').should('be.visible');
+    cy.mount(<AnalyticalTable data={data} columns={columns} filterable />);
+    cy.findByText('Lorem').should('be.visible');
+    cy.findByText('Name').realClick();
+    cy.get('[ui5-input]').typeIntoUi5Input('test123');
+    cy.findByText('Lorem').should('not.exist');
+    cy.findByText('No data found. Try adjusting the filter settings.').should('be.visible');
   });
 
   it('Alternate Row Color', () => {

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -43,6 +43,8 @@ import {
   FILTERED,
   GROUPED,
   INVALID_TABLE,
+  LIST_NO_DATA,
+  NO_DATA_FILTERED,
   SELECT_ALL,
   SELECT_PRESS_SPACE,
   UNSELECT_PRESS_SPACE
@@ -186,6 +188,7 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
   const invalidTableA11yText = i18nBundle.getText(INVALID_TABLE);
   const tableInstanceRef = useRef<Record<string, any>>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   tableInstanceRef.current = useTable(
     {
       columns,
@@ -274,8 +277,14 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
     setGroupBy,
     setGlobalFilter
   } = tableInstanceRef.current;
+
   const tableState: AnalyticalTableState = tableInstanceRef.current.state;
   const { triggerScroll } = tableState;
+
+  const noDataTextI18n = i18nBundle.getText(LIST_NO_DATA);
+  const noDataTextFiltered = i18nBundle.getText(NO_DATA_FILTERED);
+  const noDataTextLocal =
+    noDataText ?? (tableState.filters?.length > 0 || tableState.globalFilter ? noDataTextFiltered : noDataTextI18n);
 
   const [componentRef, updatedRef] = useSyncRef<AnalyticalTableDomRef>(ref);
   //@ts-expect-error: types are compatible
@@ -720,14 +729,14 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
                 )
               );
             })}
-            {loading && rawData?.length > 0 && <LoadingComponent style={{ width: `${totalColumnsWidth}px` }} />}
-            {loading && rawData?.length === 0 && (
+            {loading && rows?.length > 0 && <LoadingComponent style={{ width: `${totalColumnsWidth}px` }} />}
+            {loading && rows?.length === 0 && (
               <TablePlaceholder columns={visibleColumns} rows={minRows} style={noDataStyles} />
             )}
-            {!loading && rawData?.length === 0 && (
-              <NoDataComponent noDataText={noDataText} className={classes.noDataContainer} style={noDataStyles} />
+            {!loading && rows?.length === 0 && (
+              <NoDataComponent noDataText={noDataTextLocal} className={classes.noDataContainer} style={noDataStyles} />
             )}
-            {rawData?.length > 0 && tableRef.current && (
+            {rows?.length > 0 && tableRef.current && (
               <VirtualTableBodyContainer
                 rowCollapsedFlag={tableState.rowCollapsed}
                 dispatch={dispatch}
@@ -847,7 +856,6 @@ AnalyticalTable.defaultProps = {
   groupBy: [],
   NoDataComponent: DefaultNoDataComponent,
   LoadingComponent: DefaultLoadingComponent,
-  noDataText: 'No Data',
   reactTableOptions: {},
   tableHooks: [],
   visibleRows: 15,

--- a/packages/main/src/components/AnalyticalTable/types/index.ts
+++ b/packages/main/src/components/AnalyticalTable/types/index.ts
@@ -80,6 +80,7 @@ export interface AnalyticalTableState {
   hiddenColumns: string[];
   selectedRowIds: Record<string | number, any>;
   sortBy: Record<string | number, any>[];
+  globalFilter?: string;
   tableClientWidth?: number;
   dndColumn?: string;
   popInColumns?: Record<string | number, any>[];
@@ -418,7 +419,9 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    */
   showOverlay?: boolean;
   /**
-   * Defines the text shown if the data array is empty. If not set "No data" will be displayed.
+   * Defines the text shown if the data array is empty or a filtered table doesn't return results.
+   *
+   * __Note:__ If `noDataText` isn't set, the default text displayed is "No data". For filtered tables, it will show "No data found. Try adjusting the filter settings." instead.
    */
   noDataText?: string;
   /**

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -320,3 +320,6 @@ DOWN_ARROW=Down Arrow
 
 #XACT: Keyboard up arrow
 UP_ARROW=Up Arrow
+
+#XTXT: No-data text for filtered AnalyticalTable that returns no results
+NO_DATA_FILTERED=No data found. Try adjusting the filter settings.


### PR DESCRIPTION
This commit also enables i18n for the text placeholders.

