### PR TITLE
docs(Dialog): fix docs (controls) crash

### DIFF
--- a/packages/main/src/webComponents/Dialog/Dialog.stories.tsx
+++ b/packages/main/src/webComponents/Dialog/Dialog.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
   argTypes: {
     footer: { control: { disable: true } },
     header: { control: { disable: true } },
+    children: { control: { disable: true } },
   },
   args: {
     children: (


### PR DESCRIPTION
It seems Storybook can't handle JSX as control value anymore. As it doesn't really make sense to make it controllable anyways, disabling it is fine (imo).