### PR TITLE
fix(AnalyticalTable): offer limited support for `infiniteScroll` combined with a grouped table

### DIFF
--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -276,6 +276,7 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
 
   const tableState: AnalyticalTableState = tableInstanceRef.current.state;
   const { triggerScroll } = tableState;
+  const isGrouped = !!tableState.groupBy.length;
 
   const noDataTextI18n = i18nBundle.getText(LIST_NO_DATA);
   const noDataTextFiltered = i18nBundle.getText(NO_DATA_FILTERED);
@@ -800,6 +801,7 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
                 rows={rows}
                 handleExternalScroll={handleBodyScroll}
                 visibleRows={internalVisibleRowCount}
+                isGrouped={isGrouped}
               >
                 <VirtualTableBody
                   scrollContainerRef={scrollContainerRef}

--- a/packages/main/src/components/AnalyticalTable/types/index.ts
+++ b/packages/main/src/components/AnalyticalTable/types/index.ts
@@ -692,6 +692,8 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
    * Defines whether columns are groupable.
    *
    * __Note:__ This prop has no effect when `isTreeTable` is true or `renderRowSubComponent` is set.
+   *
+   * __Note:__ It is not recommended to use grouping in combination with `infiniteScroll` as there is no concept for this configuration.
    */
   groupable?: boolean;
   /**
@@ -746,6 +748,8 @@ export interface AnalyticalTablePropTypes extends Omit<CommonProps, 'title'> {
   columnOrder?: string[];
   /**
    * Defines whether infinite scroll is active.
+   *
+   * __Note:__ It is not recommended to use this prop in combination with a grouped table, as there is no concept for this configuration.
    */
   infiniteScroll?: boolean;
   /**


### PR DESCRIPTION
Using `infiniteScroll` with a grouped table can result in an odd user experience. For example, when rows are lazy-loaded via scrolling, new rows might only be added to existing groups. This won't change the scroll container's height, potentially forcing the user to scroll down again to load more rows.
Therefore (and as we don't have a concept for this behavior) __it's not recommended using a grouped table in combination with `infiniteScroll`__!