### PR TITLE
fix(VariantManagement): allow quotes in `VariantItem` name

### DIFF
--- a/packages/main/src/components/VariantManagement/index.tsx
+++ b/packages/main/src/components/VariantManagement/index.tsx
@@ -228,7 +228,7 @@ const VariantManagement = forwardRef<HTMLDivElement, VariantManagementPropTypes>
           const castChild = child as ReactElement<VariantItemPropTypes>;
           let updatedProps: Omit<SelectedVariant, 'children' | 'variantItem'> = {};
           const currentVariant = popoverRef.current.querySelector(
-            `ui5-li[data-children="${castChild.props.children}"]`
+            `ui5-li[data-children="${CSS.escape(castChild.props.children)}"]`
           );
           callbackProperties.prevVariants.push(castChild.props);
           if (defaultView) {


### PR DESCRIPTION
Fixes #7106 