### PR TITLE
fix(AnalyticalTable): fix bottom border position

### DIFF
--- a/packages/main/src/components/AnalyticalTable/AnalyticalTable.module.css
+++ b/packages/main/src/components/AnalyticalTable/AnalyticalTable.module.css
@@ -40,6 +40,17 @@
   font-size: var(--sapFontSize);
   font-weight: normal;
   background-color: var(--sapList_Background);
+
+  /*  bottom border*/
+  &::after {
+    content: '';
+    position: absolute;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    height: var(--_ui5wcr-AnalyticalTable-HeaderBorderWidth);
+    width: 100%;
+    background: var(--sapList_HeaderBorderColor);
+  }
 }
 
 .busyIndicator {
@@ -137,17 +148,6 @@
   overflow-y: auto;
   scrollbar-width: none;
   box-sizing: border-box;
-
-  /*  bottom border*/
-  &::after {
-    content: '';
-    position: absolute;
-    inset-block-end: 0;
-    inset-inline-start: 0;
-    height: var(--_ui5wcr-AnalyticalTable-HeaderBorderWidth);
-    width: 100%;
-    background: var(--sapList_HeaderBorderColor);
-  }
 }
 
 .alternateRowColor {


### PR DESCRIPTION
Before (::after pseudo element is scrolled with container):
<img width="1186" height="334" alt="image" src="https://github.com/user-attachments/assets/e97b63e8-952b-400c-8ca2-25376482694e" />


Now: 
<img width="1166" height="337" alt="image" src="https://github.com/user-attachments/assets/77931ec2-e166-42f1-8657-5a23f0c9dbb5" />

Issue was raised in public Slack channel.