### PR TITLE
feat(cypress-commands): support cypress v14

### DIFF
--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -1,8 +1,8 @@
-import type { MountOptions, MountReturn } from 'cypress/react18';
-import { mount } from 'cypress/react18';
-import type { ReactNode } from 'react';
 import type { ThemeProviderPropTypes } from '@ui5/webcomponents-react';
 import { ThemeProvider } from '@ui5/webcomponents-react';
+import type { MountOptions, MountReturn } from 'cypress/react';
+import { mount } from 'cypress/react';
+import type { ReactNode } from 'react';
 
 declare global {
   namespace Cypress {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "chromatic": "^11.0.0",
     "cssnano": "^7.0.0",
-    "cypress": "13.17.0",
+    "cypress": "14.0.0",
     "cypress-real-events": "^1.8.1",
     "dedent": "^1.0.0",
     "documentation": "14.0.3",

--- a/packages/cypress-commands/TestSetup.mdx
+++ b/packages/cypress-commands/TestSetup.mdx
@@ -15,7 +15,7 @@ UI5 Web Components for React is using [Cypress](https://www.cypress.io/) as pref
 When launching Cypress the first time you're guided through the setup, which then will create a [configuration file](https://docs.cypress.io/guides/references/configuration) for you. You can use any configuration you like, but since we're heavily relying on web-components, we recommend traversing the shadow DOM per default:
 
 ```js
-includeShadowDom: true
+includeShadowDom: true;
 ```
 
 [Here](https://docs.cypress.io/guides/component-testing/react/overview) you can find the Cypress Quickstart tutorial for React.
@@ -57,7 +57,7 @@ You can define the command for example in the `commands.ts/js` file:
 <summary>Example file</summary>
 
 ```tsx
-import { mount } from 'cypress/react18';
+import { mount } from 'cypress/react';
 import { ThemeProvider } from '@ui5/webcomponents-react';
 
 declare global {

--- a/packages/cypress-commands/package.json
+++ b/packages/cypress-commands/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "@ui5/webcomponents": "~2.6.0",
     "@ui5/webcomponents-base": "~2.6.0",
-    "cypress": "^12.0.0 || ^13.0.0"
+    "cypress": "^12 || ^13 || ^14"
   },
   "peerDependenciesMeta": {
     "@ui5/webcomponents": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5936,7 +5936,7 @@ __metadata:
   peerDependencies:
     "@ui5/webcomponents": ~2.6.0
     "@ui5/webcomponents-base": ~2.6.0
-    cypress: ^12.0.0 || ^13.0.0
+    cypress: ^12 || ^13 || ^14
   peerDependenciesMeta:
     "@ui5/webcomponents":
       optional: true
@@ -9021,9 +9021,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.17.0":
-  version: 13.17.0
-  resolution: "cypress@npm:13.17.0"
+"cypress@npm:14.0.0":
+  version: 14.0.0
+  resolution: "cypress@npm:14.0.0"
   dependencies:
     "@cypress/request": "npm:^3.0.6"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -9070,7 +9070,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/159ce620e32d2785082aaa1f4f30f203dcec466df4a8e80dfa299035358772fd513c35820070ba8db52e2bf58078a372ff7009068e26967f993656e7da62e221
+  checksum: 10c0/231af826d394b9a9f35200ab56e531e911f774b86b2ecb17a3183685982ac93d534e7c80cfe24ca36f74c99525025472fe28a3ccf2f246c8e67f85ecb768086b
   languageName: node
   linkType: hard
 
@@ -23121,7 +23121,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.2.0"
     chromatic: "npm:^11.0.0"
     cssnano: "npm:^7.0.0"
-    cypress: "npm:13.17.0"
+    cypress: "npm:14.0.0"
     cypress-real-events: "npm:^1.8.1"
     dedent: "npm:^1.0.0"
     documentation: "npm:14.0.3"


### PR DESCRIPTION
Allows Cypress v14 as peer dependency of `@ui5/webcomponents-cypress-commands` and updated our own cypress to v14.
Examples and Templates require this feature to be released first.