### PR TITLE
fix(DynamicPage/ObjectPage): increase header z-index

### DIFF
--- a/packages/main/src/components/DynamicPage/DynamicPage.module.css
+++ b/packages/main/src/components/DynamicPage/DynamicPage.module.css
@@ -51,7 +51,7 @@
   position: sticky;
   box-shadow: var(--sapContent_HeaderShadow);
   height: 1px;
-  z-index: 2;
+  z-index: 3;
 
   > section[data-component-name='DynamicPageAnchorBar'] {
     inset-block-start: 0;

--- a/packages/main/src/components/DynamicPageTitle/DynamicPageTitle.module.css
+++ b/packages/main/src/components/DynamicPageTitle/DynamicPageTitle.module.css
@@ -9,7 +9,7 @@
   justify-content: space-between;
   position: sticky;
   inset-block-start: 0;
-  z-index: 2;
+  z-index: 3;
   cursor: pointer;
 
   &[data-not-clickable='true'] {

--- a/packages/main/src/components/ObjectPage/ObjectPage.module.css
+++ b/packages/main/src/components/ObjectPage/ObjectPage.module.css
@@ -39,7 +39,7 @@
   background-color: var(--sapObjectHeader_Background);
   position: sticky;
   inset-block-start: 0;
-  z-index: 2;
+  z-index: 4;
   cursor: pointer;
 
   [data-component-name='DynamicPageTitle'] {
@@ -93,12 +93,12 @@
 
 .anchorBar {
   position: sticky;
-  z-index: 2;
+  z-index: 4;
 }
 
 .tabContainer {
   position: sticky;
-  z-index: 1;
+  z-index: 3;
 }
 
 .tabContainerComponent {


### PR DESCRIPTION
Prevents that parts of some Web Components (e.g. `Slider`) are shining through the header content

Fixes #6107