### PR TITLE
fix(AnalyticalTable): clear sorting correctly in tree table

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.cy.tsx
@@ -112,24 +112,93 @@ describe('AnalyticalTable', () => {
     cy.findByText('Name').click();
     cy.get('[ui5-popover]').should('be.visible');
     cy.get('[ui5-list]').clickUi5ListItemByText('Sort Ascending');
-    cy.get('@onSortSpy').should('have.been.calledWithMatch', {
-      detail: { column: { id: 'name' }, sortDirection: 'asc' },
-    });
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'name' }, sortDirection: 'asc' },
+      });
     cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', 'C');
 
     cy.findByText('Name').click();
     cy.get('[ui5-list]').clickUi5ListItemByText('Clear Sorting');
-    cy.get('@onSortSpy').should('have.been.calledWithMatch', {
-      detail: { column: { id: 'name' }, sortDirection: 'clear' },
-    });
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'name' }, sortDirection: 'clear' },
+      });
     cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', 'X');
 
     cy.findByText('Name').click();
     cy.get('[ui5-list]').clickUi5ListItemByText('Sort Descending');
-    cy.get('@onSortSpy').should('have.been.calledWithMatch', {
-      detail: { column: { id: 'name' }, sortDirection: 'desc' },
-    });
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'name' }, sortDirection: 'desc' },
+      });
     cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', 'B');
+
+    cy.log('subRows sorting');
+    const treeData = [
+      {
+        category: 'Number',
+        subRows: [{ category: '2' }, { category: '1' }, { category: '3' }],
+      },
+      {
+        category: 'Alphabet',
+        subRows: [{ category: 'B' }, { category: 'A' }, { category: 'C' }],
+      },
+    ];
+    const treeColumns: AnalyticalTableColumnDefinition[] = [{ Header: 'Category', accessor: 'category' }];
+    cy.mount(<AnalyticalTable data={treeData} columns={treeColumns} sortable isTreeTable onSort={sort} />);
+    // expand rows
+    cy.get('[ui5-button]').click({ multiple: true });
+    cy.findByText('Category').click();
+    cy.get('[ui5-list]').clickUi5ListItemByText('Sort Ascending');
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'category' }, sortDirection: 'asc' },
+      });
+    cy.get('[aria-rowindex="1"] > [aria-colindex="1"]').should('text', 'Alphabet');
+    cy.get('[aria-rowindex="2"] > [aria-colindex="1"]').should('text', 'A');
+    cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', 'B');
+    cy.get('[aria-rowindex="4"] > [aria-colindex="1"]').should('text', 'C');
+    cy.get('[aria-rowindex="5"] > [aria-colindex="1"]').should('text', 'Number');
+    cy.get('[aria-rowindex="6"] > [aria-colindex="1"]').should('text', '1');
+    cy.get('[aria-rowindex="7"] > [aria-colindex="1"]').should('text', '2');
+    cy.get('[aria-rowindex="8"] > [aria-colindex="1"]').should('text', '3');
+
+    cy.findByText('Category').click();
+    cy.get('[ui5-list]').clickUi5ListItemByText('Sort Descending');
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'category' }, sortDirection: 'desc' },
+      });
+    cy.get('[aria-rowindex="1"] > [aria-colindex="1"]').should('text', 'Number');
+    cy.get('[aria-rowindex="2"] > [aria-colindex="1"]').should('text', '3');
+    cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', '2');
+    cy.get('[aria-rowindex="4"] > [aria-colindex="1"]').should('text', '1');
+    cy.get('[aria-rowindex="5"] > [aria-colindex="1"]').should('text', 'Alphabet');
+    cy.get('[aria-rowindex="6"] > [aria-colindex="1"]').should('text', 'C');
+    cy.get('[aria-rowindex="7"] > [aria-colindex="1"]').should('text', 'B');
+    cy.get('[aria-rowindex="8"] > [aria-colindex="1"]').should('text', 'A');
+
+    cy.findByText('Category').click();
+    cy.get('[ui5-list]').clickUi5ListItemByText('Clear Sorting');
+    cy.get('@onSortSpy')
+      .its('lastCall')
+      .should('have.been.calledWithMatch', {
+        detail: { column: { id: 'category' }, sortDirection: 'clear' },
+      });
+    cy.get('[aria-rowindex="1"] > [aria-colindex="1"]').should('text', 'Number');
+    cy.get('[aria-rowindex="2"] > [aria-colindex="1"]').should('text', '2');
+    cy.get('[aria-rowindex="3"] > [aria-colindex="1"]').should('text', '1');
+    cy.get('[aria-rowindex="4"] > [aria-colindex="1"]').should('text', '3');
+    cy.get('[aria-rowindex="5"] > [aria-colindex="1"]').should('text', 'Alphabet');
+    cy.get('[aria-rowindex="6"] > [aria-colindex="1"]').should('text', 'B');
+    cy.get('[aria-rowindex="7"] > [aria-colindex="1"]').should('text', 'A');
+    cy.get('[aria-rowindex="8"] > [aria-colindex="1"]').should('text', 'C');
   });
 
   it('row count modes', () => {

--- a/packages/main/src/components/AnalyticalTable/hooks/useColumnsDeps.ts
+++ b/packages/main/src/components/AnalyticalTable/hooks/useColumnsDeps.ts
@@ -1,0 +1,30 @@
+import type { ReactTableHooks, TableInstance } from '../types/index.js';
+
+const columnsDeps = (deps, { instance }: { instance: TableInstance }) => {
+  const { webComponentsReactProperties, state } = instance;
+  const { selectionMode, selectionBehavior, withRowHighlight, highlightField, withNavigationHighlight, isTreeTable } =
+    webComponentsReactProperties;
+
+  // required as subRows aren't updated when sorting is cleared
+  const updateOnSortClear = isTreeTable ? state.sortBy.length === 0 : false;
+  return [
+    ...deps,
+    selectionMode,
+    selectionBehavior,
+    withRowHighlight,
+    highlightField,
+    withNavigationHighlight,
+    updateOnSortClear,
+  ];
+};
+
+const visibleColumnsDeps = (deps, { instance }: { instance: TableInstance }) => {
+  const { webComponentsReactProperties } = instance;
+  const { selectionMode, selectionBehavior, withRowHighlight, withNavigationHighlight } = webComponentsReactProperties;
+  return [...deps, selectionMode, selectionBehavior, withRowHighlight, withNavigationHighlight];
+};
+
+export const useColumnsDeps = (hooks: ReactTableHooks) => {
+  hooks.columnsDeps.push(columnsDeps);
+  hooks.visibleColumnsDeps.push(visibleColumnsDeps);
+};

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowHighlight.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowHighlight.tsx
@@ -31,13 +31,6 @@ const Cell = (instance: TableInstance) => {
 /*
  * TABLE HOOKS
  */
-const columnsDeps = (deps, { instance: { webComponentsReactProperties } }: { instance: TableInstance }) => {
-  return [...deps, webComponentsReactProperties.withRowHighlight, webComponentsReactProperties.highlightField];
-};
-const visibleColumnsDeps = (deps, { instance }: { instance: TableInstance }) => [
-  ...deps,
-  instance.webComponentsReactProperties.withRowHighlight,
-];
 const visibleColumns = (
   currentVisibleColumns,
   { instance: { webComponentsReactProperties } }: { instance: TableInstance },
@@ -77,8 +70,6 @@ const columns = (currentColumns, { instance }: { instance: TableInstance }) => {
 
 export const useRowHighlight = (hooks: ReactTableHooks) => {
   hooks.columns.push(columns);
-  hooks.columnsDeps.push(columnsDeps);
-  hooks.visibleColumnsDeps.push(visibleColumnsDeps);
   hooks.visibleColumns.push(visibleColumns);
 };
 

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowNavigationIndicator.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowNavigationIndicator.tsx
@@ -27,13 +27,6 @@ const Cell = (instance) => {
 /*
  * TABLE HOOKS
  */
-const columnsDeps = (deps, { instance: { webComponentsReactProperties } }: { instance: TableInstance }) => {
-  return [...deps, webComponentsReactProperties.withNavigationHighlight];
-};
-const visibleColumnsDeps = (deps, { instance }: { instance: TableInstance }) => [
-  ...deps,
-  instance.webComponentsReactProperties.withNavigationHighlight,
-];
 const visibleColumns = (
   currentVisibleColumns,
   { instance: { webComponentsReactProperties } }: { instance: TableInstance },
@@ -72,7 +65,5 @@ const columns = (currentColumns, { instance }: { instance: TableInstance }) => {
 
 export const useRowNavigationIndicators = (hooks: ReactTableHooks) => {
   hooks.columns.push(columns);
-  hooks.columnsDeps.push(columnsDeps);
-  hooks.visibleColumnsDeps.push(visibleColumnsDeps);
   hooks.visibleColumns.push(visibleColumns);
 };

--- a/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
+++ b/packages/main/src/components/AnalyticalTable/hooks/useRowSelectionColumn.tsx
@@ -131,16 +131,6 @@ const headerProps = (props, { instance }: { instance: TableInstance }) => {
   return props;
 };
 
-const columnDeps = (deps, { instance: { webComponentsReactProperties } }: { instance: TableInstance }) => {
-  return [...deps, webComponentsReactProperties.selectionMode, webComponentsReactProperties.selectionBehavior];
-};
-
-const visibleColumnsDeps = (deps, { instance }: { instance: TableInstance }) => [
-  ...deps,
-  instance.webComponentsReactProperties.selectionMode,
-  instance.webComponentsReactProperties.selectionBehavior,
-];
-
 const visibleColumns = (
   currentVisibleColumns,
   { instance: { webComponentsReactProperties } }: { instance: TableInstance },
@@ -219,8 +209,6 @@ export const useRowSelectionColumn = (hooks: ReactTableHooks) => {
   hooks.getToggleRowSelectedProps.push(setToggleRowSelectedProps);
   hooks.getToggleAllRowsSelectedProps.push(setToggleAllRowsSelectedProps);
   hooks.columns.push(columns);
-  hooks.columnsDeps.push(columnDeps);
-  hooks.visibleColumnsDeps.push(visibleColumnsDeps);
   hooks.visibleColumns.push(visibleColumns);
 };
 useRowSelectionColumn.pluginName = 'useRowSelectionColumn';

--- a/packages/main/src/components/AnalyticalTable/index.tsx
+++ b/packages/main/src/components/AnalyticalTable/index.tsx
@@ -62,6 +62,7 @@ import { TablePlaceholder } from './defaults/LoadingComponent/TablePlaceholder.j
 import { DefaultNoDataComponent } from './defaults/NoDataComponent/index.js';
 import { useA11y } from './hooks/useA11y.js';
 import { useAutoResize } from './hooks/useAutoResize.js';
+import { useColumnsDeps } from './hooks/useColumnsDeps.js';
 import { useColumnDragAndDrop } from './hooks/useDragAndDrop.js';
 import { useDynamicColumnWidths } from './hooks/useDynamicColumnWidths.js';
 import { useKeyboardNavigation } from './hooks/useKeyboardNavigation.js';
@@ -267,6 +268,7 @@ const AnalyticalTable = forwardRef<AnalyticalTableDomRef, AnalyticalTablePropTyp
     useExpanded,
     useRowSelect,
     useResizeColumns,
+    useColumnsDeps,
     useResizeColumnsConfig,
     useRowSelectionColumn,
     useAutoResize,


### PR DESCRIPTION
The actual fix adds `updateOnSortClear` to the dependency array to enforce row rerendering. 

This commit also merges all `columnDeps` hooks into one for easier maintenance.

Fixes #7649
