### PR TITLE
fix(AnalyticalTable): update loading indicator and overlay styles

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.module.css
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.module.css
@@ -12,6 +12,22 @@
   }
 }
 
+.tableContainerWithScrollBar {
+  position: relative;
+
+  &:has(> .overlay) {
+    > :not(.overlay) {
+      opacity: var(--sapContent_DisabledOpacity);
+    }
+  }
+
+  &:has(> .busyIndicator) {
+    > :not(.busyIndicator) {
+      opacity: var(--sapContent_DisabledOpacity);
+    }
+  }
+}
+
 .table {
   position: relative;
   width: 100%;
@@ -37,10 +53,6 @@
   }
 }
 
-.tableContainerWithScrollBar {
-  position: relative;
-}
-
 .busyIndicator {
   position: absolute;
   z-index: 1;
@@ -52,8 +64,6 @@
   position: absolute;
   z-index: 1;
   inset: 0;
-  background: var(--sapGroup_ContentBackground);
-  opacity: 0.8;
 
   &:focus {
     outline-offset: calc(-1 * var(--sapContent_FocusWidth));

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -756,12 +756,8 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
               active={true}
               delay={loadingDelay}
               data-component-name="AnalyticalTableBusyIndicator"
-            >
-              {/*todo: This is necessary; otherwise, the overlay bg color will not be applied. https://github.com/SAP/ui5-webcomponents/issues/9723 */}
-              <span />
-            </BusyIndicator>
+            />
           )}
-          {/*todo: use global CSS once --sapBlockLayer_Opacity is available*/}
           {showOverlay && (
             <>
               <span id={invalidTableTextId} className={classNames.hiddenA11yText} aria-hidden="true">


### PR DESCRIPTION
 > Please note that the default visualisation for controls is Disabled control and BusyIndicator on top.

Therefore we don't need to apply a different overlay bg color or similar and setting `--sapContent_DisabledOpacity` is sufficient.