### PR TITLE
fix(ObjectPage): prevent section titles from overflowing header content

### DIFF
--- a/packages/main/src/components/ObjectPage/ObjectPage.module.css
+++ b/packages/main/src/components/ObjectPage/ObjectPage.module.css
@@ -125,6 +125,7 @@
 .content {
   flex-grow: 1;
   position: relative;
+  z-index: 0;
 }
 
 @container (max-width: 599px) {


### PR DESCRIPTION
Fixes #8369 