### PR TITLE
docs(useSyncRef): add jsdoc

### DIFF
--- a/packages/base/src/hooks/useSyncRef.ts
+++ b/packages/base/src/hooks/useSyncRef.ts
@@ -1,11 +1,32 @@
 'use client';
 
-import type { MutableRefObject, Ref, RefCallback } from 'react';
+import type { RefObject, Ref, RefCallback } from 'react';
 import { useCallback, useRef } from 'react';
 
-export function useSyncRef<RefType = never>(
-  ref: Ref<RefType>,
-): [RefCallback<RefType>, MutableRefObject<RefType | null>] {
+/**
+ * A React hook that synchronizes an external ref (callback or object ref) with an internal ref.
+ *
+ * @example
+ * ```tsx
+ * const MyComponent = forwardRef<HTMLDivElement, PropTypes>((props, ref) => {
+ *   const [componentRef, localRef] = useSyncRef<HTMLDivElement>(ref);
+ *
+ *   useEffect(() => {
+ *     // `localRef.current` is always the latest DOM node (or `null`)
+ *     console.log('current node:', localRef.current);
+ *   }, []);
+ *
+ *   return <div ref={componentRef}>Hello World!</div>;
+ * });
+ * ```
+ *
+ * @returns [componentRef, localRef]
+ * A tuple containing:
+ *   - `componentRef`: a stable callback ref to attach to React elements. When the node
+ *      updates, it will forward the node to the external `ref` and update the internal one.
+ *   - `localRef`: an internal, ref object that always holds the latest node for synchronous reads.
+ */
+export function useSyncRef<RefType = never>(ref: Ref<RefType>): [RefCallback<RefType>, RefObject<RefType | null>] {
   const localRef = useRef<RefType | null>(null);
 
   const componentRef = useCallback(
@@ -15,7 +36,7 @@ export function useSyncRef<RefType = never>(
           ref(node);
         }
         if ({}.hasOwnProperty.call(ref, 'current')) {
-          (ref as MutableRefObject<RefType>).current = node;
+          (ref as RefObject<RefType>).current = node;
         }
       }
       localRef.current = node;

--- a/packages/base/src/hooks/useSyncRef.ts
+++ b/packages/base/src/hooks/useSyncRef.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { RefObject, Ref, RefCallback } from 'react';
+import type { MutableRefObject, Ref, RefCallback } from 'react';
 import { useCallback, useRef } from 'react';
 
 /**
@@ -24,9 +24,11 @@ import { useCallback, useRef } from 'react';
  * A tuple containing:
  *   - `componentRef`: a stable callback ref to attach to React elements. When the node
  *      updates, it will forward the node to the external `ref` and update the internal one.
- *   - `localRef`: an internal, ref object that always holds the latest node for synchronous reads.
+ *   - `localRef`: an internal, ref object that holds the latest node for synchronous reads.
  */
-export function useSyncRef<RefType = never>(ref: Ref<RefType>): [RefCallback<RefType>, RefObject<RefType | null>] {
+export function useSyncRef<RefType = never>(
+  ref: Ref<RefType>,
+): [RefCallback<RefType>, MutableRefObject<RefType | null>] {
   const localRef = useRef<RefType | null>(null);
 
   const componentRef = useCallback(
@@ -36,7 +38,7 @@ export function useSyncRef<RefType = never>(ref: Ref<RefType>): [RefCallback<Ref
           ref(node);
         }
         if ({}.hasOwnProperty.call(ref, 'current')) {
-          (ref as RefObject<RefType>).current = node;
+          (ref as MutableRefObject<RefType>).current = node;
         }
       }
       localRef.current = node;

--- a/packages/base/src/hooks/useSyncRef.ts
+++ b/packages/base/src/hooks/useSyncRef.ts
@@ -4,7 +4,7 @@ import type { RefObject, Ref, RefCallback } from 'react';
 import { useCallback, useRef } from 'react';
 
 /**
- * A React hook that synchronizes an external ref (callback or object ref) with an internal ref.
+ * A hook that synchronizes an external ref (callback or object) with an internal ref.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
This PR now only adds the JsDoc comment, as replacing the deprecated `MutableRefObject` type is leading to ts-errors in React18