### PR TITLE
refactor: make titleText required for object page sections

### DIFF
--- a/docs/MigrationGuide.mdx
+++ b/docs/MigrationGuide.mdx
@@ -457,6 +457,14 @@ The prop `portalContainer` has been removed as it is no longer needed due to the
 As the underlying `Text` component has been replaced with the UI5 Web Component, some inherited props `hyphenated` and `emptyIndicator` from the `Text` component have been removed.
 You can follow this [feature request](https://github.com/SAP/ui5-webcomponents/issues/9244) for updates.
 
+### ObjectPageSection
+
+The prop `titleText` is now required and the default value `true` has been removed for the `titleTextUppercase` prop to comply with the updated Fiori design guidelines.
+
+### ObjectPageSubSection
+
+The prop `titleText` is now required.
+
 ## Enum Changes
 
 For a better alignment with the UI5 Web Components, the following enums have been renamed:

--- a/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
@@ -729,7 +729,7 @@ describe('ObjectPage', () => {
     };
     cy.mount(<TestComp />);
 
-    cy.findByText('Lorem ipsum dolor sit amet').should('have.css', 'text-transform', 'uppercase');
+    cy.findByText('Lorem ipsum dolor sit amet').should('have.css', 'text-transform', 'none');
     cy.findByText('Etiam pellentesque').should('have.css', 'text-transform', 'none');
 
     cy.findByText('toggle uppercase').click();

--- a/packages/main/src/components/ObjectPageSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSection/index.tsx
@@ -22,13 +22,11 @@ export interface ObjectPageSectionPropTypes extends CommonProps {
   /**
    * Defines the title of the `ObjectPageSection`.
    *
-   * @default ''
    */
-  titleText?: string;
+  titleText: string;
   /**
    * Defines whether the title is always displayed in uppercase.
    *
-   * @default true
    */
   titleTextUppercase?: boolean;
   /**
@@ -61,10 +59,10 @@ export interface ObjectPageSectionPropTypes extends CommonProps {
  */
 const ObjectPageSection = forwardRef<HTMLElement, ObjectPageSectionPropTypes>((props, ref) => {
   const {
-    titleText = '',
+    titleText,
     id,
     children,
-    titleTextUppercase = true,
+    titleTextUppercase,
     className,
     style,
     hideTitleText,

--- a/packages/main/src/components/ObjectPageSubSection/index.tsx
+++ b/packages/main/src/components/ObjectPageSubSection/index.tsx
@@ -22,7 +22,7 @@ export interface ObjectPageSubSectionPropTypes extends CommonProps {
   /**
    * Defines the title of the `ObjectPageSubSection`.
    */
-  titleText?: string;
+  titleText: string;
   /**
    * Actions available for this subsection.
    *


### PR DESCRIPTION
BREAKING CHANGE: **ObjectPageSection**: the prop `titleText` is now required.
BREAKING CHANGE: **ObjectPageSection**: the default value `true` for the prop `titleTextUppercase` has been removed.
BREAKING CHANGE: **ObjectPageSubSection**: the prop `titleText` is now required.
