### PR TITLE
feat(SelectDialog): add `headerTextLevel` prop

### DIFF
--- a/packages/main/src/components/SelectDialog/SelectDialog.cy.tsx
+++ b/packages/main/src/components/SelectDialog/SelectDialog.cy.tsx
@@ -27,13 +27,20 @@ describe('SelectDialog', () => {
     );
     cy.findByText('Select Dialog')
       .should('have.css', 'grid-column-start', 'titleStart')
-      .should('have.css', 'grid-column-end', 'titleCenter');
+      .and('have.css', 'grid-column-end', 'titleCenter')
+      .and('have.attr', 'level', 'H1');
     cy.mount(
       <SelectDialog headerText="Select Dialog" headerTextAlignCenter open>
         {listItems}
       </SelectDialog>,
     );
-    cy.findByText('Select Dialog').should('have.css', 'grid-area', 'titleCenter');
+    cy.findByText('Select Dialog').should('have.css', 'grid-area', 'titleCenter').and('have.attr', 'level', 'H1');
+    cy.mount(
+      <SelectDialog headerText="Select Dialog" open headerTextLevel={'H2'}>
+        {listItems}
+      </SelectDialog>,
+    );
+    cy.findByText('Select Dialog').should('have.attr', 'level', 'H2');
   });
 
   it('selection', () => {

--- a/packages/main/src/components/SelectDialog/index.tsx
+++ b/packages/main/src/components/SelectDialog/index.tsx
@@ -67,6 +67,14 @@ export interface SelectDialogPropTypes
    */
   headerTextAlignCenter?: boolean;
   /**
+   * Defines the aria-level of the `headerText`.
+   * Available options are: `"H1"` to `"H6"`.
+   * This property does not influence the style of the `headerText`.
+   *
+   * @default "H1"
+   */
+  headerTextLevel?: TitleLevel | keyof typeof TitleLevel;
+  /**
    * Overwrites the default text for the confirmation button.
    */
   confirmButtonText?: string;
@@ -150,6 +158,7 @@ const SelectDialog = forwardRef<DialogDomRef, SelectDialogPropTypes>((props, ref
     growing,
     headerText,
     headerTextAlignCenter,
+    headerTextLevel = TitleLevel.H1,
     listProps = {},
     selectionMode = ListSelectionMode.Single,
     numberOfSelectedItems,
@@ -305,7 +314,7 @@ const SelectDialog = forwardRef<DialogDomRef, SelectDialogPropTypes>((props, ref
         )}
         <Title
           className={clsx(classNames.title, headerTextAlignCenter && classNames.titleCenterAlign)}
-          level={TitleLevel.H1}
+          level={headerTextLevel}
         >
           {headerText}
         </Title>

--- a/packages/main/src/components/SelectDialog/index.tsx
+++ b/packages/main/src/components/SelectDialog/index.tsx
@@ -4,6 +4,7 @@ import ButtonDesign from '@ui5/webcomponents/dist/types/ButtonDesign.js';
 import IconMode from '@ui5/webcomponents/dist/types/IconMode.js';
 import InputType from '@ui5/webcomponents/dist/types/InputType.js';
 import ListSelectionMode from '@ui5/webcomponents/dist/types/ListSelectionMode.js';
+import TitleLevel from '@ui5/webcomponents/dist/types/TitleLevel.js';
 import iconDecline from '@ui5/webcomponents-icons/dist/decline.js';
 import iconSearch from '@ui5/webcomponents-icons/dist/search.js';
 import { enrichEventWithDetails, useI18nBundle, useStylesheet, useSyncRef } from '@ui5/webcomponents-react-base';
@@ -302,7 +303,10 @@ const SelectDialog = forwardRef<DialogDomRef, SelectDialogPropTypes>((props, ref
             {i18nBundle.getText(CLEAR)}
           </Button>
         )}
-        <Title className={clsx(classNames.title, headerTextAlignCenter && classNames.titleCenterAlign)}>
+        <Title
+          className={clsx(classNames.title, headerTextAlignCenter && classNames.titleCenterAlign)}
+          level={TitleLevel.H1}
+        >
           {headerText}
         </Title>
         {showClearButton && (


### PR DESCRIPTION
#7594 needs to be merged first.

Closes #7593
Related to: #7568