### PR TITLE
ci: publish packages with OIDC trust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
             --create-release github
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: build
@@ -102,7 +101,6 @@ jobs:
         run: ${GITHUB_WORKSPACE}/node_modules/.bin/lerna publish from-git
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       ### Semantic Release Bot comments for issues and PRs ###


### PR DESCRIPTION
Replaces npm access tokens during publishing with OIDC trust:
https://docs.npmjs.com/trusted-publishers