### PR TITLE
refactor(ObjectPage): api alignment

### DIFF
--- a/docs/MigrationGuide.mdx
+++ b/docs/MigrationGuide.mdx
@@ -65,7 +65,7 @@ Most variables can be replaced by applying the corresponding CSS classes from th
 ### Common CSS substitute classes
 
 <details>
-    <summary>Show</summary>
+  <summary>Show</summary>
 
 | Removed Variable                    | Equivalent Common CSS Class   |
 | ----------------------------------- | ----------------------------- |
@@ -125,7 +125,7 @@ Most variables can be replaced by applying the corresponding CSS classes from th
 ### Removed variables without substitute
 
 <details>
-    <summary>Show</summary>
+  <summary>Show</summary>
 
 | Removed Variable      | Property and Value             |
 | --------------------- | ------------------------------ |
@@ -181,9 +181,9 @@ The `DynamicPage` component has been replaced with the `ui5-dynamic-page` web co
 #### Replaced Props
 
 - `backgroundDesign` is not available anymore. To set the background of the page you can use standard CSS and the respective CSS variables instead:
-  - **List:** `var(--sapGroup_ContentBackground)`
-  - **Solid:** `var(--sapBackgroundColor)`
-  - **Transparent:** `transparent`
+- **List:** `var(--sapGroup_ContentBackground)`
+- **Solid:** `var(--sapBackgroundColor)`
+- **Transparent:** `transparent`
 - `alwaysShowContentHeader` has been renamed to `headerPinned`
 - `headerCollapsed` has been renamed to `headerSnapped`
 - `headerContentPinnable` (default: `true`) has been replaced by `hidePinButton` (default: `false`)
@@ -196,37 +196,37 @@ The `DynamicPage` component has been replaced with the `ui5-dynamic-page` web co
 - `onPinnedStateChange` has been replaced by `onPinButtonToggle`.
 - `onToggleHeaderContent` has been replaced by `onTitleToggle`.
 
-  ```jsx
-  // v1
-  function DynamicPageComponent(props) {
-    const [pinned, setPinned] = useState(false);
-    const [expanded, setExpanded] = useState(true);
-    return (
-      <DynamicPage
-        {...props}
-        onPinnedStateChange={(pinned) => setPinned(pinned)}
-        onToggleHeaderContent={(visible) => {
-          setExpanded(visible);
-        }}
-      />
-    );
-  }
+```jsx
+// v1
+function DynamicPageComponent(props) {
+  const [pinned, setPinned] = useState(false);
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <DynamicPage
+      {...props}
+      onPinnedStateChange={(pinned) => setPinned(pinned)}
+      onToggleHeaderContent={(visible) => {
+        setExpanded(visible);
+      }}
+    />
+  );
+}
 
-  // v2
-  function DynamicPageComponent(props) {
-    const [pinned, setPinned] = useState(false);
-    const [expanded, setExpanded] = useState(true);
-    return (
-      <DynamicPage
-        {...props}
-        onPinButtonToggle={(event) => setPinned(event.target.headerPinned)}
-        onTitleToggle={(event) => {
-          setExpanded(!event.target.headerSnapped);
-        }}
-      />
-    );
-  }
-  ```
+// v2
+function DynamicPageComponent(props) {
+  const [pinned, setPinned] = useState(false);
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <DynamicPage
+      {...props}
+      onPinButtonToggle={(event) => setPinned(event.target.headerPinned)}
+      onTitleToggle={(event) => {
+        setExpanded(!event.target.headerSnapped);
+      }}
+    />
+  );
+}
+```
 
 #### Removed Props
 
@@ -250,16 +250,16 @@ Since the `ObjectPage` isn't compatible with the `DynamicPageTitle` web componen
 - `subHeader` has been renamed to `subheading` and is now a slot.
 - `header` has been renamed to `heading` and is now a `slot`. The `font-size` isn't automatically adjusted anymore, so to keep the intended design you can leverage the new `snappedHeading` prop and apply the corresponding CSS Variables yourself. (see example below)
 
-  Example:
+Example:
 
-  ```jsx
-  <DynamicPageTitle
-    heading={<Title style={{ fontSize: 'var(--sapObjectHeader_Title_FontSize)' }}>Header Title</Title>}
-    snappedHeading={
-      <Title style={{ fontSize: 'var(--sapObjectHeader_Title_SnappedFontSize)' }}>Snapped Header Title</Title>
-    }
-  />
-  ```
+```jsx
+<DynamicPageTitle
+  heading={<Title style={{ fontSize: 'var(--sapObjectHeader_Title_FontSize)' }}>Header Title</Title>}
+  snappedHeading={
+    <Title style={{ fontSize: 'var(--sapObjectHeader_Title_SnappedFontSize)' }}>Snapped Header Title</Title>
+  }
+/>
+```
 
 #### Removed Props
 
@@ -269,24 +269,24 @@ Since the `ObjectPage` isn't compatible with the `DynamicPageTitle` web componen
 - `expandedContent` is now part of the `subheading` prop, so if you've rendered a `MessageStrip` below the `subHeader` for example, you can now render the subheading and additional content both in the same slot.
 - `snappedContent` is now part of the `snappedSubheading` prop, so if you've rendered a `MessageStrip` below the `subHeader` for example, you can now render the subheading and additional content both in the same slot.
 
-  Example for combined `subHeader` and `expanded/snappedContent` in `subheading`/`snappedSubheading`:
+Example for combined `subHeader` and `expanded/snappedContent` in `subheading`/`snappedSubheading`:
 
-  ```jsx
-  <DynamicPageTitle
-    subheading={
-      <>
-        <Label>Subheader</Label>
-        <MessageStrip>Information (only visible if header content is expanded)</MessageStrip>
-      </>
-    }
-    snappedSubheading={
-      <>
-        <Label>Snapped Subheader</Label>
-        <MessageStrip>Information (only visible if header content is collapsed (snapped))</MessageStrip>
-      </>
-    }
-  />
-  ```
+```jsx
+<DynamicPageTitle
+  subheading={
+    <>
+      <Label>Subheader</Label>
+      <MessageStrip>Information (only visible if header content is expanded)</MessageStrip>
+    </>
+  }
+  snappedSubheading={
+    <>
+      <Label>Snapped Subheader</Label>
+      <MessageStrip>Information (only visible if header content is collapsed (snapped))</MessageStrip>
+    </>
+  }
+/>
+```
 
 ### Form
 
@@ -395,21 +395,6 @@ import { Loader } from '@ui5/webcomponents-react';
 import { Loader } from '@ui5/webcomponents-react-compat';
 ```
 
-### ObjectPage
-
-The newly introduced `DynamicPage` web component comes with its own `DynamicPageHeader` and `DynamicPageTitle` components, which are unfortunately incompatible with our `ObjectPage` implementation.
-Please use the following components instead:
-
-- `headerContent` now only accepts the `ObjectPageHeader` component.
-- `headerTitle` now only accepts the `ObjectPageTitle` component.
-
-**Renamed Props:**
-
-- `a11yConfig` has been renamed to `accessibilityAttributes`
-- `a11yConfig.dynamicPageAnchorBar` has been renamed to `accessibilityAttributes.objectPageAnchorBar`
-
-Also, the namings of internal `data-component-name` attributes have been adjusted accordingly. E.g. `data-component-name="DynamicPageTitleSubHeader"` has been renamed to `data-component-name="ObjectPageTitleSubHeader"`
-
 ### Text
 
 The `Text` component has been replaced with the `ui5-text` Web Component.
@@ -493,8 +478,8 @@ Names of the following enums have changed:
 **Changed Enums:**
 
 - The properties and values for the `AnalyticalTableSelectionMode` enum has been changed.
-  - `SingleSelect` is now `Single`
-  - `MultiSelect` is now `Multiple`.
+- `SingleSelect` is now `Single`
+- `MultiSelect` is now `Multiple`.
 
 **[Column Properties](https://sap.github.io/ui5-webcomponents-react/?path=/docs/data-display-analyticaltable--docs#column-properties) Changes**
 
@@ -609,6 +594,28 @@ function MyComponent() {
 </MessageBox>
 
 ```
+
+### ObjectPage
+
+The newly introduced `DynamicPage` web component comes with its own `DynamicPageHeader` and `DynamicPageTitle` components, which are unfortunately incompatible with our `ObjectPage` implementation.
+Please use the following components instead:
+
+- `headerContent` now only accepts the `ObjectPageHeader` component.
+- `headerTitle` now only accepts the `ObjectPageTitle` component.
+
+**Renamed Props:**
+
+- `a11yConfig` has been renamed to `accessibilityAttributes`
+- `a11yConfig.dynamicPageAnchorBar` has been renamed to `accessibilityAttributes.objectPageAnchorBar`
+- `alwaysShowContentHeader` has been renamed to `headerPinned`
+- `headerContentPinnable` has been renamed to `hidePinButton` and the logic has been inverted. The pin button is now shown by default.
+
+**Removed Props:**
+
+- `showHideHeaderButton`: Hiding the expand/collapse button is not supported by design anymore.
+- `showTitleInHeaderContent`: Showing the `headerTitle` as part of the `headerContent` is not supported by design anymore.
+
+Also, the namings of internal `data-component-name` attributes have been adjusted accordingly. E.g. `data-component-name="DynamicPageTitleSubHeader"` has been renamed to `data-component-name="ObjectPageTitleSubHeader"`
 
 ### ObjectPageSection
 

--- a/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.cy.tsx
@@ -43,8 +43,7 @@ describe('ObjectPage', () => {
         headerTitle={<ObjectPageTitle header="Heading" subHeader="SubHeading" />}
         headerContent={<ObjectPageHeader>ObjectPageHeader</ObjectPageHeader>}
         onToggleHeaderContent={toggle}
-        headerContentPinnable={false}
-        showHideHeaderButton
+        hidePinButton
       >
         <ObjectPageSection id="section" titleText="Section">
           Content
@@ -81,8 +80,6 @@ describe('ObjectPage', () => {
         style={{ height: '100vh' }}
         headerTitle={<ObjectPageTitle header="Heading" subHeader="SubHeading" />}
         headerContent={<ObjectPageHeader>ObjectPageHeader</ObjectPageHeader>}
-        headerContentPinnable
-        showHideHeaderButton
         onPinnedStateChange={pin}
         data-testid="op"
       >
@@ -111,7 +108,7 @@ describe('ObjectPage', () => {
     cy.findByText('ObjectPageHeader').should('not.be.visible');
   });
 
-  it('programmatically pin header (`alwaysShowContentHeader`)', () => {
+  it('programmatically pin header (`headerPinned`)', () => {
     document.body.style.margin = '0px';
     const TestComp = ({ onPinnedStateChange }: ObjectPagePropTypes) => {
       const [pinned, setPinned] = useState(false);
@@ -133,9 +130,7 @@ describe('ObjectPage', () => {
             style={{ height: '95vh' }}
             headerTitle={<ObjectPageTitle header="Heading" subHeader="SubHeading" />}
             headerContent={<ObjectPageHeader>ObjectPageHeader</ObjectPageHeader>}
-            headerContentPinnable
-            showHideHeaderButton
-            alwaysShowContentHeader={pinned}
+            headerPinned={pinned}
             onPinnedStateChange={handlePinChange}
             data-testid="op"
           >
@@ -212,8 +207,6 @@ describe('ObjectPage', () => {
             <div style={{ height: '400px', width: '100%', background: 'lightyellow' }}>ObjectPageHeader</div>
           </ObjectPageHeader>
         }
-        headerContentPinnable
-        showHideHeaderButton
         data-testid="op"
       >
         <ObjectPageSection id="section" titleText="Section">
@@ -394,7 +387,6 @@ describe('ObjectPage', () => {
           headerTitle={DPTitle}
           headerContent={DPContent}
           data-testid="op"
-          showHideHeaderButton
           ref={ref}
           footer={withFooter && Footer}
           mode={mode}
@@ -492,7 +484,6 @@ describe('ObjectPage', () => {
           headerTitle={DPTitle}
           headerContent={DPContent}
           data-testid="op"
-          showHideHeaderButton
           ref={ref}
           footer={withFooter && Footer}
           mode={mode}

--- a/packages/main/src/components/ObjectPage/ObjectPage.module.css
+++ b/packages/main/src/components/ObjectPage/ObjectPage.module.css
@@ -41,6 +41,7 @@
   inset-block-start: 0;
   z-index: 2;
   cursor: pointer;
+  display: grid;
 
   [data-component-name='ObjectPageTitle'] {
     grid-column: 2;
@@ -168,10 +169,6 @@
 }
 
 .subSectionPopover::part(content) {
-  padding: 0;
-}
-
-.titleInHeader {
   padding: 0;
 }
 

--- a/packages/main/src/components/ObjectPage/ObjectPage.stories.tsx
+++ b/packages/main/src/components/ObjectPage/ObjectPage.stories.tsx
@@ -32,7 +32,7 @@ import {
   Text,
   Title,
   ToggleButton
-} from '../..';
+} from '../../index.js';
 import { ObjectPage } from './index.js';
 
 const meta = {
@@ -48,9 +48,7 @@ const meta = {
   },
   args: {
     mode: ObjectPageMode.Default,
-    showHideHeaderButton: true,
     selectedSectionId: 'goals',
-    headerContentPinnable: true,
     imageShapeCircle: true,
     image: SampleImage,
     style: { height: '700px' },
@@ -337,7 +335,6 @@ export const WithCustomOverflowButton: Story = {
       <>
         <ObjectPage
           style={{ width: '1000px' }}
-          showHideHeaderButton={false}
           headerTitle={
             <ObjectPageTitle
               {...titleProps}
@@ -351,7 +348,6 @@ export const WithCustomOverflowButton: Story = {
         />
         <ObjectPage
           style={{ width: '1400px' }}
-          showHideHeaderButton={false}
           headerTitle={
             <ObjectPageTitle
               {...titleProps}

--- a/packages/main/src/components/ObjectPage/index.tsx
+++ b/packages/main/src/components/ObjectPage/index.tsx
@@ -4,7 +4,6 @@ import type { TabContainerTabSelectEventDetail } from '@ui5/webcomponents/dist/T
 import AvatarSize from '@ui5/webcomponents/dist/types/AvatarSize.js';
 import {
   debounce,
-  deprecationNotice,
   enrichEventWithDetails,
   ThemingParameters,
   useStylesheet,
@@ -22,15 +21,14 @@ import type { AvatarPropTypes, TabContainerDomRef } from '../../webComponents/in
 import { Tab, TabContainer } from '../../webComponents/index.js';
 import { ObjectPageAnchorBar } from '../ObjectPageAnchorBar/index.js';
 import type {
-  ObjectPageHeaderPropTypes,
-  InternalProps as ObjectPageHeaderPropTypesWithInternals
+  InternalProps as ObjectPageHeaderPropTypesWithInternals,
+  ObjectPageHeaderPropTypes
 } from '../ObjectPageHeader/index.js';
-import { ObjectPageHeader } from '../ObjectPageHeader/index.js';
 import type { ObjectPageSectionPropTypes } from '../ObjectPageSection/index.js';
 import type { ObjectPageSubSectionPropTypes } from '../ObjectPageSubSection/index.js';
 import type {
-  ObjectPageTitlePropTypes,
-  InternalProps as ObjectPageTitlePropTypesWithInternals
+  InternalProps as ObjectPageTitlePropTypesWithInternals,
+  ObjectPageTitlePropTypes
 } from '../ObjectPageTitle/index.js';
 import { CollapsedAvatar } from './CollapsedAvatar.js';
 import { classNames, styleData } from './ObjectPage.module.css.js';
@@ -115,15 +113,9 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    */
   selectedSubSectionId?: string;
   /**
-   * Defines whether the `headerContent` is hidden by scrolling down.
+   * Defines whether the `headerContent` is pinned.
    */
-  alwaysShowContentHeader?: boolean;
-  /**
-   * Defines whether the title is displayed in the content section of the header or above the image.
-   *
-   * @deprecated: This feature will be removed with our next major release.
-   */
-  showTitleInHeaderContent?: boolean;
+  headerPinned?: boolean;
   /**
    * Defines whether the image should be displayed in a circle or in a square.<br />
    * __Note:__ If the `image` is not a `string`, this prop has no effect.
@@ -139,13 +131,9 @@ export interface ObjectPagePropTypes extends Omit<CommonProps, 'placeholder'> {
    */
   mode?: ObjectPageMode | keyof typeof ObjectPageMode;
   /**
-   * Defines whether the pin button of the header is displayed.
+   * Defines if the pin button for the `headerContent` is hidden.
    */
-  showHideHeaderButton?: boolean;
-  /**
-   * Defines whether the `headerContent` is pinnable.
-   */
-  headerContentPinnable?: boolean;
+  hidePinButton?: boolean;
   /**
    * Defines internally used accessibility properties/attributes.
    */
@@ -201,13 +189,11 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
     className,
     style,
     slot,
-    showHideHeaderButton,
     children,
     selectedSectionId,
-    alwaysShowContentHeader,
-    showTitleInHeaderContent,
+    headerPinned: headerPinnedProp,
     headerContent,
-    headerContentPinnable,
+    hidePinButton,
     accessibilityAttributes,
     placeholder,
     onSelectedSectionChange,
@@ -226,7 +212,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
     selectedSectionId ?? firstSectionId
   );
   const [selectedSubSectionId, setSelectedSubSectionId] = useState(props.selectedSubSectionId);
-  const [headerPinned, setHeaderPinned] = useState(alwaysShowContentHeader);
+  const [headerPinned, setHeaderPinned] = useState(headerPinnedProp);
   const isProgrammaticallyScrolled = useRef(false);
   const prevSelectedSectionId = useRef<string | undefined>(undefined);
 
@@ -244,21 +230,9 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
   const [headerCollapsedInternal, setHeaderCollapsedInternal] = useState<undefined | boolean>(undefined);
   const [scrolledHeaderExpanded, setScrolledHeaderExpanded] = useState(false);
   const scrollTimeout = useRef(0);
-  const titleInHeader = headerTitle && showTitleInHeaderContent;
   const [sectionSpacer, setSectionSpacer] = useState(0);
   const [currentTabModeSection, setCurrentTabModeSection] = useState(null);
   const sections = mode === ObjectPageMode.IconTabBar ? currentTabModeSection : children;
-
-  const deprecationNoticeDisplayed = useRef(false);
-  useEffect(() => {
-    if (showTitleInHeaderContent && !deprecationNoticeDisplayed.current) {
-      deprecationNotice(
-        'showTitleInHeaderContent',
-        'showTitleInHeaderContent is deprecated and will be removed with the next major release.'
-      );
-      deprecationNoticeDisplayed.current = true;
-    }
-  }, [showTitleInHeaderContent]);
 
   useEffect(() => {
     const currentSection =
@@ -433,13 +407,13 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
   }, [selectedSubSectionId, isProgrammaticallyScrolled.current, sectionSpacer]);
 
   useEffect(() => {
-    if (alwaysShowContentHeader !== undefined) {
-      setHeaderPinned(alwaysShowContentHeader);
+    if (headerPinnedProp !== undefined) {
+      setHeaderPinned(headerPinnedProp);
     }
-    if (alwaysShowContentHeader) {
+    if (headerPinnedProp) {
       onToggleHeaderContentVisibility({ detail: { visible: true } });
     }
-  }, [alwaysShowContentHeader]);
+  }, [headerPinnedProp]);
 
   const prevHeaderPinned = useRef(headerPinned);
   useEffect(() => {
@@ -626,10 +600,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
     }
   }, [isAfterScroll]);
 
-  const titleHeaderNotClickable =
-    (alwaysShowContentHeader && !headerContentPinnable) ||
-    !headerContent ||
-    (!showHideHeaderButton && !headerContentPinnable);
+  const titleHeaderNotClickable = (headerPinnedProp && hidePinButton) || !headerContent || hidePinButton;
 
   const onTitleClick = useCallback(
     (e) => {
@@ -643,31 +614,25 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
 
   const snappedHeaderInObjPage = headerTitle && headerTitle.props.snappedContent && headerCollapsed === true && !!image;
 
-  const hasHeaderContent = !!headerContent;
-  const renderTitleSection = useCallback(
-    (inHeader = false) => {
-      const titleInHeaderClass = inHeader ? classNames.titleInHeader : undefined;
-
-      if (headerTitle?.props && headerTitle.props?.showSubHeaderRight === undefined) {
-        return cloneElement(headerTitle as ReactElement<ObjectPageTitlePropsWithDataAttributes>, {
-          showSubHeaderRight: true,
-          className: clsx(titleInHeaderClass, headerTitle?.props?.className),
-          onToggleHeaderContentVisibility: onTitleClick,
-          'data-not-clickable': titleHeaderNotClickable,
-          'data-header-content-visible': headerContent && headerCollapsed !== true,
-          'data-is-snapped-rendered-outside': snappedHeaderInObjPage
-        });
-      }
+  const renderTitleSection = () => {
+    if (headerTitle?.props && headerTitle.props?.showSubHeaderRight === undefined) {
       return cloneElement(headerTitle as ReactElement<ObjectPageTitlePropsWithDataAttributes>, {
-        className: clsx(titleInHeaderClass, headerTitle?.props?.className),
+        showSubHeaderRight: true,
+        className: clsx(headerTitle?.props?.className),
         onToggleHeaderContentVisibility: onTitleClick,
         'data-not-clickable': titleHeaderNotClickable,
         'data-header-content-visible': headerContent && headerCollapsed !== true,
         'data-is-snapped-rendered-outside': snappedHeaderInObjPage
       });
-    },
-    [headerTitle, titleHeaderNotClickable, onTitleClick, headerCollapsed, snappedHeaderInObjPage, hasHeaderContent]
-  );
+    }
+    return cloneElement(headerTitle as ReactElement<ObjectPageTitlePropsWithDataAttributes>, {
+      className: clsx(headerTitle?.props?.className),
+      onToggleHeaderContentVisibility: onTitleClick,
+      'data-not-clickable': titleHeaderNotClickable,
+      'data-header-content-visible': headerContent && headerCollapsed !== true,
+      'data-is-snapped-rendered-outside': snappedHeaderInObjPage
+    });
+  };
 
   const isInitial = useRef(true);
   useEffect(() => {
@@ -693,40 +658,14 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
         children: (
           <div className={classNames.headerContainer} data-component-name="ObjectPageHeaderContainer">
             {avatar}
-            {(headerContent.props.children || titleInHeader) && (
-              <div data-component-name="ObjectPageHeaderContent">
-                {titleInHeader && renderTitleSection(true)}
-                {headerContent.props.children}
-              </div>
+            {headerContent.props.children && (
+              <div data-component-name="ObjectPageHeaderContent">{headerContent.props.children}</div>
             )}
           </div>
         )
       });
-    } else if (titleInHeader) {
-      return (
-        <ObjectPageHeader
-          topHeaderHeight={topHeaderHeight}
-          style={headerCollapsed === true ? { position: 'absolute', visibility: 'hidden' } : undefined}
-          headerPinned={headerPinned || scrolledHeaderExpanded}
-          ref={componentRefHeaderContent}
-        >
-          <div className={classNames.headerContainer} data-component-name="ObjectPageHeaderContainer">
-            {avatar}
-            <div data-component-name="ObjectPageHeaderContent">{titleInHeader && renderTitleSection(true)}</div>
-          </div>
-        </ObjectPageHeader>
-      );
     }
-  }, [
-    headerContent,
-    topHeaderHeight,
-    headerPinned,
-    scrolledHeaderExpanded,
-    titleInHeader,
-    avatar,
-    headerContentRef,
-    renderTitleSection
-  ]);
+  }, [headerContent, topHeaderHeight, headerPinned, scrolledHeaderExpanded, avatar, headerContentRef]);
 
   const onTabItemSelect = (event) => {
     if (typeof onBeforeNavigate === 'function') {
@@ -810,7 +749,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
   const objectPageStyles: CSSProperties = {
     ...style
   };
-  if (headerCollapsed === true && (headerContent || titleInHeader)) {
+  if (headerCollapsed === true && headerContent) {
     objectPageStyles[ObjectPageCssVariables.titleFontSize] = ThemingParameters.sapObjectHeader_Title_SnappedFontSize;
   }
 
@@ -837,8 +776,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
         style={{
           gridAutoColumns: `min-content ${
             headerTitle && image && headerCollapsed === true ? `calc(100% - 3rem - 1rem)` : '100%'
-          }`,
-          display: !showTitleInHeaderContent || headerCollapsed === true ? 'grid' : 'none'
+          }`
         }}
       >
         {headerTitle && image && headerCollapsed === true && (
@@ -866,8 +804,7 @@ const ObjectPage = forwardRef<HTMLDivElement, ObjectPagePropTypes>((props, ref) 
         >
           <ObjectPageAnchorBar
             headerContentVisible={headerContent && headerCollapsed !== true}
-            headerContentPinnable={headerContentPinnable}
-            showHideHeaderButton={showHideHeaderButton}
+            hidePinButton={hidePinButton}
             headerPinned={headerPinned}
             accessibilityAttributes={accessibilityAttributes}
             onToggleHeaderContentVisibility={onToggleHeaderContentVisibility}

--- a/packages/main/src/components/ObjectPageAnchorBar/index.tsx
+++ b/packages/main/src/components/ObjectPageAnchorBar/index.tsx
@@ -29,13 +29,9 @@ interface ObjectPageAnchorBarPropTypes extends CommonProps {
    */
   headerContentVisible: boolean;
   /**
-   * Determines if the header content is pinnable .
+   * Defines if the pin button is hidden.
    */
-  headerContentPinnable: boolean;
-  /**
-   * Determines if the hide header button is shown .
-   */
-  showHideHeaderButton: boolean;
+  hidePinButton: boolean;
   /**
    * Determines if the header is initially pinned .
    */
@@ -71,9 +67,8 @@ interface ObjectPageAnchorBarPropTypes extends CommonProps {
  */
 const ObjectPageAnchorBar = forwardRef<HTMLElement, ObjectPageAnchorBarPropTypes>((props, ref) => {
   const {
-    showHideHeaderButton,
     headerContentVisible,
-    headerContentPinnable,
+    hidePinButton,
     headerPinned,
     style,
     accessibilityAttributes,
@@ -85,8 +80,8 @@ const ObjectPageAnchorBar = forwardRef<HTMLElement, ObjectPageAnchorBarPropTypes
 
   useStylesheet(styleData, ObjectPageAnchorBar.displayName);
   const showHideHeaderBtnRef = useRef<ButtonDomRef>(null);
-  const shouldRenderHeaderPinnableButton = headerContentPinnable && headerContentVisible;
-  const showBothActions = shouldRenderHeaderPinnableButton && showHideHeaderButton;
+  const shouldRenderHeaderPinnableButton = !hidePinButton && headerContentVisible;
+  const showBothActions = shouldRenderHeaderPinnableButton;
 
   const onPinHeader = useCallback(
     (e) => {
@@ -124,28 +119,26 @@ const ObjectPageAnchorBar = forwardRef<HTMLElement, ObjectPageAnchorBarPropTypes
       data-component-name="ObjectPageAnchorBar"
       style={style}
       role={accessibilityAttributes?.objectPageAnchorBar?.role}
-      className={showHideHeaderButton || headerContentPinnable ? classNames.container : null}
+      className={!hidePinButton ? classNames.container : null}
       ref={ref}
     >
-      {showHideHeaderButton && (
-        <Button
-          ref={showHideHeaderBtnRef}
-          icon={!headerContentVisible ? iconArrowDown : iconArrowUp}
-          data-ui5wcr-dynamic-page-header-action=""
-          className={clsx(
-            classNames.anchorBarActionButton,
-            classNames.anchorBarActionButtonExpandable,
-            showBothActions && classNames.anchorBarActionPinnableAndExpandable
-          )}
-          style={anchorButtonVariables}
-          onClick={onToggleHeaderButtonClick}
-          onMouseOver={onHoverToggleButton}
-          onMouseLeave={onHoverToggleButton}
-          tooltip={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
-          accessibleName={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
-          data-component-name="ObjectPageAnchorBarExpandBtn"
-        />
-      )}
+      <Button
+        ref={showHideHeaderBtnRef}
+        icon={!headerContentVisible ? iconArrowDown : iconArrowUp}
+        data-ui5wcr-dynamic-page-header-action=""
+        className={clsx(
+          classNames.anchorBarActionButton,
+          classNames.anchorBarActionButtonExpandable,
+          showBothActions && classNames.anchorBarActionPinnableAndExpandable
+        )}
+        style={anchorButtonVariables}
+        onClick={onToggleHeaderButtonClick}
+        onMouseOver={onHoverToggleButton}
+        onMouseLeave={onHoverToggleButton}
+        tooltip={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
+        accessibleName={i18nBundle.getText(!headerContentVisible ? EXPAND_HEADER : COLLAPSE_HEADER)}
+        data-component-name="ObjectPageAnchorBarExpandBtn"
+      />
       {shouldRenderHeaderPinnableButton && (
         <ToggleButton
           icon={headerPinned ? iconPushPinOn : iconPushPinOff}


### PR DESCRIPTION
BREAKING CHANGE: the props `showHideHeaderButton` and `showTitleInHeaderContent` have been removed.
BREAKING CHANGE: the prop `alwaysShowContentHeader` has been renamed to `headerPinned`
BREAKING CHANGE: the prop `headerContentPinnable` has been renamed to `hidePinButton` and its logic has been inverted. The pin button is now shown by default.