### PR TITLE
fix(ObjectStatus): remove `HTMLDivElement` from `onClick` type

### DIFF
--- a/packages/main/src/components/ObjectStatus/index.tsx
+++ b/packages/main/src/components/ObjectStatus/index.tsx
@@ -100,11 +100,9 @@ export interface ObjectStatusPropTypes extends CommonProps {
    *
    * __Note:__ This prop has no effect if `active` is not set to `true`.
    *
-   * __Note:__ In order to support legacy code, `HTMLDivElement` is still supported even though the `click` event is never fired if the component isn't `active`.
-   *
    * @since 0.16.6
    */
-  onClick?: MouseEventHandler<HTMLButtonElement | HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const getStateSpecifics = (state, showDefaultIcon, userIcon, stateAnnouncementText, i18nTexts) => {

--- a/packages/main/src/components/ObjectStatus/index.tsx
+++ b/packages/main/src/components/ObjectStatus/index.tsx
@@ -221,6 +221,7 @@ const ObjectStatus = forwardRef<HTMLDivElement | HTMLButtonElement, ObjectStatus
       ref={ref}
       className={objStatusClasses}
       style={style}
+      // @ts-expect-error: onClick is only registered if the event target is a HTMLButtonElement
       onClick={active ? onClick : undefined}
       tabIndex={active ? 0 : undefined}
       data-icon-only={!children}


### PR DESCRIPTION
BREAKING CHANGE: **TypeScript**: the `HTMLDivElement` type has been removed from the `onClick` handler.
