### PR TITLE
fix(CommonProps - TypeScript): remove `dangerouslySetInnerHTML` from types

### DIFF
--- a/docs/MigrationGuide.mdx
+++ b/docs/MigrationGuide.mdx
@@ -38,6 +38,11 @@ function MyRootComponent() {
 }
 ```
 
+### Changes Exclusive to TypeScript
+
+- Removed `dangerouslySetInnerHTML` from general prop types since it was never intended to be used with our library.
+  If you've previously used this prop and the component didn't change with the update, then it might still work, but you'll probably need to suppress the typescript error.
+
 ## Removed hooks
 
 ### `useResponsiveContentPadding`

--- a/packages/main/src/types/CommonProps.ts
+++ b/packages/main/src/types/CommonProps.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties, HTMLAttributes } from 'react';
 
-export interface CommonProps<T = HTMLElement> extends HTMLAttributes<T> {
+export interface CommonProps<T = HTMLElement> extends Omit<HTMLAttributes<T>, 'dangerouslySetInnerHTML'> {
   /**
    * Element style which will be appended to the most outer element of a component.
    * Use this prop carefully, some css properties might break the component.


### PR DESCRIPTION
BREAKING CHANGE: `dangerouslySetInnerHTML` type has been removed
