### PR TITLE
chore: enhance manifest processing

### DIFF
--- a/packages/cli/src/scripts/create-wrappers/main.ts
+++ b/packages/cli/src/scripts/create-wrappers/main.ts
@@ -47,6 +47,11 @@ export default async function createWrappers(packageName: string, outDir: string
       continue;
     }
 
+    // Skip non-public declarations
+    if (declaration._ui5privacy && declaration._ui5privacy !== 'public') {
+      continue;
+    }
+
     const wrapper = new WebComponentWrapper(declaration.tagName, declaration.name, webComponentImport, packageName);
     const attributes = declaration.members?.filter(filterAttributes) ?? [];
 


### PR DESCRIPTION
`custom-manifest.json` did not include private classes, which caused issues when scripts attempted to resolve the hierarchy because some classes were missing.

Starting with the next release, `custom-manifest.json` will include private declarations (only custom elements). Therefore, this PR filters them out during wrapper generation. All private properties, slots, and other members for these declarations will still be filtered out.
