### PR TITLE
fix(AnalyticalTable): apply `hAlign` correctly for grouped rows

### DIFF
--- a/packages/main/src/components/AnalyticalTable/defaults/Column/Grouped.tsx
+++ b/packages/main/src/components/AnalyticalTable/defaults/Column/Grouped.tsx
@@ -1,8 +1,6 @@
 import iconNavDownArrow from '@ui5/webcomponents-icons/dist/navigation-down-arrow.js';
 import iconNavRightArrow from '@ui5/webcomponents-icons/dist/navigation-right-arrow.js';
 import { clsx } from 'clsx';
-import type { CSSProperties } from 'react';
-import { TextAlign } from '../../../../enums/TextAlign.js';
 import { Icon } from '../../../../webComponents/Icon/index.js';
 import type { CellInstance } from '../../types/index.js';
 import { RenderColumnTypes } from '../../types/index.js';
@@ -11,12 +9,7 @@ export const Grouped = (props: CellInstance) => {
   const { cell, row, webComponentsReactProperties } = props;
   const { translatableTexts, classes } = webComponentsReactProperties;
 
-  const style: CSSProperties = {};
-  if (cell.column.hAlign && (cell.column.hAlign !== TextAlign.Left || cell.column.hAlign !== TextAlign.Begin)) {
-    style.marginRight = 'auto';
-  }
-
-  const { column: _0, ...attr } = row.getToggleRowExpandedProps({ style, column: cell.column });
+  const { column: _0, ...attr } = row.getToggleRowExpandedProps({ column: cell.column });
 
   return (
     <>


### PR DESCRIPTION
Fixes #8397