### PR TITLE
chore(deps): downgrade TypeScript to `v5.7.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "postcss-nesting": "^13.0.0",
     "prettier": "^3.0.0",
     "rimraf": "^6.0.0",
-    "typescript": "5.8.2",
+    "typescript": "5.7.3",
     "typescript-eslint": "^8.8.0",
     "vite": "^6.0.0",
     "vite-plugin-istanbul": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23518,13 +23518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.2":
-  version: 5.8.2
-  resolution: "typescript@npm:5.8.2"
+"typescript@npm:5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
+  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
   languageName: node
   linkType: hard
 
@@ -23548,13 +23548,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
-  version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
+  checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
   languageName: node
   linkType: hard
 
@@ -23667,7 +23667,7 @@ __metadata:
     rimraf: "npm:^6.0.0"
     storybook: "npm:8.6.4"
     tocbot: "npm:4.35.0"
-    typescript: "npm:5.8.2"
+    typescript: "npm:5.7.3"
     typescript-eslint: "npm:^8.8.0"
     vite: "npm:^6.0.0"
     vite-plugin-istanbul: "npm:^7.0.0"


### PR DESCRIPTION
Storybook currently only supports `typescript` < `5.8.0`