### PR TITLE
fix: attach ui5-webcomponents event handlers before browser paint

### DIFF
--- a/packages/base/src/wrapper/withWebComponent.tsx
+++ b/packages/base/src/wrapper/withWebComponent.tsx
@@ -190,7 +190,7 @@ export const withWebComponent = <Props extends Record<string, any>, RefType = Ui
       });
     }, [Component, ...propsToApply]);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       setAttachEvents(true);
     }, []);
 


### PR DESCRIPTION
Fixes #7217 