### PR TITLE
fix(UI5CustomEvent - TypeScript): correctly `currentTarget` type

### DIFF
--- a/packages/main/src/types/Ui5CustomEvent.ts
+++ b/packages/main/src/types/Ui5CustomEvent.ts
@@ -1,3 +1,5 @@
-export interface Ui5CustomEvent<EventTarget = HTMLElement, Detail = never> extends Omit<CustomEvent<Detail>, 'target'> {
+export interface Ui5CustomEvent<EventTarget = HTMLElement, Detail = never>
+  extends Omit<CustomEvent<Detail>, 'target' | 'currentTarget'> {
   target: EventTarget;
+  currentTarget: EventTarget | null;
 }


### PR DESCRIPTION
Fixes #6136