### PR TITLE
fix(Form): fix vertical alignment of FormItems for `labelSpan=12`

### DIFF
--- a/packages/main/src/components/Form/Form.module.css
+++ b/packages/main/src/components/Form/Form.module.css
@@ -10,6 +10,10 @@
 
   --_ui5wcr_form_label_text_align: end;
 
+  &.labelSpan12 {
+    align-items: start;
+  }
+
   [data-component-name='FormGroupTitle'] {
     margin-inline: 1rem;
   }

--- a/packages/main/src/components/Form/index.tsx
+++ b/packages/main/src/components/Form/index.tsx
@@ -366,7 +366,11 @@ const Form = forwardRef<HTMLFormElement, FormPropTypes>((props, ref) => {
 
     return { formItems, formGroups, registerItem, unregisterItem, rowsWithGroup };
   }, [items, registerItem, unregisterItem, currentNumberOfColumns, titleText, currentLabelSpan]);
-  const formClassNames = clsx(classNames.form, classNames[backgroundDesign.toLowerCase()]);
+  const formClassNames = clsx(
+    classNames.form,
+    classNames[backgroundDesign.toLowerCase()],
+    currentLabelSpan == 12 && classNames.labelSpan12
+  );
   const CustomTag = as as ElementType;
 
   const prevFormItems = useRef<undefined | FormItemLayoutInfo[]>(undefined);


### PR DESCRIPTION
fixes #5815
