### PR TITLE
fix(MessageBox): don't throw error if onClose is not passed

### DIFF
--- a/packages/main/src/components/MessageBox/MessageBox.cy.tsx
+++ b/packages/main/src/components/MessageBox/MessageBox.cy.tsx
@@ -233,4 +233,14 @@ describe('MessageBox', () => {
     cy.findByText('Confirmation').should('not.exist');
     cy.findByText('Custom Header').should('be.visible');
   });
+
+  it('#6215 - should not crash if no onClose handler is passed', () => {
+    cy.on('uncaught:exception', (err) => {
+      if (err.message.contains('onClose is not a function')) {
+        throw err;
+      }
+    });
+    cy.mount(<MessageBox open>Content</MessageBox>);
+    cy.findByText('OK').click();
+  });
 });

--- a/packages/main/src/components/MessageBox/index.tsx
+++ b/packages/main/src/components/MessageBox/index.tsx
@@ -191,7 +191,9 @@ const MessageBox = forwardRef<DialogDomRef, MessageBoxPropTypes>((props, ref) =>
   const handleOnClose = (e) => {
     const { action } = e.target.dataset;
     stopPropagation(e);
-    onClose(enrichEventWithDetails(e, { action }));
+    if (typeof onClose === 'function') {
+      onClose(enrichEventWithDetails(e, { action }));
+    }
   };
 
   const messageBoxId = useIsomorphicId();


### PR DESCRIPTION
Fixes #6215
