### PR TITLE
fix: suppress hydration warnings for web components

### DIFF
--- a/packages/main/src/internal/withWebComponent.tsx
+++ b/packages/main/src/internal/withWebComponent.tsx
@@ -169,6 +169,7 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
         {...regularProps}
         {...nonWebComponentRelatedProps}
         class={className}
+        suppressHydrationWarning
       >
         {slots}
         {children}


### PR DESCRIPTION
As UI5 Web Components are adding some attributes while being rendered on the client (like their own tag name), we should suppress hydration warnings for all UI5 Web Components.