### PR TITLE
fix(Loader): deprecate component

### DIFF
--- a/packages/main/src/components/Loader/index.tsx
+++ b/packages/main/src/components/Loader/index.tsx
@@ -44,7 +44,7 @@ const Loader = forwardRef<HTMLDivElement, LoaderPropTypes>((props, ref) => {
   const backgroundSize = type !== LoaderType.Determinate ? '40%' : progress;
 
   useEffect(() => {
-    deprecationNotice('Loader', 'The `Loader` component is deprecated. Please use `BusyIndicator` instead.');
+    deprecationNotice('Loader', 'The `Loader` component is deprecated. Please use the `BusyIndicator` instead.');
   }, []);
 
   useEffect(() => {

--- a/packages/main/src/components/Loader/index.tsx
+++ b/packages/main/src/components/Loader/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useI18nBundle, useStylesheet } from '@ui5/webcomponents-react-base';
+import { deprecationNotice, useI18nBundle, useStylesheet } from '@ui5/webcomponents-react-base';
 import { clsx } from 'clsx';
 import type { CSSProperties } from 'react';
 import React, { forwardRef, useEffect, useState } from 'react';
@@ -29,6 +29,10 @@ export interface LoaderPropTypes extends CommonProps {
 /**
  * The `Loader` signals that an operation is currently being executed. It uses as little space as possible to allow the user to interact with the UI.<br />
  * It can be used to signal a data update on an already existing dataset, or where an expansion will happen.
+ *
+ * __Note:__ This component is __deprecated__ and will be removed with our next major release (v2.0.0)! Please use the [BusyIndicator](https://sap.github.io/ui5-webcomponents-react/?path=/docs/user-feedback-busyindicator--docs) instead.
+ *
+ * @deprecated This component is deprecated and will be removed with our next major release (v2.0.0)! Please use the [BusyIndicator](https://sap.github.io/ui5-webcomponents-react/?path=/docs/user-feedback-busyindicator--docs) instead.
  */
 const Loader = forwardRef<HTMLDivElement, LoaderPropTypes>((props, ref) => {
   const { className, type, progress, slot, style, delay, ...rest } = props;
@@ -38,6 +42,10 @@ const Loader = forwardRef<HTMLDivElement, LoaderPropTypes>((props, ref) => {
 
   const loaderClasses = clsx(classNames.loader, className, classNames[`loader${type}`]);
   const backgroundSize = type !== LoaderType.Determinate ? '40%' : progress;
+
+  useEffect(() => {
+    deprecationNotice('Loader', 'The `Loader` component is deprecated. Please use `BusyIndicator` instead.');
+  }, []);
 
   useEffect(() => {
     let timeout;


### PR DESCRIPTION
This component is a remnant of temporary design guidelines and is not recommended to be used anymore. The `BusyIndicator` should be the only loading indicator available. Therefore, we will remove this component in favor of the `BusyIndicator` with our next release.

For further information see [Fiori for Web Design Guidelines](https://experience.sap.com/fiori-design-web/busy-handling/)