### PR TITLE
fix(MessageBox): don't throw error if `onClose` is not passed

### DIFF
--- a/packages/main/src/components/MessageBox/MessageBox.cy.tsx
+++ b/packages/main/src/components/MessageBox/MessageBox.cy.tsx
@@ -220,4 +220,14 @@ describe('MessageBox', () => {
     cy.findByText('Confirmation').should('not.exist');
     cy.findByText('Custom Header').should('be.visible');
   });
+
+  it('#6215 - should not crash if no onClose handler is passed', () => {
+    cy.on('uncaught:exception', (err) => {
+      if (err.message.contains('onClose is not a function')) {
+        throw err;
+      }
+    });
+    cy.mount(<MessageBox open>Content</MessageBox>);
+    cy.findByText('OK').click();
+  });
 });

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -190,14 +190,16 @@ const MessageBox = forwardRef<DialogDomRef, MessageBoxPropTypes>((props, ref) =>
     if (typeof props.onBeforeClose === 'function') {
       props.onBeforeClose(e);
     }
-    if (e.detail.escPressed) {
+    if (e.detail.escPressed && typeof onClose === 'function') {
       onClose(undefined, e.detail.escPressed);
     }
   };
 
   const handleOnClose: ButtonPropTypes['onClick'] = (e) => {
     const { action } = e.currentTarget.dataset;
-    onClose(action);
+    if (typeof onClose === 'function') {
+      onClose(action);
+    }
   };
 
   const messageBoxId = useId();


### PR DESCRIPTION
Fixes #6215