### PR TITLE
fix(cypress-commands): make the options optional for clickUi5ListItemByText

### DIFF
--- a/packages/cypress-commands/src/commands.ts
+++ b/packages/cypress-commands/src/commands.ts
@@ -74,7 +74,7 @@ declare global {
        * cy.get('[ui5-list]').clickUi5ListItemByText("List Item")
        * cy.clickUi5ListItemByText("List Item")
        */
-      clickUi5ListItemByText(text: string, options: Partial<ClickOptions>): Chainable<Element>;
+      clickUi5ListItemByText(text: string, options?: Partial<ClickOptions>): Chainable<Element>;
 
       /**
        * Click on an `ui5-option` of the `ui5-select` component by text.
@@ -194,15 +194,15 @@ Cypress.Commands.add('closeUi5PopupWithEsc', () => {
   cy.get('body').type('{esc}', { force: true });
 });
 
-Cypress.Commands.add('clickUi5ListItemByText', { prevSubject: 'optional' }, (subject, text) => {
+Cypress.Commands.add('clickUi5ListItemByText', { prevSubject: 'optional' }, (subject, text, options = {}) => {
   cy.document().then((doc) => {
     const _subject = (subject as Cypress.JQueryWithSelector<UI5Element>)?.[0] || doc;
     const li = _subject.querySelector(`[text="${text}"]`);
 
     if (li) {
-      cy.wrap(li).click();
+      cy.wrap(li).click(options);
     } else {
-      cy.wrap(_subject).contains(text).click();
+      cy.wrap(_subject).contains(text).click(options);
     }
   });
 });

--- a/packages/cypress-commands/src/commands.ts
+++ b/packages/cypress-commands/src/commands.ts
@@ -69,12 +69,12 @@ declare global {
        * __Note:__ Chaining this command to a `ui5-list` selector is recommended.
        *
        * @param {string} text The text of the list item that should be clicked.
-       * @param options ClickOptions
+       * @param {Partial<ClickOptions>} [options] ClickOptions (without `force`)
        * @example
        * cy.get('[ui5-list]').clickUi5ListItemByText("List Item")
        * cy.clickUi5ListItemByText("List Item")
        */
-      clickUi5ListItemByText(text: string, options?: Partial<ClickOptions>): Chainable<Element>;
+      clickUi5ListItemByText(text: string, options?: Partial<Omit<ClickOptions, 'force'>>): Chainable<Element>;
 
       /**
        * Click on an `ui5-option` of the `ui5-select` component by text.
@@ -85,7 +85,7 @@ declare global {
        * @param options ClickOptions
        *
        *
-       * @example cy.get('[ui5-select]').clickUi5SelectOptionByText('Option2');*
+       * @example cy.get('[ui5-select]').clickUi5SelectOptionByText('Option2');
        */
       clickUi5SelectOptionByText(text: string, options?: Partial<ClickOptions>): Chainable<Element>;
 


### PR DESCRIPTION
In the last commit for `cypress-commands/src/commands.ts`, new `options` parameter is added as a mandatory parameter for function `clickUi5ListItemByText` but it's not used.

It should be optional as other functions and the default value should be `{}`.

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents-react/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents-react/blob/main/CONTRIBUTING.md#contribute-code) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents-react/blob/main/docs/Guidelines.md#commit-message-style)
